### PR TITLE
Preserve storage document _etag value on merge

### DIFF
--- a/packages/azure-services/src/storage/storage-client.ts
+++ b/packages/azure-services/src/storage/storage-client.ts
@@ -73,7 +73,14 @@ export class StorageClient {
         }
 
         const mergedDocument = response.item;
-        _.merge(mergedDocument, document);
+        // preserve storage document _etag value
+        _.mergeWith(mergedDocument, document, (target: T, source: T, key) => {
+            if (key === '_etag') {
+                return target;
+            }
+
+            return undefined;
+        });
 
         return this.cosmosClientWrapper.upsertItem<T>(mergedDocument, this.dbName, this.collectionName, effectivePartitionKey);
     }


### PR DESCRIPTION
#### Description of changes

Preserve storage document _etag value on merge

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
