### PR TITLE
Enable app insights auto collect console and requests

### DIFF
--- a/packages/logger/src/app-insights-logger-client.spec.ts
+++ b/packages/logger/src/app-insights-logger-client.spec.ts
@@ -223,7 +223,7 @@ describe(AppInsightsLoggerClient, () => {
 
     function setupAppInsightsConfigurationCall(): void {
         appInsightsConfigMock
-            .setup(c => c.setAutoCollectConsole(false))
+            .setup(c => c.setAutoCollectConsole(true))
             .returns(() => appInsightsConfigMock.object)
             .verifiable(Times.once());
 
@@ -232,7 +232,7 @@ describe(AppInsightsLoggerClient, () => {
             .returns(() => appInsightsConfigMock.object)
             .verifiable(Times.once());
         appInsightsConfigMock
-            .setup(c => c.setAutoCollectRequests(false))
+            .setup(c => c.setAutoCollectRequests(true))
             .returns(() => appInsightsConfigMock.object)
             .verifiable(Times.once());
     }

--- a/packages/logger/src/app-insights-logger-client.ts
+++ b/packages/logger/src/app-insights-logger-client.ts
@@ -18,9 +18,9 @@ export class AppInsightsLoggerClient implements LoggerClient {
     public setup(baseProperties?: BaseTelemetryProperties): void {
         this.appInsightsObject
             .setup()
-            .setAutoCollectConsole(false)
+            .setAutoCollectConsole(true)
             .setAutoCollectExceptions(true)
-            .setAutoCollectRequests(false);
+            .setAutoCollectRequests(true);
 
         // this should be set after calling setup
         this.appInsightsObject.defaultClient.commonProperties = {


### PR DESCRIPTION
#### Description of changes

Change app insights config so that console/logger activity and requests will be sent to Application Insights, so that we can get tracking events details for failed tasks.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
