### PR TITLE
Avoid scanning on unsupported pages

### DIFF
--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -20,17 +20,17 @@ export class HCCrawlerOptionsFactory {
         @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
     ) {}
 
-    public createConnectOptions(crawlUrl: string, baseUrl: string, browserWSEndpoint: string): CrawlerConnectOptions {
-        const launchOptions = this.createLaunchOptions(crawlUrl, baseUrl);
+    public createConnectOptions(crawlUrl: string, websiteUrl: string, browserWSEndpoint: string): CrawlerConnectOptions {
+        const launchOptions = this.createLaunchOptions(crawlUrl, websiteUrl);
         const connectOptions = launchOptions as CrawlerConnectOptions;
         connectOptions.browserWSEndpoint = browserWSEndpoint;
 
         return connectOptions;
     }
 
-    public createLaunchOptions(crawlUrl: string, baseUrl: string): CrawlerLaunchOptions {
+    public createLaunchOptions(crawlUrl: string, websiteUrl: string): CrawlerLaunchOptions {
         const scanResult: CrawlerScanResult[] = [];
-        const allowedDomain = node_url.parse(baseUrl).hostname;
+        const allowedDomain = node_url.parse(websiteUrl).hostname;
         const exporter = this.isDebug()
             ? new JSONLineExporter({
                   file: `${__dirname}/crawl-trace-${new Date().valueOf()}.json`,
@@ -46,7 +46,7 @@ export class HCCrawlerOptionsFactory {
             retryCount: 1,
             preRequest: (options: CrawlerRequestOptions) => {
                 let processUrl = true;
-                if (!this.isAllowedUrl(options.url, baseUrl)) {
+                if (!this.isAllowedUrl(options.url, websiteUrl)) {
                     processUrl = false;
                 }
                 this.logger.logInfo(`[hc-crawl] ${processUrl ? 'Processing' : 'Skipping'} URL ${options.url}`);
@@ -57,7 +57,7 @@ export class HCCrawlerOptionsFactory {
                 const links = new Set<string>();
                 if (result.links !== undefined) {
                     result.links.forEach(link => {
-                        if (this.isAllowedUrl(link, baseUrl)) {
+                        if (this.isAllowedUrl(link, websiteUrl)) {
                             links.add(link);
                             this.logger.logInfo(`[hc-crawl] Found link ${link}`);
                         }

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -46,7 +46,7 @@ export class HCCrawlerOptionsFactory {
             retryCount: 1,
             preRequest: (options: CrawlerRequestOptions) => {
                 let processUrl = true;
-                if (!this.isAllowedUrl(options.url, allowedDomain)) {
+                if (!this.isAllowedUrl(options.url, url)) {
                     processUrl = false;
                 }
                 this.logger.logInfo(`[hc-crawl] ${processUrl ? 'Processing' : 'Skipping'} URL ${options.url}`);
@@ -57,7 +57,7 @@ export class HCCrawlerOptionsFactory {
                 const links = new Set<string>();
                 if (result.links !== undefined) {
                     result.links.forEach(link => {
-                        if (this.isAllowedUrl(link, allowedDomain)) {
+                        if (this.isAllowedUrl(link, url)) {
                             links.add(link);
                             this.logger.logInfo(`[hc-crawl] Found link ${link}`);
                         }
@@ -89,13 +89,18 @@ export class HCCrawlerOptionsFactory {
         return this.currentProcess.execArgv.filter(arg => arg.toLocaleLowerCase() === '--debug').length > 0;
     }
 
-    private isAllowedUrl(url: string, allowedDomain: string): boolean {
+    private isAllowedUrl(childUrl: string, baseUrl: string): boolean {
         // tslint:disable-next-line: max-line-length
+        const allowedDomain = node_url.parse(baseUrl).hostname;
+        const allowedPath = node_url.parse(baseUrl).pathname;
         const ignoredExtentions = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
         const loginPageBaseUrl = 'https://login.microsoftonline.com/';
 
         return (
-            node_url.parse(url).hostname === allowedDomain && url.indexOf(loginPageBaseUrl) === -1 && url.match(ignoredExtentions) === null
+            node_url.parse(childUrl).hostname === allowedDomain &&
+            node_url.parse(childUrl).pathname.startsWith(allowedPath) &&
+            childUrl.indexOf(loginPageBaseUrl) === -1 &&
+            childUrl.match(ignoredExtentions) === null
         );
     }
 }

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -91,9 +91,9 @@ export class HCCrawlerOptionsFactory {
 
     private isAllowedUrl(childUrl: string, baseUrl: string): boolean {
         // tslint:disable-next-line: max-line-length
+        const ignoredExtentions = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
         const allowedDomain = node_url.parse(baseUrl).hostname;
         const allowedPath = node_url.parse(baseUrl).pathname;
-        const ignoredExtentions = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
         const loginPageBaseUrl = 'https://login.microsoftonline.com/';
 
         return (

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -93,6 +93,7 @@ export class HCCrawlerOptionsFactory {
         // tslint:disable-next-line: max-line-length
         const IGNORED_EXTENSIONS = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
         const loginPageBaseUrl = 'https://login.microsoftonline.com/';
+
         return url.indexOf(loginPageBaseUrl) === -1 && url.match(IGNORED_EXTENSIONS) === null;
     }
 }

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -46,7 +46,7 @@ export class HCCrawlerOptionsFactory {
             retryCount: 1,
             preRequest: (options: CrawlerRequestOptions) => {
                 let processUrl = true;
-                if (!this.isAllowedUrl(options.url)) {
+                if (!this.isAllowedUrl(options.url, allowedDomain)) {
                     processUrl = false;
                 }
                 this.logger.logInfo(`[hc-crawl] ${processUrl ? 'Processing' : 'Skipping'} URL ${options.url}`);
@@ -57,7 +57,7 @@ export class HCCrawlerOptionsFactory {
                 const links = new Set<string>();
                 if (result.links !== undefined) {
                     result.links.forEach(link => {
-                        if (node_url.parse(link).hostname === allowedDomain && this.isAllowedUrl(link)) {
+                        if (this.isAllowedUrl(link, allowedDomain)) {
                             links.add(link);
                             this.logger.logInfo(`[hc-crawl] Found link ${link}`);
                         }
@@ -89,11 +89,13 @@ export class HCCrawlerOptionsFactory {
         return this.currentProcess.execArgv.filter(arg => arg.toLocaleLowerCase() === '--debug').length > 0;
     }
 
-    private isAllowedUrl(url: string): boolean {
+    private isAllowedUrl(url: string, allowedDomain: string): boolean {
         // tslint:disable-next-line: max-line-length
-        const IGNORED_EXTENSIONS = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
+        const ignoredExtentions = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
         const loginPageBaseUrl = 'https://login.microsoftonline.com/';
 
-        return url.indexOf(loginPageBaseUrl) === -1 && url.match(IGNORED_EXTENSIONS) === null;
+        return (
+            node_url.parse(url).hostname === allowedDomain && url.indexOf(loginPageBaseUrl) === -1 && url.match(ignoredExtentions) === null
+        );
     }
 }

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -20,8 +20,8 @@ export class HCCrawlerOptionsFactory {
         @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
     ) {}
 
-    public createConnectOptions(url: string, baseUrl: string, browserWSEndpoint: string): CrawlerConnectOptions {
-        const launchOptions = this.createLaunchOptions(url, baseUrl);
+    public createConnectOptions(crawlUrl: string, baseUrl: string, browserWSEndpoint: string): CrawlerConnectOptions {
+        const launchOptions = this.createLaunchOptions(crawlUrl, baseUrl);
         const connectOptions = launchOptions as CrawlerConnectOptions;
         connectOptions.browserWSEndpoint = browserWSEndpoint;
 
@@ -30,7 +30,7 @@ export class HCCrawlerOptionsFactory {
 
     public createLaunchOptions(crawlUrl: string, baseUrl: string): CrawlerLaunchOptions {
         const scanResult: CrawlerScanResult[] = [];
-        const allowedDomain = node_url.parse(crawlUrl).hostname;
+        const allowedDomain = node_url.parse(baseUrl).hostname;
         const exporter = this.isDebug()
             ? new JSONLineExporter({
                   file: `${__dirname}/crawl-trace-${new Date().valueOf()}.json`,
@@ -46,7 +46,7 @@ export class HCCrawlerOptionsFactory {
             retryCount: 1,
             preRequest: (options: CrawlerRequestOptions) => {
                 let processUrl = true;
-                if (!this.isAllowedUrl(crawlUrl, baseUrl)) {
+                if (!this.isAllowedUrl(options.url, baseUrl)) {
                     processUrl = false;
                 }
                 this.logger.logInfo(`[hc-crawl] ${processUrl ? 'Processing' : 'Skipping'} URL ${options.url}`);
@@ -89,7 +89,7 @@ export class HCCrawlerOptionsFactory {
         return this.currentProcess.execArgv.filter(arg => arg.toLocaleLowerCase() === '--debug').length > 0;
     }
 
-    private isAllowedUrl(childUrl: string, baseUrl: string): boolean {
+    private isAllowedUrl(url: string, baseUrl: string): boolean {
         // tslint:disable-next-line: max-line-length
         const ignoredExtentions = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
         const allowedDomain = node_url.parse(baseUrl).hostname;
@@ -97,10 +97,10 @@ export class HCCrawlerOptionsFactory {
         const loginPageBaseUrl = 'https://login.microsoftonline.com/';
 
         return (
-            node_url.parse(childUrl).hostname === allowedDomain &&
-            node_url.parse(childUrl).pathname.startsWith(allowedPath) &&
-            childUrl.indexOf(loginPageBaseUrl) === -1 &&
-            childUrl.match(ignoredExtentions) === null
+            node_url.parse(url).hostname === allowedDomain &&
+            node_url.parse(url).pathname.startsWith(allowedPath) &&
+            url.indexOf(loginPageBaseUrl) === -1 &&
+            url.match(ignoredExtentions) === null
         );
     }
 }

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -28,13 +28,6 @@ export class HCCrawlerOptionsFactory {
         return connectOptions;
     }
 
-    private isAllowedUrl(url: string) {
-        // tslint:disable-next-line: max-line-length
-        const IGNORED_EXTENSIONS = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
-        const loginPageBaseUrl = 'https://login.microsoftonline.com/';
-        return url.indexOf(loginPageBaseUrl) == -1 && url.match(IGNORED_EXTENSIONS) === null;
-    }
-
     public createLaunchOptions(url: string): CrawlerLaunchOptions {
         const scanResult: CrawlerScanResult[] = [];
         const allowedDomain = node_url.parse(url).hostname;
@@ -94,5 +87,12 @@ export class HCCrawlerOptionsFactory {
 
     private isDebug(): boolean {
         return this.currentProcess.execArgv.filter(arg => arg.toLocaleLowerCase() === '--debug').length > 0;
+    }
+
+    private isAllowedUrl(url: string): boolean {
+        // tslint:disable-next-line: max-line-length
+        const IGNORED_EXTENSIONS = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
+        const loginPageBaseUrl = 'https://login.microsoftonline.com/';
+        return url.indexOf(loginPageBaseUrl) === -1 && url.match(IGNORED_EXTENSIONS) === null;
     }
 }

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -30,7 +30,7 @@ export class HCCrawlerOptionsFactory {
 
     public createLaunchOptions(url: string): CrawlerLaunchOptions {
         // tslint:disable-next-line: max-line-length
-        const IGNORED_EXTENSIONS = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt)$/i;
+        const IGNORED_EXTENSIONS = /(\.pdf|\.js|\.css|\.svg|\.png|\.jpg|\.jpeg|\.gif|\.json|\.xml|\.exe|\.dmg|\.zip|\.war|\.rar|\.ico|\.txt|\.yaml)$/i;
         const scanResult: CrawlerScanResult[] = [];
         const allowedDomain = node_url.parse(url).hostname;
         const exporter = this.isDebug()

--- a/packages/runner/src/crawler/launch-options-factory.spec.ts
+++ b/packages/runner/src/crawler/launch-options-factory.spec.ts
@@ -102,7 +102,7 @@ describe('LaunchOptionsFactory', () => {
     });
 
     it('validate only valid child link is added for complicated base urls', () => {
-        const url = 'http://www.host.com/p/a/t/h?query=string#hash';
+        const url = 'http://www.host.com/p/a/t/h?query=hello';
         const crawResult = createCrawlResult(url);
         const validLink = 'https://www.host.com/p/a/t/h/foo';
         const invalidLink = 'https://www.host.com/bar/foo';

--- a/packages/runner/src/crawler/launch-options-factory.spec.ts
+++ b/packages/runner/src/crawler/launch-options-factory.spec.ts
@@ -102,7 +102,7 @@ describe('LaunchOptionsFactory', () => {
     });
 
     it('validate only valid child link is added for complicated base urls', () => {
-        const url = 'http://www.host.com/p/a/t/h?query=hello';
+        const url = 'https://www.host.com/p/a/t/h?query=hello';
         const crawResult = createCrawlResult(url);
         const validLink = 'https://www.host.com/p/a/t/h/foo';
         const invalidLink = 'https://www.host.com/bar/foo';

--- a/packages/runner/src/crawler/launch-options-factory.spec.ts
+++ b/packages/runner/src/crawler/launch-options-factory.spec.ts
@@ -74,12 +74,26 @@ describe('LaunchOptionsFactory', () => {
     });
 
     it('should only add valid links to the scan result', () => {
-        const url = 'https://www.microsoft.com/device/surface';
+        const url = 'https://www.microsoft.com/device/';
         const crawResult = createCrawlResult(url);
         const pdfLink = 'https://www.microsoft.com/device/surface.pdf';
         const externalLink = 'https://www.external.com/device/child-link';
         const validLink = 'https://www.microsoft.com/device/child-link';
         crawResult.links = [pdfLink, externalLink, validLink];
+
+        const options: CrawlerLaunchOptions = testSubject.createConnectOptions(url, browserWSEndPoint);
+
+        options.onSuccess(crawResult);
+        expect(options.scanResult[0].links).toEqual([validLink]);
+    });
+
+    it('should not add child links that do not share the same path to the scan result', () => {
+        const url = 'https://www.microsoft.com/device/';
+        const crawResult = createCrawlResult(url);
+        const validLink = 'https://www.microsoft.com/device/surface';
+        const ancestorLink = 'https://www.microsoft.com/';
+        const siblingLink = 'https://www.microsoft.com/service/foo';
+        crawResult.links = [validLink, ancestorLink, siblingLink];
 
         const options: CrawlerLaunchOptions = testSubject.createConnectOptions(url, browserWSEndPoint);
 

--- a/packages/runner/src/crawler/launch-options-factory.spec.ts
+++ b/packages/runner/src/crawler/launch-options-factory.spec.ts
@@ -106,7 +106,7 @@ describe('LaunchOptionsFactory', () => {
     });
 
     it('validate only valid child link is added for complicated base urls', () => {
-        baseUrl = 'https://www.host.com/p/a/';
+        baseUrl = 'https://www.host.com/p/a/?query=helloworld';
         const url = 'https://www.host.com/p/a/t/h?query=hello';
         const crawResult = createCrawlResult(url);
         const validLink1 = 'https://www.host.com/p/a/t/h/foo';

--- a/packages/runner/src/crawler/launch-options-factory.spec.ts
+++ b/packages/runner/src/crawler/launch-options-factory.spec.ts
@@ -100,4 +100,18 @@ describe('LaunchOptionsFactory', () => {
         options.onSuccess(crawResult);
         expect(options.scanResult[0].links).toEqual([validLink]);
     });
+
+    it('validate only valid child link is added for complicated base urls', () => {
+        const url = 'http://www.host.com/p/a/t/h?query=string#hash';
+        const crawResult = createCrawlResult(url);
+        const validLink = 'https://www.host.com/p/a/t/h/foo';
+        const invalidLink = 'https://www.host.com/bar/foo';
+
+        crawResult.links = [validLink, invalidLink];
+
+        const options: CrawlerLaunchOptions = testSubject.createConnectOptions(url, browserWSEndPoint);
+
+        options.onSuccess(crawResult);
+        expect(options.scanResult[0].links).toEqual([validLink]);
+    });
 });

--- a/packages/runner/src/crawler/launch-options-factory.spec.ts
+++ b/packages/runner/src/crawler/launch-options-factory.spec.ts
@@ -36,14 +36,14 @@ describe('LaunchOptionsFactory', () => {
         });
     });
 
-    test.each(getNotAllowedUrls())('should reject the unsupprted urls preRequest %o', async (preRequestUrl: string) => {
+    test.each(getNotAllowedUrls())('should reject the unsupported urls preRequest %o', async (preRequestUrl: string) => {
         const options: CrawlerConnectOptions = testSubject.createConnectOptions(preRequestUrl, browserWSEndPoint);
 
         const reqOptions: CrawlerRequestOptions = {
             url: preRequestUrl,
         };
-        const shouldProceeed: boolean = options.preRequest(reqOptions);
-        expect(shouldProceeed).toEqual(false);
+        const shouldProceed: boolean = options.preRequest(reqOptions);
+        expect(shouldProceed).toEqual(false);
     });
 
     it('should reject crawling for login page', () => {
@@ -52,8 +52,8 @@ describe('LaunchOptionsFactory', () => {
         const reqOptions: CrawlerRequestOptions = {
             url: loginUrl,
         };
-        const shouldProceeed: boolean = options.preRequest(reqOptions);
-        expect(shouldProceeed).toEqual(false);
+        const shouldProceed: boolean = options.preRequest(reqOptions);
+        expect(shouldProceed).toEqual(false);
     });
 
     it('should call success of valid url', () => {
@@ -61,5 +61,19 @@ describe('LaunchOptionsFactory', () => {
         const options: CrawlerLaunchOptions = testSubject.createConnectOptions(url, browserWSEndPoint);
 
         options.onSuccess(createCrawlResult(url));
+    });
+
+    it('should only add valid links to the scan result', () => {
+        const url = 'https://www.microsoft.com/device/surface';
+        const crawResult = createCrawlResult(url);
+        const pdfLink = 'https://www.microsoft.com/device/surface.pdf';
+        const externalLink = 'https://www.external.com/device/child-link';
+        const validLink = 'https://www.microsoft.com/device/child-link';
+        crawResult.links = [pdfLink, externalLink, validLink];
+
+        const options: CrawlerLaunchOptions = testSubject.createConnectOptions(url, browserWSEndPoint);
+
+        options.onSuccess(crawResult);
+        expect(options.scanResult[0].links).toEqual([validLink]);
     });
 });

--- a/packages/runner/src/crawler/launch-options-factory.spec.ts
+++ b/packages/runner/src/crawler/launch-options-factory.spec.ts
@@ -56,6 +56,16 @@ describe('LaunchOptionsFactory', () => {
         expect(shouldProceed).toEqual(false);
     });
 
+    it('should reject crawling for not allowed domain', () => {
+        const url = 'https://www.microsoft.com/abc/xyz';
+        const options: CrawlerConnectOptions = testSubject.createConnectOptions(url, browserWSEndPoint);
+        const reqOptions: CrawlerRequestOptions = {
+            url: 'https://www.external.com/abc/xyz',
+        };
+        const shouldProceed: boolean = options.preRequest(reqOptions);
+        expect(shouldProceed).toEqual(false);
+    });
+
     it('should call success of valid url', () => {
         const url = 'https://www.microsoft.com/device/surface';
         const options: CrawlerLaunchOptions = testSubject.createConnectOptions(url, browserWSEndPoint);

--- a/packages/runner/src/crawler/link-explorer.spec.ts
+++ b/packages/runner/src/crawler/link-explorer.spec.ts
@@ -24,6 +24,7 @@ describe('LinkExplorer', () => {
     let loggerMock: IMock<Logger>;
     let processMock: IMock<typeof process>;
     const testUrl = 'https://www.microsoft.com';
+    const baeUrl = testUrl;
     const invalidUrl = 'https://www.xyzxyz.com';
     beforeEach(() => {
         crawlerMock = Mock.ofType<HCCrawlerTyped>();
@@ -35,7 +36,7 @@ describe('LinkExplorer', () => {
         processMock = Mock.ofInstance(process);
         launchOptionsStub = new HCCrawlerOptionsFactory(loggerMock.object, processMock.object).createConnectOptions(
             testUrl,
-            testUrl,
+            baeUrl,
             It.isAny(),
         );
         linkExplorer = new LinkExplorer(crawlerMock.object, launchOptionsStub, loggerMock.object);

--- a/packages/runner/src/crawler/link-explorer.spec.ts
+++ b/packages/runner/src/crawler/link-explorer.spec.ts
@@ -33,7 +33,11 @@ describe('LinkExplorer', () => {
         crawlerMock = getPromisableDynamicMock(crawlerMock);
         loggerMock = Mock.ofType(Logger);
         processMock = Mock.ofInstance(process);
-        launchOptionsStub = new HCCrawlerOptionsFactory(loggerMock.object, processMock.object).createConnectOptions(testUrl, It.isAny());
+        launchOptionsStub = new HCCrawlerOptionsFactory(loggerMock.object, processMock.object).createConnectOptions(
+            testUrl,
+            testUrl,
+            It.isAny(),
+        );
         linkExplorer = new LinkExplorer(crawlerMock.object, launchOptionsStub, loggerMock.object);
     });
 

--- a/packages/runner/src/runner/runner.spec.ts
+++ b/packages/runner/src/runner/runner.spec.ts
@@ -166,7 +166,7 @@ describe('runner', () => {
             .verifiable(Times.once());
 
         crawlerTaskMock
-            .setup(async o => o.crawl(scanMetadata.scanUrl, browser))
+            .setup(async o => o.crawl(scanMetadata.scanUrl, scanMetadata.baseUrl, browser))
             .returns(async () => Promise.resolve(crawlerScanResults))
             .verifiable(Times.once());
 

--- a/packages/runner/src/runner/runner.ts
+++ b/packages/runner/src/runner/runner.ts
@@ -39,7 +39,7 @@ export class Runner {
             // start new web driver process
             browser = await this.webDriverTask.launch();
             // scan website page for next level pages references
-            const crawlerScanResults = await this.crawlerTask.crawl(scanMetadata.scanUrl, browser);
+            const crawlerScanResults = await this.crawlerTask.crawl(scanMetadata.scanUrl, scanMetadata.baseUrl, browser);
             this.logger.logInfo(`Completed crawling ${scanMetadata.scanUrl}`);
 
             // convert pages references to a storage model

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -28,14 +28,7 @@ export class Page {
     }
 
     public async goto(url: string): Promise<void> {
-        const gotoUrlPromise = this.puppeteerPage
-            .goto(url, { waitUntil: ['load'] })
-            .then(response => {
-                const contentType = response.headers()['content-type'];
-                if (contentType.indexOf('text/html') !== -1) {
-                    throw Error(`Scan cannot run on ${url} of document type: ${contentType}`);
-                }
-            });
+        const gotoUrlPromise = this.puppeteerPage.goto(url, { waitUntil: ['load'] });
 
         const waitForNetworkLoadPromise = this.puppeteerPage.waitForNavigation({ waitUntil: ['networkidle0'], timeout: 15000 });
 

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -31,14 +31,17 @@ export class Page {
         const gotoUrlPromise = this.puppeteerPage
             .goto(url, { waitUntil: ['load'] })
             .then(response => {
-                if (response.headers()['content-type'] !== 'text/html ') {
-                    throw Error('scan cannot run on this type of document');
+                const contentType = response.headers()['content-type'];
+                if (contentType.indexOf('text/html') !== -1) {
+                    throw Error(`Scan cannot run on ${url} of document type: ${contentType}`);
                 }
             });
+
         const waitForNetworkLoadPromise = this.puppeteerPage.waitForNavigation({ waitUntil: ['networkidle0'], timeout: 15000 });
 
-        try {
-            await gotoUrlPromise;
+        await gotoUrlPromise;
+
+        try {    
             // We ignore error if the page still has network activity after 15 sec
             await waitForNetworkLoadPromise;
             // tslint:disable-next-line:no-empty

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -28,12 +28,17 @@ export class Page {
     }
 
     public async goto(url: string): Promise<void> {
-        const gotoUrlPromise = this.puppeteerPage.goto(url, { waitUntil: ['load'] });
+        const gotoUrlPromise = this.puppeteerPage
+            .goto(url, { waitUntil: ['load'] })
+            .then(response => {
+                if (response.headers()['content-type'] !== 'text/html ') {
+                    throw Error('scan cannot run on this type of document');
+                }
+            });
         const waitForNetworkLoadPromise = this.puppeteerPage.waitForNavigation({ waitUntil: ['networkidle0'], timeout: 15000 });
 
-        await gotoUrlPromise;
-
         try {
+            await gotoUrlPromise;
             // We ignore error if the page still has network activity after 15 sec
             await waitForNetworkLoadPromise;
             // tslint:disable-next-line:no-empty

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -29,7 +29,6 @@ export class Page {
 
     public async goto(url: string): Promise<void> {
         const gotoUrlPromise = this.puppeteerPage.goto(url, { waitUntil: ['load'] });
-
         const waitForNetworkLoadPromise = this.puppeteerPage.waitForNavigation({ waitUntil: ['networkidle0'], timeout: 15000 });
 
         await gotoUrlPromise;

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -41,7 +41,7 @@ export class Page {
 
         await gotoUrlPromise;
 
-        try {    
+        try {
             // We ignore error if the page still has network activity after 15 sec
             await waitForNetworkLoadPromise;
             // tslint:disable-next-line:no-empty

--- a/packages/runner/src/tasks/crawler-task.spec.ts
+++ b/packages/runner/src/tasks/crawler-task.spec.ts
@@ -46,7 +46,7 @@ describe('CrawlerTask', () => {
         const crawlerConnectOptions = { browserWSEndpoint: 'wsEndpoint' };
         const linkExplorerResult = { error: 'link explorer result' };
         hcCrawlerOptionsFactoryMock
-            .setup(o => o.createConnectOptions('url', 'wsEndpoint'))
+            .setup(o => o.createConnectOptions('url', 'baseUrl', 'wsEndpoint'))
             .returns(() => <CrawlerConnectOptions>(<unknown>crawlerConnectOptions))
             .verifiable(Times.once());
         hcCrawlerConnectMock
@@ -62,7 +62,7 @@ describe('CrawlerTask', () => {
             .returns(async () => Promise.resolve(linkExplorerResult))
             .verifiable(Times.once());
 
-        const result = await crawlerTask.crawl('url', <Puppeteer.Browser>(<unknown>browserMock));
+        const result = await crawlerTask.crawl('url', 'baseUrl', <Puppeteer.Browser>(<unknown>browserMock));
 
         expect(result).toEqual(linkExplorerResult);
         hcCrawlerOptionsFactoryMock.verifyAll();

--- a/packages/runner/src/tasks/crawler-task.ts
+++ b/packages/runner/src/tasks/crawler-task.ts
@@ -22,8 +22,8 @@ export class CrawlerTask {
         private readonly linkExplorerFactory: LinkExplorerFactory = linkExplorerFactoryImpl,
     ) {}
 
-    public async crawl(url: string, browser: Browser): Promise<CrawlerScanResults> {
-        const connectOptions = this.hcCrawlerOptionsFactory.createConnectOptions(url, browser.wsEndpoint());
+    public async crawl(url: string, baseUrl: string, browser: Browser): Promise<CrawlerScanResults> {
+        const connectOptions = this.hcCrawlerOptionsFactory.createConnectOptions(url, baseUrl, browser.wsEndpoint());
         const crawler = await HCCrawler.connect(connectOptions);
         const linkExplorer = this.linkExplorerFactory(crawler, connectOptions, this.logger);
 

--- a/packages/runner/test-utilities/common-mock-methods.ts
+++ b/packages/runner/test-utilities/common-mock-methods.ts
@@ -22,6 +22,7 @@ export function getNotAllowedUrls(): string[] {
         'https://www.bing.com/abc.war',
         'https://www.bing.com/abc.rar',
         'https://www.bing.com/abc.svg',
+        'https://www.bing.com/abc.yaml',
     ];
 }
 


### PR DESCRIPTION
#### Description of changes
Currently we only check if the url is supported when we are about to crawl the page, but we are not excluding unsupported pages in the crawl result. Thus those unsupported pages are still being scanned.

1. ignore urls end with .yaml;
2. Avoid adding urls that are not allowed into the crawl result.


#### Pull request checklist

- [x] Addresses an existing issue: Fixes #190 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
