### PR TITLE
Queued messages are now smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
             "./packages/scan-request-sender/node_modules",
             "./packages/scan-request-sender/src/test-resources/",
             "./packages/scan-request-sender/test-results",
+            "./packages/scan-request-sender/out",
             "./packages/azure-client/dist",
             "./packages/azure-client/node_modules",
             "./packages/azure-client/src/test-resources/",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
             "./packages/service-library/node_modules",
             "./packages/service-library/src/test-resources/",
             "./packages/service-library/test-results",
+            "./packages/service-library/dist",
+            "./packages/common/dist",
             "./packages/common/node_modules",
             "./packages/common/src/test-resources/",
             "./packages/common/test-results",

--- a/packages/scan-request-sender/src/sender/scan-request-sender.spec.ts
+++ b/packages/scan-request-sender/src/sender/scan-request-sender.spec.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 
 import { Queue, StorageConfig } from 'azure-services';
 import { PageDocumentProvider } from 'service-library';
-import { ItemType, RunState, WebsitePage, WebsitePageExtra } from 'storage-documents';
+import { ItemType, RunState, ScanRequestMessage, WebsitePage, WebsitePageExtra } from 'storage-documents';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { ScanRequestSender } from './scan-request-sender';
 
@@ -35,8 +35,9 @@ describe('Scan request Sender', () => {
         let websitePageUpdateDelta: WebsitePageExtra;
 
         websitePages.forEach(page => {
+            const message: ScanRequestMessage = getScanRequestMessage(page);
             queueMock
-                .setup(async q => q.createMessage(storageConfigStub.scanQueue, page))
+                .setup(async q => q.createMessage(storageConfigStub.scanQueue, message))
                 .returns(async () => Promise.resolve())
                 .verifiable(Times.once());
 
@@ -60,8 +61,9 @@ describe('Scan request Sender', () => {
         let websitePageUpdateDelta: WebsitePageExtra;
 
         websitePages.forEach(page => {
+            const message: ScanRequestMessage = getScanRequestMessage(page);
             queueMock
-                .setup(async q => q.createMessage(storageConfigStub.scanQueue, page))
+                .setup(async q => q.createMessage(storageConfigStub.scanQueue, message))
                 .returns(async () => Promise.resolve())
                 .verifiable(Times.once());
 
@@ -101,5 +103,13 @@ describe('Scan request Sender', () => {
                 links: ['https://www.microsoft.com/1', 'https://www.microsoft.com/2'],
             },
         ] as WebsitePage[];
+    }
+
+    function getScanRequestMessage(page: WebsitePage): ScanRequestMessage {
+        return {
+            url: page.url,
+            baseUrl: page.baseUrl,
+            websiteId: page.websiteId,
+        };
     }
 });

--- a/packages/scan-request-sender/src/sender/scan-request-sender.ts
+++ b/packages/scan-request-sender/src/sender/scan-request-sender.ts
@@ -18,7 +18,6 @@ export class ScanRequestSender {
         await Promise.all(
             websitePage.map(async page => {
                 await this.updatePageState(page);
-                // Convert to the type here.
                 const message = this.createScanRequestMessage(page);
                 await this.queue.createMessage(this.storageConfig.scanQueue, message);
             }),

--- a/packages/storage-documents/src/index.ts
+++ b/packages/storage-documents/src/index.ts
@@ -8,3 +8,4 @@ export { WebsitePage, WebsitePageBase, WebsitePageExtra } from './website-page';
 export { PageLastScanResult, Website } from './website';
 export { RunResult } from './run-result';
 export { StorageDocument } from './storage-document';
+export { ScanRequestMessage } from './scan-request-message';

--- a/packages/storage-documents/src/scan-request-message.ts
+++ b/packages/storage-documents/src/scan-request-message.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export interface ScanRequestMessage {
+    baseUrl: string;
+    name?: string;
+    serviceTreeId?: string;
+    url: string;
+    websiteId: string;
+}


### PR DESCRIPTION
#### Description of changes
Only a subset of the data will now be enqueued. This will help us queue more items.
This includes - 
- websiteId
- baseUrl
- url

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
