### PR TITLE
Mark unscannable pages

### DIFF
--- a/packages/runner/src/factories/page-scan-result-factory.spec.ts
+++ b/packages/runner/src/factories/page-scan-result-factory.spec.ts
@@ -61,10 +61,13 @@ describe('PageScanResultFactory', () => {
         setupHashGenerator(runTime);
         const issueScanResults = {
             error: 'crawl error',
+            unscannable: true,
         };
         const crawlerScanResults = createCrawlerScanResults();
         const expectedResult = createPageScanResult(runTime);
-        expectedResult.scan = { run: { runTime: runTime.toJSON(), state: RunState.failed, error: 'crawl error' } };
+        expectedResult.scan = {
+            run: { runTime: runTime.toJSON(), state: RunState.failed, error: 'crawl error', unscannable: true },
+        };
 
         const result = pageScanResultFactory.create(crawlerScanResults, issueScanResults, scanMetadata, runTime);
 

--- a/packages/runner/src/factories/page-scan-result-factory.ts
+++ b/packages/runner/src/factories/page-scan-result-factory.ts
@@ -92,6 +92,7 @@ export class PageScanResultFactory {
                     runTime: runTime.toJSON(),
                     state: runState,
                     error: issueScanResults.error,
+                    unscannable: issueScanResults.unscannable === true ? true : false,
                 },
             };
         }

--- a/packages/runner/src/factories/page-scan-result-factory.ts
+++ b/packages/runner/src/factories/page-scan-result-factory.ts
@@ -92,7 +92,7 @@ export class PageScanResultFactory {
                     runTime: runTime.toJSON(),
                     state: runState,
                     error: issueScanResults.error,
-                    unscannable: issueScanResults.unscannable === true ? true : false,
+                    unscannable: issueScanResults.unscannable,
                 },
             };
         }

--- a/packages/runner/src/scanner/axe-scan-results.ts
+++ b/packages/runner/src/scanner/axe-scan-results.ts
@@ -5,4 +5,5 @@ import { AxeResults } from 'axe-core';
 export interface AxeScanResults {
     results?: AxeResults;
     error?: string;
+    unscannable?: boolean;
 }

--- a/packages/runner/src/scanner/page.spec.ts
+++ b/packages/runner/src/scanner/page.spec.ts
@@ -9,6 +9,7 @@ import { AxePuppeteer } from 'axe-puppeteer';
 import * as Puppeteer from 'puppeteer';
 import { IMock, Mock, Times } from 'typemoq';
 import { AxePuppeteerFactory, Page, PuppeteerBrowserFactory } from './page';
+import { AxeScanResults } from './axe-scan-results';
 
 class PuppeteerPageMock {}
 
@@ -41,6 +42,8 @@ beforeEach(() => {
 describe('Page', () => {
     it('should analyze accessibility issues', async () => {
         const axeResults: AxeResults = <AxeResults>(<unknown>{ type: 'AxeResults' });
+        const scanResults: AxeScanResults = { results: axeResults };
+        const scanUrl = 'https://www.example.com';
         axePuppeteerMock
             .setup(async o => o.analyze())
             .returns(async () => Promise.resolve(axeResults))
@@ -50,9 +53,9 @@ describe('Page', () => {
             .returns(() => axePuppeteerMock.object)
             .verifiable(Times.once());
 
-        const result = await page.scanForA11yIssues();
+        const result = await page.scanForA11yIssues(scanUrl);
 
-        expect(result).toEqual(axeResults);
+        expect(result).toEqual(scanResults);
         axePuppeteerMock.verifyAll();
         axePuppeteerFactoryMock.verifyAll();
     });

--- a/packages/runner/src/scanner/page.spec.ts
+++ b/packages/runner/src/scanner/page.spec.ts
@@ -4,55 +4,136 @@
 import 'reflect-metadata';
 import '../../test-utilities/common-mock-methods';
 
-import { AxeResults } from 'axe-core';
 import { AxePuppeteer } from 'axe-puppeteer';
 import * as Puppeteer from 'puppeteer';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, Mock, Times, It } from 'typemoq';
 import { AxePuppeteerFactory, Page, PuppeteerBrowserFactory } from './page';
 import { AxeScanResults } from './axe-scan-results';
+import { AxeResults } from 'axe-core';
 
-class PuppeteerPageMock {}
+class PuppeteerPageMock {
+    constructor(
+        private gotoMock: (url: string, options: Puppeteer.DirectNavigationOptions) => Promise<Puppeteer.Response>,
+        private waitForNavigationMock: (options?: Puppeteer.NavigationOptions) => Promise<Puppeteer.Response>,
+        private setBypassCSPMock: (enabled: boolean) => Promise<void>,
+    ) {}
+    public goto(url: string, options: Puppeteer.DirectNavigationOptions): Promise<Puppeteer.Response> {
+        return this.gotoMock(url, options);
+    }
+
+    public waitForNavigation(options?: Puppeteer.NavigationOptions): Promise<Puppeteer.Response> {
+        return this.waitForNavigationMock(options);
+    }
+
+    public setBypassCSP(enabled: boolean): Promise<void> {
+        return this.setBypassCSPMock(enabled);
+    }
+}
 
 class PuppeteerBrowserMock {
-    constructor(public readonly puppeteerPage: PuppeteerPageMock = new PuppeteerPageMock()) {}
+    constructor(public readonly puppeteerPage: PuppeteerPageMock) {}
 
     public async newPage(): Promise<Puppeteer.Page> {
         return Promise.resolve(<Puppeteer.Page>(<unknown>this.puppeteerPage));
     }
 }
 
-let axePuppeteerFactoryMock: IMock<AxePuppeteerFactory>;
-let puppeteerBrowserFactory: IMock<PuppeteerBrowserFactory>;
-let axePuppeteerMock: IMock<AxePuppeteer>;
-let puppeteerBrowserMock: PuppeteerBrowserMock;
-let page: Page;
-
-beforeEach(() => {
-    axePuppeteerFactoryMock = Mock.ofType<AxePuppeteerFactory>();
-    puppeteerBrowserFactory = Mock.ofType<PuppeteerBrowserFactory>();
-    axePuppeteerMock = Mock.ofType<AxePuppeteer>();
-    puppeteerBrowserMock = new PuppeteerBrowserMock();
-    puppeteerBrowserFactory
-        .setup(o => o())
-        .returns(() => <Puppeteer.Browser>(<unknown>puppeteerBrowserMock))
-        .verifiable(Times.once());
-    page = new Page(puppeteerBrowserFactory.object, axePuppeteerFactoryMock.object);
-});
-
 describe('Page', () => {
-    it('should analyze accessibility issues', async () => {
+    let gotoMock: IMock<(url: string, options: Puppeteer.DirectNavigationOptions) => Promise<Puppeteer.Response>>;
+    let waitForNavigationMock: IMock<(options?: Puppeteer.DirectNavigationOptions) => Promise<Puppeteer.Response>>;
+    let setBypassCSPMock: IMock<(enabled: boolean) => Promise<void>>;
+    let puppeteerPageMock: PuppeteerPageMock;
+    let axePuppeteerFactoryMock: IMock<AxePuppeteerFactory>;
+    let puppeteerBrowserFactory: IMock<PuppeteerBrowserFactory>;
+    let axePuppeteerMock: IMock<AxePuppeteer>;
+    let puppeteerBrowserMock: PuppeteerBrowserMock;
+    let page: Page;
+
+    beforeEach(() => {
+        gotoMock = Mock.ofInstance((url: string, options: Puppeteer.DirectNavigationOptions) => {
+            return null;
+        });
+        waitForNavigationMock = Mock.ofInstance((options?: Puppeteer.NavigationOptions) => {
+            return null;
+        });
+        setBypassCSPMock = Mock.ofInstance((enabled: boolean) => {
+            return null;
+        });
+
+        puppeteerPageMock = new PuppeteerPageMock(gotoMock.object, waitForNavigationMock.object, setBypassCSPMock.object);
+        axePuppeteerFactoryMock = Mock.ofType<AxePuppeteerFactory>();
+        puppeteerBrowserFactory = Mock.ofType<PuppeteerBrowserFactory>();
+        axePuppeteerMock = Mock.ofType<AxePuppeteer>();
+        puppeteerBrowserMock = new PuppeteerBrowserMock(puppeteerPageMock);
+        puppeteerBrowserFactory
+            .setup(o => o())
+            .returns(() => <Puppeteer.Browser>(<unknown>puppeteerBrowserMock))
+            .verifiable(Times.once());
+        page = new Page(puppeteerBrowserFactory.object, axePuppeteerFactoryMock.object);
+    });
+
+    it('should return error info when page is not html', async () => {
+        const scanUrl = 'https://www.non-html-url.com';
+        const errorResult: AxeScanResults = {
+            error: `Cannot scan ${scanUrl} because it is not a html page.`,
+            unscannable: true,
+        };
+        const response: Puppeteer.Response = {
+            headers: () => {
+                return { 'content-type': 'text/plain' };
+            },
+        } as any;
+        const options: Puppeteer.DirectNavigationOptions = {
+            waitUntil: ['load' as Puppeteer.LoadEvent],
+        };
+        gotoMock
+            .setup(async goto => goto(scanUrl, options))
+            .returns(async () => Promise.resolve(response as Puppeteer.Response))
+            .verifiable(Times.once());
+        waitForNavigationMock.setup(async wait => wait(It.isAny())).verifiable(Times.once());
+
+        axePuppeteerMock.setup(async o => o.analyze()).verifiable(Times.never());
+        axePuppeteerFactoryMock
+            .setup(apfm => apfm(page.puppeteerPage))
+            .returns(() => axePuppeteerMock.object)
+            .verifiable(Times.once());
+
+        await page.create();
+        const result = await page.scanForA11yIssues(scanUrl);
+
+        expect(result).toEqual(errorResult);
+    });
+
+    it('should analyze accessibility issues, even if error thrwon when waitForNavigation', async () => {
         const axeResults: AxeResults = <AxeResults>(<unknown>{ type: 'AxeResults' });
         const scanResults: AxeScanResults = { results: axeResults };
         const scanUrl = 'https://www.example.com';
+        const response: Puppeteer.Response = {
+            headers: () => {
+                return { 'content-type': 'text/html' };
+            },
+        } as any;
+        gotoMock
+            .setup(async goto => goto(scanUrl, It.isAny()))
+            .returns(async () => Promise.resolve(response as Puppeteer.Response))
+            .verifiable(Times.once());
+        waitForNavigationMock
+            .setup(async wait => wait(It.isAny()))
+            .returns(async () => {
+                throw new Error('network timed out');
+            })
+            .verifiable(Times.once());
+
         axePuppeteerMock
             .setup(async o => o.analyze())
             .returns(async () => Promise.resolve(axeResults))
             .verifiable(Times.once());
         axePuppeteerFactoryMock
-            .setup(o => o(page.puppeteerPage))
+            .setup(o => o(It.isAny()))
             .returns(() => axePuppeteerMock.object)
             .verifiable(Times.once());
 
+        await page.create();
         const result = await page.scanForA11yIssues(scanUrl);
 
         expect(result).toEqual(scanResults);
@@ -64,5 +145,14 @@ describe('Page', () => {
         await page.create();
         expect(page.puppeteerPage).toEqual(puppeteerBrowserMock.puppeteerPage);
         puppeteerBrowserFactory.verifyAll();
+    });
+
+    it('should call setBypassCSP', async () => {
+        setBypassCSPMock.setup(set => set(true)).verifiable(Times.once());
+
+        await page.create();
+        await page.enableBypassCSP();
+        expect(page.puppeteerPage).toEqual(puppeteerBrowserMock.puppeteerPage);
+        setBypassCSPMock.verifyAll();
     });
 });

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -61,6 +61,7 @@ export class Page {
     }
 
     private getContentType(headers: Record<string, string>): string {
-        return headers['content-type'] || headers['Content-Type'];
+        // All header names are lower-case, According to puppeteer API doc
+        return headers['content-type'];
     }
 }

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -46,6 +46,7 @@ export class Page {
 
         const axePuppeteer: AxePuppeteer = this.axePuppeteerFactory(this.puppeteerPage);
         const scanResults = await axePuppeteer.analyze();
+
         return { results: scanResults };
     }
 
@@ -57,7 +58,8 @@ export class Page {
 
     private isHtmlPage(response: Puppeteer.Response): boolean {
         const contentType = this.getContentType(response.headers());
-        return contentType != null && contentType.indexOf('text/html') != -1;
+
+        return contentType !== undefined && contentType.indexOf('text/html') !== -1;
     }
 
     private getContentType(headers: Record<string, string>): string {

--- a/packages/runner/src/scanner/page.ts
+++ b/packages/runner/src/scanner/page.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AxeResults } from 'axe-core';
 import { AxePuppeteer } from 'axe-puppeteer';
 import { inject, injectable } from 'inversify';
 import * as Puppeteer from 'puppeteer';
+
+import { AxeScanResults } from './axe-scan-results';
 
 export type AxePuppeteerFactory = (page: Puppeteer.Page) => AxePuppeteer;
 export type PuppeteerBrowserFactory = () => Puppeteer.Browser;
@@ -27,28 +28,39 @@ export class Page {
         return this.puppeteerPage.setBypassCSP(true);
     }
 
-    public async goto(url: string): Promise<void> {
+    public async scanForA11yIssues(url: string): Promise<AxeScanResults> {
         const gotoUrlPromise = this.puppeteerPage.goto(url, { waitUntil: ['load'] });
         const waitForNetworkLoadPromise = this.puppeteerPage.waitForNavigation({ waitUntil: ['networkidle0'], timeout: 15000 });
 
-        await gotoUrlPromise;
+        const response = await gotoUrlPromise;
+
+        if (!this.isHtmlPage(response)) {
+            return { unscannable: true, error: `Cannot scan ${url} because it is not a html page.` };
+        }
 
         try {
             // We ignore error if the page still has network activity after 15 sec
             await waitForNetworkLoadPromise;
             // tslint:disable-next-line:no-empty
         } catch {}
-    }
 
-    public async scanForA11yIssues(): Promise<AxeResults> {
         const axePuppeteer: AxePuppeteer = this.axePuppeteerFactory(this.puppeteerPage);
-
-        return axePuppeteer.analyze();
+        const scanResults = await axePuppeteer.analyze();
+        return { results: scanResults };
     }
 
     public async close(): Promise<void> {
         if (this.puppeteerPage !== undefined) {
             await this.puppeteerPage.close();
         }
+    }
+
+    private isHtmlPage(response: Puppeteer.Response): boolean {
+        const contentType = this.getContentType(response.headers());
+        return contentType != null && contentType.indexOf('text/html') != -1;
+    }
+
+    private getContentType(headers: Record<string, string>): string {
+        return headers['content-type'] || headers['Content-Type'];
     }
 }

--- a/packages/runner/src/scanner/scanner.spec.ts
+++ b/packages/runner/src/scanner/scanner.spec.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 // tslint:disable:no-import-side-effect no-any
-import 'reflect-metadata';
 import '../../test-utilities/common-mock-methods';
+import 'reflect-metadata';
 
 import { AxeResults } from 'axe-core';
 import { Logger } from 'logger';
 import { IMock, Mock, Times } from 'typemoq';
+
 import { AxeScanResults } from './axe-scan-results';
 import { AxePuppeteerFactory, Page } from './page';
 import { Scanner } from './scanner';
@@ -32,7 +33,7 @@ describe('Scanner', () => {
         const url = 'some url';
         const axeResultsStub = ('axe results' as any) as AxeResults;
         setupNewPageCall(url);
-        setupPageScanCall(axeResultsStub);
+        setupPageScanCall(url, axeResultsStub);
         await scanner.scan(url);
 
         verifyMocks();
@@ -42,7 +43,7 @@ describe('Scanner', () => {
         const url = 'some url';
         const errorMessage: string = `An error occurred while scanning website page ${url}.`;
         setupNewPageCall(url);
-        setupPageErrorScanCall(errorMessage);
+        setupPageErrorScanCall(url, errorMessage);
         setupPageCloseCall();
         const scanResult: AxeScanResults = await scanner.scan(url);
         expect(scanResult.error).not.toBeNull();
@@ -51,24 +52,23 @@ describe('Scanner', () => {
     function setupNewPageCall(url: string): void {
         pageMock.setup(async p => p.create()).verifiable(Times.once());
         pageMock.setup(async p => p.enableBypassCSP()).verifiable(Times.once());
-        pageMock.setup(async p => p.goto(url)).verifiable(Times.once());
     }
 
     function setupPageCloseCall(): void {
         pageMock.setup(async b => b.close()).verifiable();
     }
 
-    function setupPageScanCall(axeResults: AxeResults): void {
+    function setupPageScanCall(url: string, axeResults: AxeResults): void {
         pageMock
-            .setup(async p => p.scanForA11yIssues())
-            .returns(async () => Promise.resolve(axeResults))
+            .setup(async p => p.scanForA11yIssues(url))
+            .returns(async () => Promise.resolve({ results: axeResults }))
             .verifiable(Times.once());
     }
 
-    function setupPageErrorScanCall(errorMessage: string): void {
+    function setupPageErrorScanCall(url: string, errorMessage: string): void {
         pageMock
-            .setup(async p => p.scanForA11yIssues())
-            .returns(async () => Promise.reject(errorMessage))
+            .setup(async p => p.scanForA11yIssues(url))
+            .returns(async () => Promise.resolve({ error: errorMessage }))
             .verifiable(Times.once());
     }
 

--- a/packages/runner/src/scanner/scanner.spec.ts
+++ b/packages/runner/src/scanner/scanner.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 // tslint:disable:no-import-side-effect no-any
-import '../../test-utilities/common-mock-methods';
 import 'reflect-metadata';
+import '../../test-utilities/common-mock-methods';
 
 import { AxeResults } from 'axe-core';
 import { Logger } from 'logger';

--- a/packages/runner/src/scanner/scanner.ts
+++ b/packages/runner/src/scanner/scanner.ts
@@ -16,11 +16,8 @@ export class Scanner {
 
             await this.page.create();
             await this.page.enableBypassCSP();
-            await this.page.goto(url);
 
-            const result = await this.page.scanForA11yIssues();
-
-            return { results: result };
+            return this.page.scanForA11yIssues(url);
         } catch (error) {
             this.logger.trackExceptionAny(error, `[scanner] An error occurred while scanning website page ${url}.`);
 

--- a/packages/runner/src/scanner/scanner.ts
+++ b/packages/runner/src/scanner/scanner.ts
@@ -17,7 +17,7 @@ export class Scanner {
             await this.page.create();
             await this.page.enableBypassCSP();
 
-            return this.page.scanForA11yIssues(url);
+            return await this.page.scanForA11yIssues(url);
         } catch (error) {
             this.logger.trackExceptionAny(error, `[scanner] An error occurred while scanning website page ${url}.`);
 

--- a/packages/runner/src/tasks/data-factory-task.spec.ts
+++ b/packages/runner/src/tasks/data-factory-task.spec.ts
@@ -85,7 +85,7 @@ describe('DataFactoryTask', () => {
     });
 
     it('convert to scan result model w/ error', () => {
-        const axeScanResults = <AxeScanResults>(<unknown>{ type: 'AxeScanResults', error: 'error' });
+        const axeScanResults = <AxeScanResults>(<unknown>{ type: 'AxeScanResults', error: 'error', unscannable: false });
         const scanMetadata = <ScanMetadata>(<unknown>{ type: 'ScanMetadata' });
         const scanResults: IssueScanResult[] = [<IssueScanResult>(<unknown>{ type: 'ScanResult' })];
 
@@ -98,6 +98,7 @@ describe('DataFactoryTask', () => {
 
         expect(result.results).toEqual([]);
         expect(result.error).toEqual(axeScanResults.error);
+        expect(result.unscannable).toEqual(false);
         scanResultFactoryMock.verifyAll();
     });
 

--- a/packages/runner/src/tasks/data-factory-task.ts
+++ b/packages/runner/src/tasks/data-factory-task.ts
@@ -33,7 +33,7 @@ export class DataFactoryTask {
 
             return { results: scanResults };
         } else {
-            return { results: [], error: axeScanResults.error, unscannable: axeScanResults.unscannable === true ? true : false };
+            return { results: [], error: axeScanResults.error, unscannable: axeScanResults.unscannable };
         }
     }
 

--- a/packages/runner/src/tasks/data-factory-task.ts
+++ b/packages/runner/src/tasks/data-factory-task.ts
@@ -33,7 +33,7 @@ export class DataFactoryTask {
 
             return { results: scanResults };
         } else {
-            return { results: [], error: axeScanResults.error, unscannable: axeScanResults.unscannable };
+            return { results: [], error: axeScanResults.error, unscannable: axeScanResults.unscannable === true ? true : false };
         }
     }
 

--- a/packages/runner/src/tasks/data-factory-task.ts
+++ b/packages/runner/src/tasks/data-factory-task.ts
@@ -33,7 +33,7 @@ export class DataFactoryTask {
 
             return { results: scanResults };
         } else {
-            return { results: [], error: axeScanResults.error };
+            return { results: [], error: axeScanResults.error, unscannable: axeScanResults.unscannable };
         }
     }
 

--- a/packages/runner/src/tasks/page-state-updater-task.spec.ts
+++ b/packages/runner/src/tasks/page-state-updater-task.spec.ts
@@ -93,6 +93,7 @@ describe('PageStateUpdaterTask', () => {
         websitePage.lastRun = {
             state: RunState.completed,
             runTime: runTime.toJSON(),
+            unscannable: false,
         };
         const pageScanResult = createPageScanResult(runTime);
 
@@ -114,6 +115,7 @@ describe('PageStateUpdaterTask', () => {
         websitePage.lastRun = {
             state: RunState.failed,
             runTime: runTime.toJSON(),
+            unscannable: false,
         };
         const pageScanResult = createPageScanResult(runTime);
         pageScanResult.crawl.run.state = RunState.failed;
@@ -158,7 +160,7 @@ function createPageScanResult(runTime: Date): PageScanResult {
         },
         scan: {
             result: { runTime: runTime.toJSON(), level: ScanLevel.fail, issues: ['test id 1'] },
-            run: { runTime: runTime.toJSON(), state: RunState.completed },
+            run: { runTime: runTime.toJSON(), state: RunState.completed, unscannable: false },
         },
         partitionKey: scanMetadata.websiteId,
     };

--- a/packages/runner/src/tasks/page-state-updater-task.ts
+++ b/packages/runner/src/tasks/page-state-updater-task.ts
@@ -42,7 +42,7 @@ export class PageStateUpdaterTask {
             pageScanResult.crawl.run.state === RunState.failed || pageScanResult.scan.run.state === RunState.failed
                 ? RunState.failed
                 : RunState.completed;
-        const unscannable = pageScanResult.scan.run.unscannable === true ? true : false;
+        const unscannable = pageScanResult.scan.run.unscannable;
 
         websitePage.lastRun = {
             state: pageRunState,

--- a/packages/runner/src/tasks/page-state-updater-task.ts
+++ b/packages/runner/src/tasks/page-state-updater-task.ts
@@ -42,10 +42,12 @@ export class PageStateUpdaterTask {
             pageScanResult.crawl.run.state === RunState.failed || pageScanResult.scan.run.state === RunState.failed
                 ? RunState.failed
                 : RunState.completed;
+        const unscannable = pageScanResult.scan.run.unscannable === true ? true : false;
 
         websitePage.lastRun = {
             state: pageRunState,
             runTime: runTime.toJSON(),
+            unscannable,
         };
 
         await this.storageClient.mergeOrWriteDocument(websitePage);

--- a/packages/storage-documents/src/issue-scan-result.ts
+++ b/packages/storage-documents/src/issue-scan-result.ts
@@ -43,4 +43,5 @@ export interface IssueScanResult extends StorageDocument {
 export interface IssueScanResults {
     results?: IssueScanResult[];
     error?: string;
+    unscannable?: boolean;
 }

--- a/packages/storage-documents/src/run-result.ts
+++ b/packages/storage-documents/src/run-result.ts
@@ -7,4 +7,5 @@ export interface RunResult {
     state: RunState;
     error?: string;
     retries?: number;
+    unscannable?: boolean;
 }

--- a/packages/storage-documents/src/website-page.ts
+++ b/packages/storage-documents/src/website-page.ts
@@ -23,7 +23,6 @@ export interface WebsitePageExtra {
     lastReferenceSeen?: string;
     lastRun?: RunResult;
     links?: string[];
-    unscannable?: boolean;
 }
 
 /**


### PR DESCRIPTION
#### Description of changes

Before we run a11y scan on a page, I'm making the change to check the response header of the page, if it is not 'text/html', we return error information and skip the scan.

Then the page document will have a flag ``unscannable = true`` in its last run property.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
