### PR TITLE
Updated to run query differently based on deep scanning flag.

### DIFF
--- a/packages/service-library/src/data-providers/page-document-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-document-provider.spec.ts
@@ -5,12 +5,12 @@ import 'reflect-metadata';
 
 import { CosmosOperationResponse, StorageClient } from 'azure-services';
 import * as moment from 'moment';
-import { ItemType, RunState, WebsitePage, WebsitePageExtra } from 'storage-documents';
+import { ItemType, RunState, Website, WebsitePage, WebsitePageExtra } from 'storage-documents';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { PageDocumentProvider } from './page-document-provider';
 
-// tslint:disable-next-line: mocha-no-side-effect-code
+// tslint:disable: mocha-no-side-effect-code
 const unMockedMoment = jest.requireActual('moment') as typeof moment;
 const currentTime = '2019-01-01';
 
@@ -32,8 +32,7 @@ describe('PageDocumentProvider', () => {
         pageDocumentProvider = new PageDocumentProvider(storageClientMock.object);
     });
 
-    describe('getWebsiteIds', () => {
-        // tslint:disable-next-line: mocha-no-side-effect-code
+    describe('getWebsites', () => {
         const query = getWebSiteIdsQuery();
         const token = 'continuationToken';
 
@@ -43,7 +42,7 @@ describe('PageDocumentProvider', () => {
             storageClientMock
                 .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), token, 'website'))
                 .returns(() => Promise.resolve(response));
-            await expect(pageDocumentProvider.getWebsiteIds(token)).resolves.toBe(response);
+            await expect(pageDocumentProvider.getWebsites(token)).resolves.toBe(response);
         });
 
         it('throws on response with invalid status code', async () => {
@@ -52,106 +51,88 @@ describe('PageDocumentProvider', () => {
             storageClientMock
                 .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), token, 'website'))
                 .returns(() => Promise.resolve(response));
-            await expect(pageDocumentProvider.getWebsiteIds(token)).rejects.not.toBeNull();
+            await expect(pageDocumentProvider.getWebsites(token)).rejects.not.toBeNull();
         });
     });
 
     describe('getPagesNeverScanned', () => {
-        const websiteId = 'website1';
-        let query: string;
         const itemCount = 5;
 
-        beforeEach(() => {
-            query = `SELECT TOP ${itemCount} * FROM c WHERE
-            c.itemType = 'page' and c.websiteId = '${websiteId}' and c.lastReferenceSeen >= '${getMinLastReferenceSeenValue()}'
-            and c.basePage = true
-            and (IS_NULL(c.lastRun) or NOT IS_DEFINED(c.lastRun))`;
-        });
+        test.each([createWebsiteDocument('website1'), createWebsiteDocument('website1', true), createWebsiteDocument('website1', false)])(
+            'returns pages across multiple calls',
+            async (website: Website) => {
+                const pageResultsFor1stCall = ['pageId1', 'pageId2'];
+                const pageResultsFor2ndCall = ['pageId3', 'pageId4'];
+                const query = getPagesNeverScannedQuery(website, 5);
 
-        it('returns pages across multiple calls', async () => {
-            const pageResultsFor1stCall = ['pageId1', 'pageId2'];
-            const pageResultsFor2ndCall = ['pageId3', 'pageId4'];
+                storageClientMock
+                    .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, website.websiteId))
+                    .returns(() => Promise.resolve({ item: pageResultsFor1stCall.slice(0), statusCode: 200, continuationToken: 'token1' }));
+                storageClientMock
+                    .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), 'token1', website.websiteId))
+                    .returns(() => Promise.resolve({ item: pageResultsFor2ndCall.slice(0), statusCode: 200 }));
 
-            storageClientMock
-                .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, websiteId))
-                .returns(() => Promise.resolve({ item: pageResultsFor1stCall.slice(0), statusCode: 200, continuationToken: 'token1' }));
-            storageClientMock
-                .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), 'token1', websiteId))
-                .returns(() => Promise.resolve({ item: pageResultsFor2ndCall.slice(0), statusCode: 200 }));
+                const results = await pageDocumentProvider.getPagesNeverScanned(website, itemCount);
 
-            const results = await pageDocumentProvider.getPagesNeverScanned(websiteId, itemCount);
+                expect(results).toEqual(pageResultsFor1stCall.concat(pageResultsFor2ndCall));
+            },
+        );
 
-            expect(results).toEqual(pageResultsFor1stCall.concat(pageResultsFor2ndCall));
-        });
+        test.each([createWebsiteDocument('website1'), createWebsiteDocument('website1', true), createWebsiteDocument('website1', false)])(
+            'throws on response with invalid status code',
+            async (website: Website) => {
+                const pageResultsFor1stCall = ['pageId1', 'pageId2'];
+                const query = getPagesNeverScannedQuery(website, 5);
 
-        it('throws on response with invalid status code', async () => {
-            const pageResultsFor1stCall = ['pageId1', 'pageId2'];
+                storageClientMock
+                    .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, website.websiteId))
+                    .returns(() => Promise.resolve({ item: pageResultsFor1stCall, statusCode: 401, continuationToken: 'token1' }));
 
-            storageClientMock
-                .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, websiteId))
-                .returns(() => Promise.resolve({ item: pageResultsFor1stCall, statusCode: 401, continuationToken: 'token1' }));
-
-            await expect(pageDocumentProvider.getPagesNeverScanned(websiteId, itemCount)).rejects.not.toBeNull();
-        });
+                await expect(pageDocumentProvider.getPagesNeverScanned(website, itemCount)).rejects.not.toBeNull();
+            },
+        );
     });
 
     describe('getPagesScanned', () => {
-        const websiteId = 'website1';
-        let query: string;
         const itemCount = 5;
 
-        beforeEach(() => {
-            const maxRescanAfterFailureTime = moment()
-                .subtract(PageDocumentProvider.failedPageRescanIntervalInHours, 'hour')
-                .toJSON();
-            const maxRescanTime = moment()
-                .subtract(PageDocumentProvider.pageRescanIntervalInDays, 'day')
-                .toJSON();
+        test.each([createWebsiteDocument('website1'), createWebsiteDocument('website1', true), createWebsiteDocument('website1', false)])(
+            'returns pages across multiple calls',
+            async (website: Website) => {
+                const pageResultsFor1stCall = ['pageId1', 'pageId2'];
+                const pageResultsFor2ndCall = ['pageId3', 'pageId4'];
+                const query = getPagesScannedQuery(website, itemCount);
 
-            query = `SELECT TOP ${itemCount} * FROM c WHERE
-            c.itemType = '${
-                ItemType.page
-            }' and c.websiteId = '${websiteId}' and c.lastReferenceSeen >= '${getMinLastReferenceSeenValue()}' and c.basePage = true
-            and (
-            ((c.lastRun.state = '${RunState.failed}' or c.lastRun.state = '${RunState.queued}' or c.lastRun.state = '${RunState.running}')
-                and (c.lastRun.retries < ${
-                    PageDocumentProvider.maxScanRetryCount
-                } or IS_NULL(c.lastRun.retries) or NOT IS_DEFINED(c.lastRun.retries))
-                and c.lastRun.runTime <= '${maxRescanAfterFailureTime}'
-                and (IS_NULL(c.lastRun.unscannable) or NOT IS_DEFINED(c.lastRun.unscannable) or c.lastRun.unscannable <> true))
-            or (c.lastRun.state = '${RunState.completed}' and c.lastRun.runTime <= '${maxRescanTime}')
-            ) order by c.lastRun.runTime asc`;
-        });
+                storageClientMock
+                    .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, website.websiteId))
+                    .returns(() => Promise.resolve({ item: pageResultsFor1stCall.slice(0), statusCode: 200, continuationToken: 'token1' }));
+                storageClientMock
+                    .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), 'token1', website.websiteId))
+                    .returns(() => Promise.resolve({ item: pageResultsFor2ndCall.slice(0), statusCode: 200 }));
 
-        it('returns pages across multiple calls', async () => {
-            const pageResultsFor1stCall = ['pageId1', 'pageId2'];
-            const pageResultsFor2ndCall = ['pageId3', 'pageId4'];
+                const results = await pageDocumentProvider.getPagesScanned(website, itemCount);
 
-            storageClientMock
-                .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, websiteId))
-                .returns(() => Promise.resolve({ item: pageResultsFor1stCall.slice(0), statusCode: 200, continuationToken: 'token1' }));
-            storageClientMock
-                .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), 'token1', websiteId))
-                .returns(() => Promise.resolve({ item: pageResultsFor2ndCall.slice(0), statusCode: 200 }));
+                expect(results).toEqual(pageResultsFor1stCall.concat(pageResultsFor2ndCall));
+            },
+        );
 
-            const results = await pageDocumentProvider.getPagesScanned(websiteId, itemCount);
+        test.each([createWebsiteDocument('website1'), createWebsiteDocument('website1', true), createWebsiteDocument('website1', false)])(
+            'returns pages across multiple calls',
+            async (website: Website) => {
+                const pageResultsFor1stCall = ['pageId1', 'pageId2'];
+                const query = getPagesScannedQuery(website, itemCount);
 
-            expect(results).toEqual(pageResultsFor1stCall.concat(pageResultsFor2ndCall));
-        });
+                storageClientMock
+                    .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, website.websiteId))
+                    .returns(() => Promise.resolve({ item: pageResultsFor1stCall, statusCode: 401, continuationToken: 'token1' }));
 
-        it('throws on response with invalid status code', async () => {
-            const pageResultsFor1stCall = ['pageId1', 'pageId2'];
-
-            storageClientMock
-                .setup(s => s.queryDocuments(It.is((q: string) => compareQuery(q, query)), undefined, websiteId))
-                .returns(() => Promise.resolve({ item: pageResultsFor1stCall, statusCode: 401, continuationToken: 'token1' }));
-
-            await expect(pageDocumentProvider.getPagesNeverScanned(websiteId, itemCount)).rejects.not.toBeNull();
-        });
+                await expect(pageDocumentProvider.getPagesNeverScanned(website, itemCount)).rejects.not.toBeNull();
+            },
+        );
     });
 
     describe('getReadyToScanPagesForWebsite', () => {
-        const websiteId = 'website1';
+        const website = createWebsiteDocument('website1');
         let getPagesNotScannedBeforeMock: IMock<typeof pageDocumentProvider.getPagesNeverScanned>;
         let getPagesScannedAtLeastOnceMock: IMock<typeof pageDocumentProvider.getPagesScanned>;
         let webPagesNotScannedBefore: WebsitePage[];
@@ -174,9 +155,9 @@ describe('PageDocumentProvider', () => {
         it('returns only pages not scanned before', async () => {
             webPagesNotScannedBefore = createWebsitePages(itemCount, 'un-scanned-page-id');
 
-            getPagesNotScannedBeforeMock.setup(g => g(websiteId, itemCount)).returns(() => Promise.resolve(webPagesNotScannedBefore));
+            getPagesNotScannedBeforeMock.setup(g => g(website, itemCount)).returns(() => Promise.resolve(webPagesNotScannedBefore));
 
-            const result = await pageDocumentProvider.getReadyToScanPagesForWebsite(websiteId, itemCount);
+            const result = await pageDocumentProvider.getReadyToScanPagesForWebsite(website, itemCount);
 
             expect(result).toEqual(webPagesNotScannedBefore);
         });
@@ -185,10 +166,10 @@ describe('PageDocumentProvider', () => {
             webPagesNotScannedBefore = [];
             webPagesScannedAtLeastOnce = createWebsitePages(itemCount, 'scanned-page-id');
 
-            getPagesNotScannedBeforeMock.setup(g => g(websiteId, itemCount)).returns(() => Promise.resolve(webPagesNotScannedBefore));
-            getPagesScannedAtLeastOnceMock.setup(g => g(websiteId, itemCount)).returns(() => Promise.resolve(webPagesScannedAtLeastOnce));
+            getPagesNotScannedBeforeMock.setup(g => g(website, itemCount)).returns(() => Promise.resolve(webPagesNotScannedBefore));
+            getPagesScannedAtLeastOnceMock.setup(g => g(website, itemCount)).returns(() => Promise.resolve(webPagesScannedAtLeastOnce));
 
-            const result = await pageDocumentProvider.getReadyToScanPagesForWebsite(websiteId, itemCount);
+            const result = await pageDocumentProvider.getReadyToScanPagesForWebsite(website, itemCount);
 
             expect(result).toEqual(webPagesScannedAtLeastOnce);
         });
@@ -198,37 +179,40 @@ describe('PageDocumentProvider', () => {
             webPagesNotScannedBefore = createWebsitePages(webPagesNotScannedCount, 'un-scanned-page-id');
             webPagesScannedAtLeastOnce = createWebsitePages(itemCount - webPagesNotScannedCount, 'scanned-page-id');
 
-            getPagesNotScannedBeforeMock.setup(g => g(websiteId, itemCount)).returns(() => Promise.resolve(webPagesNotScannedBefore));
+            getPagesNotScannedBeforeMock.setup(g => g(website, itemCount)).returns(() => Promise.resolve(webPagesNotScannedBefore));
             getPagesScannedAtLeastOnceMock
-                .setup(g => g(websiteId, itemCount - webPagesNotScannedCount))
+                .setup(g => g(website, itemCount - webPagesNotScannedCount))
                 .returns(() => Promise.resolve(webPagesScannedAtLeastOnce));
 
-            const result = await pageDocumentProvider.getReadyToScanPagesForWebsite(websiteId, itemCount);
+            const result = await pageDocumentProvider.getReadyToScanPagesForWebsite(website, itemCount);
 
             expect(result).toEqual(webPagesNotScannedBefore.concat(webPagesScannedAtLeastOnce));
         });
     });
 
     describe('getReadyToScanPages', () => {
-        let getWebsiteIdsMock: IMock<typeof pageDocumentProvider.getWebsiteIds>;
+        let getWebsitesMock: IMock<typeof pageDocumentProvider.getWebsites>;
         let getReadyToScanPagesForWebsiteMock: IMock<typeof pageDocumentProvider.getReadyToScanPagesForWebsite>;
         const continuationToken = 'continuation-token1';
-        let websiteIdsResponse: CosmosOperationResponse<string[]>;
+        let websitesResponse: CosmosOperationResponse<Website[]>;
         const pageBatchSize = 2;
         let allPages: WebsitePage[];
 
         beforeEach(() => {
-            getWebsiteIdsMock = Mock.ofInstance(pageDocumentProvider.getWebsiteIds, MockBehavior.Strict);
+            getWebsitesMock = Mock.ofInstance(pageDocumentProvider.getWebsites, MockBehavior.Strict);
             getReadyToScanPagesForWebsiteMock = Mock.ofInstance(pageDocumentProvider.getReadyToScanPagesForWebsite, MockBehavior.Strict);
 
-            pageDocumentProvider.getWebsiteIds = getWebsiteIdsMock.object;
+            pageDocumentProvider.getWebsites = getWebsitesMock.object;
             pageDocumentProvider.getReadyToScanPagesForWebsite = getReadyToScanPagesForWebsiteMock.object;
-            websiteIdsResponse = createSuccessCosmosResponse(['websiteId1', 'websiteId2'], continuationToken);
-            getWebsiteIdsMock.setup(s => s(continuationToken)).returns(() => Promise.resolve(websiteIdsResponse));
+            websitesResponse = createSuccessCosmosResponse(
+                [createWebsiteDocument('website1'), createWebsiteDocument('website2')],
+                continuationToken,
+            );
+            getWebsitesMock.setup(s => s(continuationToken)).returns(() => Promise.resolve(websitesResponse));
 
             allPages = [];
-            websiteIdsResponse.item.forEach(item => {
-                const pagesForWebsite = createWebsitePages(pageBatchSize, item);
+            websitesResponse.item.forEach(item => {
+                const pagesForWebsite = createWebsitePages(pageBatchSize, item.websiteId);
                 allPages.push(...pagesForWebsite);
 
                 getReadyToScanPagesForWebsiteMock.setup(g => g(item, pageBatchSize)).returns(() => Promise.resolve(pagesForWebsite));
@@ -236,7 +220,7 @@ describe('PageDocumentProvider', () => {
         });
 
         afterEach(() => {
-            getWebsiteIdsMock.verifyAll();
+            getWebsitesMock.verifyAll();
             getReadyToScanPagesForWebsiteMock.verifyAll();
         });
 
@@ -294,9 +278,11 @@ describe('PageDocumentProvider', () => {
         return q1.replace(/\s+/g, ' ') === q2.replace(/\s+/g, ' ');
     }
     function getWebSiteIdsQuery(): string {
-        return `SELECT VALUE c.websiteId FROM c WHERE c.itemType = '${ItemType.website}' ORDER BY c.websiteId`;
+        return `SELECT * FROM c WHERE c.itemType = '${ItemType.website}' ORDER BY c.websiteId`;
     }
-
+    function getPageScanningCondition(website: Website): string {
+        return website.deepScanningEnabled ? '1=1' : 'c.basePage = true';
+    }
     function getMinLastReferenceSeenValue(): string {
         return moment()
             .subtract(PageDocumentProvider.minLastReferenceSeenInDays, 'day')
@@ -318,5 +304,50 @@ describe('PageDocumentProvider', () => {
             item: result,
             statusCode: 200,
         };
+    }
+    function createWebsiteDocument(websiteId: string, deepScanningEnabled?: boolean): Website {
+        const website = {
+            id: 'A1234',
+            itemType: ItemType.website,
+            partitionKey: 'website',
+            websiteId: websiteId,
+            name: 'Test',
+            baseUrl: 'https://wwww.baseurl.com',
+            serviceTreeId: 'awe1234',
+        };
+
+        if (deepScanningEnabled !== undefined) {
+            (<any>website).deepScanningEnabled = deepScanningEnabled;
+        }
+
+        return website;
+    }
+    function getPagesNeverScannedQuery(website: Website, itemCount: number): string {
+        return `SELECT TOP ${itemCount} * FROM c WHERE
+        c.itemType = 'page' and c.websiteId = '${website.websiteId}' and c.lastReferenceSeen >= '${getMinLastReferenceSeenValue()}'
+        and ${getPageScanningCondition(website)}
+        and (IS_NULL(c.lastRun) or NOT IS_DEFINED(c.lastRun))`;
+    }
+    function getPagesScannedQuery(website: Website, itemCount: number): string {
+        const maxRescanAfterFailureTime = moment()
+            .subtract(PageDocumentProvider.failedPageRescanIntervalInHours, 'hour')
+            .toJSON();
+        const maxRescanTime = moment()
+            .subtract(PageDocumentProvider.pageRescanIntervalInDays, 'day')
+            .toJSON();
+
+        return `SELECT TOP ${itemCount} * FROM c WHERE
+            c.itemType = '${ItemType.page}' and c.websiteId = '${
+            website.websiteId
+        }' and c.lastReferenceSeen >= '${getMinLastReferenceSeenValue()}' and ${getPageScanningCondition(website)}
+            and (
+            ((c.lastRun.state = '${RunState.failed}' or c.lastRun.state = '${RunState.queued}' or c.lastRun.state = '${RunState.running}')
+                and (c.lastRun.retries < ${
+                    PageDocumentProvider.maxScanRetryCount
+                } or IS_NULL(c.lastRun.retries) or NOT IS_DEFINED(c.lastRun.retries))
+                and c.lastRun.runTime <= '${maxRescanAfterFailureTime}'
+                and (IS_NULL(c.lastRun.unscannable) or NOT IS_DEFINED(c.lastRun.unscannable) or c.lastRun.unscannable <> true))
+            or (c.lastRun.state = '${RunState.completed}' and c.lastRun.runTime <= '${maxRescanTime}')
+            ) order by c.lastRun.runTime asc`;
     }
 });

--- a/packages/service-library/src/test-utilities/db-mock-helpers.ts
+++ b/packages/service-library/src/test-utilities/db-mock-helpers.ts
@@ -72,7 +72,12 @@ export function createPageDocument(options?: {
     return page;
 }
 
-export function createWebsiteDocument(options?: { label?: string; websiteId?: string; baseUrl?: string }): Website {
+export function createWebsiteDocument(options?: {
+    label?: string;
+    websiteId?: string;
+    baseUrl?: string;
+    deepScanningEnabled?: boolean;
+}): Website {
     const website = {
         id: createRandomString('id'),
         itemType: ItemType.website,
@@ -83,6 +88,10 @@ export function createWebsiteDocument(options?: { label?: string; websiteId?: st
         serviceTreeId: createRandomString('serviceTreeId'),
     };
     (<any>website).label = options === undefined || options.label === undefined ? undefined : options.label;
+
+    if (options !== undefined && options.deepScanningEnabled) {
+        (<any>website).deepScanningEnabled = options.deepScanningEnabled;
+    }
 
     return website;
 }


### PR DESCRIPTION
#### Description of changes

Updated to run query differently based on deep scanning flag.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
