### PR TITLE
adding runtime config package that updates config on blob update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 test-results/
 out/
+coverage/
 
 **/.secrets
 **/local.settings.json

--- a/.vscode/workspace.code-workspace
+++ b/.vscode/workspace.code-workspace
@@ -16,10 +16,10 @@
             "name": "service-library",
             "path": "../packages/service-library"
         },
-      {
-        "name": "azure-services",
-        "path": "../packages/azure-services"
-      },
+        {
+            "name": "azure-services",
+            "path": "../packages/azure-services"
+        },
         {
             "name": "storage-documents",
             "path": "../packages/storage-documents"
@@ -35,6 +35,10 @@
         {
             "name": "resource-deployment",
             "path": "../packages/resource-deployment"
+        },
+        {
+            "name": "runtime-config-provider",
+            "path": "../packages/runtime-config-provider"
         },
         {
             "name": "root",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,10 @@
             "./packages/common/node_modules",
             "./packages/common/src/test-resources/",
             "./packages/common/test-results",
-            "./packages/resource-deployment/dist"
+            "./packages/resource-deployment/dist",
+            "./packages/runtime-config-provider/test-results",
+            "./packages/runtime-config-provider/node_modules",
+            "./packages/runtime-config-provider/dist"
         ],
         "file_type_method": "INCLUDE",
         "file_types": [

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -11,3 +11,4 @@ export {
     TaskRuntimeConfig,
     ServiceConfiguration,
 } from './configuration/service-configuration';
+export { AsyncInterval } from './timers/async-interval';

--- a/packages/common/src/timers/async-interval.spec.ts
+++ b/packages/common/src/timers/async-interval.spec.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+import { AsyncInterval } from './async-interval';
+
+describe(AsyncInterval, () => {
+    let testSubject: AsyncInterval;
+
+    beforeEach(() => {
+        testSubject = new AsyncInterval();
+    });
+
+    it('executes the callback in interval till it returns false', async () => {
+        let callCount = 0;
+        const intervalTimeInMilliSec = 2;
+        const expectedCallCount = 3;
+
+        const callback = async () => {
+            callCount += 1;
+            const shouldExecuteAgain = callCount < expectedCallCount;
+
+            return Promise.resolve(shouldExecuteAgain);
+        };
+
+        testSubject.setIntervalExecution(callback, intervalTimeInMilliSec);
+
+        await waitForTimeout(100);
+        expect(callCount).toBe(expectedCallCount);
+    });
+
+    it('executes the callback in interval even if callback fails', async () => {
+        let callCount = 0;
+        const intervalTimeInMilliSec = 3;
+        const expectedCallCount = 3;
+
+        const callback = async () => {
+            callCount += 1;
+            const shouldExecuteAgain = callCount < expectedCallCount;
+
+            if (callCount === 1) {
+                return Promise.reject();
+            }
+
+            return Promise.resolve(shouldExecuteAgain);
+        };
+
+        testSubject.setIntervalExecution(callback, intervalTimeInMilliSec);
+
+        await waitForTimeout(100);
+
+        expect(callCount).toBe(3);
+    });
+
+    async function waitForTimeout(timeoutValue: number): Promise<void> {
+        return new Promise<void>(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, timeoutValue);
+        });
+    }
+});

--- a/packages/common/src/timers/async-interval.ts
+++ b/packages/common/src/timers/async-interval.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { injectable } from 'inversify';
+
+@injectable()
+export class AsyncInterval {
+    /**
+     * Executes the given callback after the given interval time in loop,
+     * till the callback returns value other than true
+     */
+    public setIntervalExecution(callback: () => Promise<boolean>, intervalInMilliSec: number): void {
+        setTimeout(async () => {
+            try {
+                const response = await callback();
+                if (response === true) {
+                    this.setIntervalExecution(callback, intervalInMilliSec);
+                }
+            } catch (e) {
+                console.log('error occured in interval execution - ', e);
+                this.setIntervalExecution(callback, intervalInMilliSec);
+            }
+        }, intervalInMilliSec);
+    }
+}

--- a/packages/runtime-config-provider/README.md
+++ b/packages/runtime-config-provider/README.md
@@ -1,0 +1,20 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# Accessibility Insights Service - Storage
+
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/packages/runtime-config-provider/jest.config.js
+++ b/packages/runtime-config-provider/jest.config.js
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../jest.config.base');
+const package = require('./package');
+
+module.exports = {
+    ...baseConfig,
+    displayName: package.name,
+};

--- a/packages/runtime-config-provider/package.json
+++ b/packages/runtime-config-provider/package.json
@@ -1,0 +1,47 @@
+{
+    "name": "runtime-config-provider",
+    "version": "1.0.0",
+    "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
+    "scripts": {
+        "build": "tsc && echo",
+        "cbuild": "npm-run-all --serial clean build",
+        "clean": "rimraf dist test-results",
+        "lint": "tslint -c ../../tslint.json -p ./tsconfig.json",
+        "lint:fix": "tslint --fix -c ../../tslint.json -p ./tsconfig.json --force",
+        "test": "jest --coverage --colors"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Microsoft/accessibility-insights-service.git"
+    },
+    "main": "dist/index.js",
+    "author": "Microsoft",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Microsoft/accessibility-insights-service/issues"
+    },
+    "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
+    "devDependencies": {
+        "@types/jest": "^24.0.11",
+        "@types/node": "^11.13.4",
+        "jest": "^24.7.1",
+        "jest-circus": "^24.7.1",
+        "jest-junit": "^6.3.0",
+        "rimraf": "^2.6.3",
+        "ts-jest": "^24.0.2",
+        "tslint": "^5.12.1",
+        "tslint-microsoft-contrib": "^6.0.0",
+        "typemoq": "^2.1.0",
+        "typescript": "^3.4.3"
+    },
+    "dependencies": {
+        "@azure/identity": "^1.0.0-preview.1",
+        "@azure/ms-rest-js": "^2.0.3",
+        "@azure/storage-blob": "12.0.0-preview.1",
+        "common": "1.0.0",
+        "convict": "^5.0.0",
+        "inversify": "^5.0.1",
+        "lodash": "^4.17.14",
+        "reflect-metadata": "^0.1.13"
+    }
+}

--- a/packages/runtime-config-provider/prettier.config.js
+++ b/packages/runtime-config-provider/prettier.config.js
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../prettier.config');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/packages/runtime-config-provider/src/blob-reader.spec.ts
+++ b/packages/runtime-config-provider/src/blob-reader.spec.ts
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { RestError } from '@azure/ms-rest-js';
+import { BlobClient, BlobServiceClient, ContainerClient, Models } from '@azure/storage-blob';
+import { Stream } from 'stream';
+import { IMock, Mock } from 'typemoq';
+import { BlobReader } from './blob-reader';
+import { BlobServiceClientFactory } from './ioc-types';
+
+// tslint:disable: no-null-keyword no-object-literal-type-assertion
+
+describe(BlobReader, () => {
+    let testSubject: BlobReader;
+    let blobServiceClientMock: IMock<BlobServiceClient>;
+    let blobServiceClientFactoryStub: BlobServiceClientFactory;
+    let containerClientMock: IMock<ContainerClient>;
+    let blobClientMock: IMock<BlobClient>;
+
+    const containerName = 'container1';
+    const blobName = 'blob1';
+
+    beforeEach(() => {
+        blobServiceClientMock = Mock.ofType(BlobServiceClient);
+        blobServiceClientFactoryStub = () => blobServiceClientMock.object;
+
+        containerClientMock = Mock.ofType(ContainerClient);
+        blobClientMock = Mock.ofType(BlobClient);
+
+        blobServiceClientMock.setup(s => s.getContainerClient(containerName)).returns(() => containerClientMock.object);
+        containerClientMock.setup(s => s.getBlobClient(blobName)).returns(() => blobClientMock.object);
+
+        testSubject = new BlobReader(blobServiceClientFactoryStub);
+    });
+
+    describe('getModifiedBlobContent', () => {
+        it('downloads blob content as string', async () => {
+            const dataChunks = ['chunk1', 'chunk2'];
+            const readableStream = getReadableStreamForDataChunks(dataChunks);
+            const modifiedTime = new Date(2, 3, 2019);
+
+            setupSuccessfulDownloadBlobCall(readableStream, modifiedTime);
+
+            const content = await testSubject.getModifiedBlobContent(containerName, blobName, modifiedTime);
+
+            expect(content.isModified).toBe(true);
+            expect(content.notFound).toBe(false);
+            expect(content.updatedContent).toBe(dataChunks.join(''));
+        });
+
+        it('throws if unable to parse blob content', async () => {
+            const readableStream = getErrorReadableStream();
+            const modifiedTime = new Date(2, 3, 2019);
+
+            setupSuccessfulDownloadBlobCall(readableStream, modifiedTime);
+
+            await expect(testSubject.getModifiedBlobContent(containerName, blobName, modifiedTime)).rejects.toBeDefined();
+        });
+
+        test.each([null, { statusCode: 401 } as RestError])('throws if rest call failed with error response - %o', async errResponse => {
+            const modifiedTime = new Date(2, 3, 2019);
+
+            setupFailureDownloadBlobCall(errResponse, modifiedTime);
+
+            await expect(testSubject.getModifiedBlobContent(containerName, blobName, modifiedTime)).rejects.toBe(errResponse);
+        });
+
+        it('returns not modified when content not changed', async () => {
+            const errResponse = { statusCode: 304 } as RestError;
+            const modifiedTime = new Date(2, 3, 2019);
+
+            setupFailureDownloadBlobCall(errResponse, modifiedTime);
+
+            const actualResponse = await testSubject.getModifiedBlobContent(containerName, blobName, modifiedTime);
+
+            expect(actualResponse.isModified).toBe(false);
+            expect(actualResponse.notFound).toBe(false);
+            expect(actualResponse.updatedContent).toBeUndefined();
+        });
+
+        it('returns not found when blob not found', async () => {
+            const errResponse = { statusCode: 404 } as RestError;
+            const modifiedTime = new Date(2, 3, 2019);
+
+            setupFailureDownloadBlobCall(errResponse, modifiedTime);
+
+            const actualResponse = await testSubject.getModifiedBlobContent(containerName, blobName, modifiedTime);
+
+            expect(actualResponse.notFound).toBe(true);
+            expect(actualResponse.isModified).toBe(undefined);
+            expect(actualResponse.updatedContent).toBeUndefined();
+        });
+    });
+
+    function setupSuccessfulDownloadBlobCall(readableStream: NodeJS.ReadableStream, modifiedSince: Date): void {
+        const response: Models.BlobDownloadResponse = ({
+            readableStreamBody: readableStream,
+        } as unknown) as Models.BlobDownloadResponse;
+
+        blobClientMock
+            .setup(async s =>
+                s.download(0, undefined, { blobAccessConditions: { modifiedAccessConditions: { ifModifiedSince: modifiedSince } } }),
+            )
+            .returns(async () => {
+                return response;
+            });
+    }
+
+    function setupFailureDownloadBlobCall(response: unknown, modifiedSince: Date): void {
+        blobClientMock
+            .setup(async s =>
+                s.download(0, undefined, { blobAccessConditions: { modifiedAccessConditions: { ifModifiedSince: modifiedSince } } }),
+            )
+            .returns(async () => Promise.reject(response));
+    }
+
+    function getReadableStreamForDataChunks(chunks: string[]): NodeJS.ReadableStream {
+        const readableStream = new Stream.Readable();
+        chunks.forEach(chunk => {
+            readableStream.push(chunk);
+        });
+        readableStream.push(null);
+
+        return readableStream;
+    }
+
+    function getErrorReadableStream(): NodeJS.ReadableStream {
+        return new Stream.Readable();
+    }
+});

--- a/packages/runtime-config-provider/src/blob-reader.ts
+++ b/packages/runtime-config-provider/src/blob-reader.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { RestError } from '@azure/ms-rest-js';
+import { BlobClient, BlobServiceClient } from '@azure/storage-blob';
+import { inject, injectable } from 'inversify';
+import { isNil } from 'lodash';
+import { BlobServiceClientFactory, runtimeConfigIocTypes } from './ioc-types';
+
+export interface BlobContentUpdateResponse {
+    isModified: boolean;
+    notFound: boolean;
+    updatedContent: string;
+}
+
+@injectable()
+export class BlobReader {
+    private readonly blobServiceClient: BlobServiceClient;
+
+    constructor(@inject(runtimeConfigIocTypes.BlobServiceClientFactory) blobServiceClientProvider: BlobServiceClientFactory) {
+        this.blobServiceClient = blobServiceClientProvider();
+    }
+
+    public async getModifiedBlobContent(containerName: string, blobName: string, modifiedSince: Date): Promise<BlobContentUpdateResponse> {
+        const blobClient = this.getBlobClient(containerName, blobName);
+
+        try {
+            const response = await blobClient.download(0, undefined, {
+                blobAccessConditions: { modifiedAccessConditions: { ifModifiedSince: modifiedSince } },
+            });
+
+            return {
+                notFound: false,
+                isModified: true,
+                updatedContent: await this.getContentFromStream(response.readableStreamBody),
+            };
+        } catch (e) {
+            const restResponse = e as RestError;
+            if (!isNil(restResponse)) {
+                if (restResponse.statusCode === 404) {
+                    return {
+                        notFound: true,
+                        isModified: undefined,
+                        updatedContent: undefined,
+                    };
+                }
+                if (restResponse.statusCode === 304) {
+                    return {
+                        notFound: false,
+                        isModified: false,
+                        updatedContent: undefined,
+                    };
+                }
+            }
+            throw e;
+        }
+    }
+
+    private getBlobClient(containerName: string, blobName: string): BlobClient {
+        const containerClient = this.blobServiceClient.getContainerClient(containerName);
+
+        return containerClient.getBlobClient(blobName);
+    }
+
+    private async getContentFromStream(readableStream: NodeJS.ReadableStream): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const chunks: string[] = [];
+
+            readableStream.on('data', (data: unknown) => {
+                chunks.push(data.toString());
+            });
+            readableStream.on('end', () => {
+                resolve(chunks.join(''));
+            });
+            readableStream.on('error', err => {
+                reject(err);
+            });
+        });
+    }
+}

--- a/packages/runtime-config-provider/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/runtime-config-provider/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServiceConfiguration verifies custom config 1`] = `
+Object {
+  "logConfig": Object {
+    "logInConsole": Object {
+      "default": true,
+      "doc": "Property to decide if console logging is enabled",
+      "format": "Boolean",
+    },
+  },
+  "queueConfig": Object {
+    "maxQueueSize": Object {
+      "default": 10,
+      "doc": "Maximum message the queue can have",
+      "format": "int",
+    },
+  },
+  "scanConfig": Object {
+    "failedPageRescanIntervalInHours": Object {
+      "default": 3,
+      "doc": "Minimum hours since the last scan failed. Pages newer than this time will not be scanned.",
+      "format": "int",
+    },
+    "maxScanRetryCount": Object {
+      "default": 3,
+      "doc": "Maximum number of retries allowed for a page scan",
+      "format": "int",
+    },
+    "minLastReferenceSeenInDays": Object {
+      "default": 3,
+      "doc": "Minimum days since we last saw a page. Pages older than this time will not be scanned.",
+      "format": "int",
+    },
+    "pageRescanIntervalInDays": Object {
+      "default": 3,
+      "doc": "Minimum days since we last scanned. Pages newer than this time will not be scanned.",
+      "format": "int",
+    },
+  },
+  "taskConfig": Object {
+    "taskTimeoutInMinutes": Object {
+      "default": 3,
+      "doc": "Timeout value after which the task has to be terminated",
+      "format": "int",
+    },
+  },
+}
+`;
+
+exports[`ServiceConfiguration verifies dev config 1`] = `
+Object {
+  "logConfig": Object {
+    "logInConsole": Object {
+      "default": true,
+      "doc": "Property to decide if console logging is enabled",
+      "format": "Boolean",
+    },
+  },
+  "queueConfig": Object {
+    "maxQueueSize": Object {
+      "default": 10,
+      "doc": "Maximum message the queue can have",
+      "format": "int",
+    },
+  },
+  "scanConfig": Object {
+    "failedPageRescanIntervalInHours": Object {
+      "default": 3,
+      "doc": "Minimum hours since the last scan failed. Pages newer than this time will not be scanned.",
+      "format": "int",
+    },
+    "maxScanRetryCount": Object {
+      "default": 3,
+      "doc": "Maximum number of retries allowed for a page scan",
+      "format": "int",
+    },
+    "minLastReferenceSeenInDays": Object {
+      "default": 3,
+      "doc": "Minimum days since we last saw a page. Pages older than this time will not be scanned.",
+      "format": "int",
+    },
+    "pageRescanIntervalInDays": Object {
+      "default": 3,
+      "doc": "Minimum days since we last scanned. Pages newer than this time will not be scanned.",
+      "format": "int",
+    },
+  },
+  "taskConfig": Object {
+    "taskTimeoutInMinutes": Object {
+      "default": 3,
+      "doc": "Timeout value after which the task has to be terminated",
+      "format": "int",
+    },
+  },
+}
+`;

--- a/packages/runtime-config-provider/src/configuration/config-file-updater.spec.ts
+++ b/packages/runtime-config-provider/src/configuration/config-file-updater.spec.ts
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { AsyncInterval } from 'common';
+import * as fs from 'fs';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { BlobReader } from '../blob-reader';
+import { ConfigFileUpdater } from './config-file-updater';
+
+// tslint:disable: no-any no-unsafe-any
+
+describe(ConfigFileUpdater, () => {
+    let testSubject: ConfigFileUpdater;
+    let asyncIntervalMock: IMock<AsyncInterval>;
+    let blobReaderMock: IMock<BlobReader>;
+    let fsMock: IMock<typeof fs>;
+    const fileContent = 'file content';
+    let intervalCallback: () => Promise<boolean>;
+
+    beforeEach(() => {
+        asyncIntervalMock = Mock.ofType(AsyncInterval, MockBehavior.Strict);
+        // tslint:disable-next-line:no-empty
+        blobReaderMock = Mock.ofType(BlobReader, MockBehavior.Strict, false, () => {});
+        fsMock = Mock.ofInstance(fs);
+
+        testSubject = new ConfigFileUpdater(blobReaderMock.object, asyncIntervalMock.object, fsMock.object);
+    });
+
+    describe('initialize', () => {
+        it('does not initialize more than once', async () => {
+            setupVerifiableGetBlobContentCall();
+            setupVerifiableFileWriteCall();
+            setupVerifiableIntervalExecutionCall();
+
+            await testSubject.initialize();
+            await testSubject.initialize();
+
+            verifyAll();
+        });
+
+        it('should throw if file write fails', async () => {
+            setupVerifiableGetBlobContentCall();
+            setupVerifiableFailedFileWriteCall();
+
+            await expect(testSubject.initialize()).rejects.toBeDefined();
+
+            verifyAll();
+        });
+    });
+
+    describe('notifySubscribers', () => {
+        beforeEach(async () => {
+            setupVerifiableGetBlobContentCall();
+            setupVerifiableFileWriteCall();
+            setupVerifiableIntervalExecutionCall();
+
+            await testSubject.initialize();
+            resetMocks();
+        });
+
+        it('notifies subscribers when blob updated', async () => {
+            let callbackInvoked = false;
+            const callback = async () => {
+                callbackInvoked = true;
+            };
+            testSubject.subscribe(callback);
+            setupVerifiableGetBlobContentCall();
+            setupVerifiableFileWriteCall();
+
+            await intervalCallback();
+
+            expect(callbackInvoked).toBe(true);
+        });
+
+        it('does not notify subscribers when blob not updated', async () => {
+            let callbackInvoked = false;
+            const callback = async () => {
+                callbackInvoked = true;
+            };
+            testSubject.subscribe(callback);
+
+            setupVerifiableUnmodifiedGetBlobContentCall();
+            await intervalCallback();
+            expect(callbackInvoked).toBe(false);
+        });
+    });
+
+    describe('last modified time', () => {
+        it('verifies modified time is updated on every call', async () => {
+            const fetchContentTimes: Date[] = [];
+            const expectedStartTime = new Date(1, 1, 2019);
+            blobReaderMock
+                .setup(b => b.getModifiedBlobContent('runtime-configuration', 'runtime-config.json', It.isAny()))
+                .returns(async (container, blob, time) => {
+                    fetchContentTimes.push(time);
+
+                    return Promise.resolve({ notFound: false, isModified: true, updatedContent: fileContent });
+                });
+            setupVerifiableFileWriteCall();
+            setupVerifiableIntervalExecutionCall();
+
+            await testSubject.initialize();
+
+            expect(fetchContentTimes[0]).toEqual(expectedStartTime);
+
+            await intervalCallback();
+            await waitForTimeout(10);
+            await intervalCallback();
+
+            expect(fetchContentTimes[1] < fetchContentTimes[2]).toBe(true);
+        });
+    });
+
+    function setupVerifiableGetBlobContentCall(): void {
+        blobReaderMock
+            .setup(b => b.getModifiedBlobContent('runtime-configuration', 'runtime-config.json', It.isAny()))
+            .returns(() => Promise.resolve({ notFound: false, isModified: true, updatedContent: fileContent }));
+    }
+
+    function setupVerifiableUnmodifiedGetBlobContentCall(): void {
+        blobReaderMock
+            .setup(b => b.getModifiedBlobContent('runtime-configuration', 'runtime-config.json', It.isAny()))
+            .returns(() => Promise.resolve({ notFound: false, isModified: false, updatedContent: undefined }));
+    }
+
+    function setupVerifiableFileWriteCall(): void {
+        fsMock
+            .setup(f => f.writeFile(ConfigFileUpdater.filePath, fileContent, It.isAny()))
+            .callback((filePath, content, callback) => {
+                callback();
+            })
+            .verifiable(Times.once());
+    }
+
+    function setupVerifiableFailedFileWriteCall(): void {
+        fsMock
+            .setup(f => f.writeFile(ConfigFileUpdater.filePath, fileContent, It.isAny()))
+            .callback((filePath, content, callback) => {
+                callback(new Error('file write failure message'));
+            })
+            .verifiable(Times.once());
+    }
+
+    async function waitForTimeout(timeoutValue: number): Promise<void> {
+        return new Promise<void>(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, timeoutValue);
+        });
+    }
+
+    function setupVerifiableIntervalExecutionCall(): void {
+        asyncIntervalMock
+            .setup(a => a.setIntervalExecution(It.isAny(), ConfigFileUpdater.updateCheckIntervalInMilliSec))
+            .returns(callback => {
+                intervalCallback = callback;
+            })
+            .verifiable(Times.once());
+    }
+
+    function verifyAll(): void {
+        blobReaderMock.verifyAll();
+        fsMock.verifyAll();
+        asyncIntervalMock.verifyAll();
+    }
+
+    function resetMocks(): void {
+        blobReaderMock.reset();
+        fsMock.reset();
+        asyncIntervalMock.reset();
+    }
+});

--- a/packages/runtime-config-provider/src/configuration/config-file-updater.ts
+++ b/packages/runtime-config-provider/src/configuration/config-file-updater.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AsyncInterval } from 'common';
+import * as fs from 'fs';
+import { inject, injectable } from 'inversify';
+import { isNil } from 'lodash';
+import { BlobReader } from '../blob-reader';
+
+@injectable()
+export class ConfigFileUpdater {
+    public static filePath = `${__dirname}/runtime-config.json`;
+    public static readonly updateCheckIntervalInMilliSec = 5 * 60 * 60;
+
+    private lastModifiedTime: Date = new Date(1, 1, 2019);
+    private initializePromise: Promise<void>;
+
+    private readonly subscribers: (() => Promise<void>)[] = [];
+
+    constructor(
+        @inject(BlobReader) private readonly blobReader: BlobReader,
+        @inject(AsyncInterval) private readonly asyncInterval: AsyncInterval,
+        private readonly fileSystem: typeof fs = fs,
+    ) {}
+
+    public subscribe(callback: () => Promise<void>): void {
+        this.subscribers.push(callback);
+    }
+
+    public async initialize(): Promise<void> {
+        if (isNil(this.initializePromise)) {
+            this.initializePromise = this.setup();
+        }
+
+        return this.initializePromise;
+    }
+
+    private async setup(): Promise<void> {
+        await this.triggerUpdate();
+
+        this.asyncInterval.setIntervalExecution(async () => {
+            await this.triggerUpdate();
+
+            return true;
+        }, ConfigFileUpdater.updateCheckIntervalInMilliSec);
+    }
+
+    private async triggerUpdate(): Promise<void> {
+        const newTime = new Date();
+        const response = await this.blobReader.getModifiedBlobContent(
+            'runtime-configuration',
+            'runtime-config.json',
+            this.lastModifiedTime,
+        );
+        if (response.isModified) {
+            await this.writeToFile(response.updatedContent);
+            this.lastModifiedTime = newTime;
+            await this.notifySubscribers();
+        }
+    }
+
+    private async writeToFile(updatedContent: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.fileSystem.writeFile(ConfigFileUpdater.filePath, updatedContent, err => {
+                if (isNil(err)) {
+                    resolve();
+                } else {
+                    reject(err);
+                }
+            });
+        });
+    }
+
+    private async notifySubscribers(): Promise<void> {
+        this.subscribers.forEach(async callback => {
+            await callback();
+        });
+    }
+}

--- a/packages/runtime-config-provider/src/configuration/config-file-updater.ts
+++ b/packages/runtime-config-provider/src/configuration/config-file-updater.ts
@@ -46,15 +46,15 @@ export class ConfigFileUpdater {
     }
 
     private async triggerUpdate(): Promise<void> {
-        const newTime = new Date();
+        const currentTime = new Date();
         const response = await this.blobReader.getModifiedBlobContent(
             'runtime-configuration',
             'runtime-config.json',
             this.lastModifiedTime,
         );
+        this.lastModifiedTime = currentTime;
         if (response.isModified) {
             await this.writeToFile(response.updatedContent);
-            this.lastModifiedTime = newTime;
             await this.notifySubscribers();
         }
     }

--- a/packages/runtime-config-provider/src/configuration/service-configuration.spec.ts
+++ b/packages/runtime-config-provider/src/configuration/service-configuration.spec.ts
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import * as convict from 'convict';
+import * as fs from 'fs';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { ConfigFileUpdater } from './config-file-updater';
+import { RuntimeConfig, ServiceConfiguration } from './service-configuration';
+
+// tslint:disable: non-literal-fs-path no-unsafe-any no-any
+
+describe(ServiceConfiguration, () => {
+    let testSubject: ServiceConfiguration;
+    let fsMock: IMock<typeof fs>;
+    let convictMock: IMock<typeof convict>;
+    let configMock: IMock<convict.Config<RuntimeConfig>>;
+    let actualSchema: convict.Schema<RuntimeConfig>;
+    let configFileUpdater: IMock<ConfigFileUpdater>;
+    let configUpdaterCallback: Function;
+
+    beforeEach(() => {
+        configFileUpdater = Mock.ofType(ConfigFileUpdater, MockBehavior.Strict);
+        convictMock = Mock.ofInstance(convict);
+
+        configMock = Mock.ofInstance(convict({}) as any);
+
+        fsMock = Mock.ofInstance(fs, MockBehavior.Strict);
+        testSubject = new ServiceConfiguration(configFileUpdater.object, fsMock.object, convictMock.object);
+
+        setupVerifiableconfigFileUpdaterSetupCalls();
+    });
+
+    it('verifies dev config', async () => {
+        setupVerifiableFileExistsCall(ServiceConfiguration.profilePath, false);
+        const keyToFetch = 'logConfig';
+        const expectedConfigValue = 'config value';
+
+        setupVerifiableSchemaSetupCall();
+        setupLoadCustomFileConfigCallsNotCalled();
+        configMock.setup(c => c.get(keyToFetch)).returns(() => expectedConfigValue as any);
+
+        const actualConfigValue = await testSubject.getConfigValue(keyToFetch);
+
+        expect(actualConfigValue).toBe(expectedConfigValue);
+        expect(actualSchema).toMatchSnapshot();
+
+        verifyMocks();
+    });
+
+    it('loads config only once', async () => {
+        setupVerifiableFileExistsCall(ServiceConfiguration.profilePath, false);
+        const keyToFetch = 'logConfig';
+        const expectedConfigValue = 'config value';
+
+        setupVerifiableSchemaSetupCall();
+        configMock.setup(c => c.get(keyToFetch)).returns(() => expectedConfigValue as any);
+
+        let actualConfigValue = await testSubject.getConfigValue(keyToFetch);
+        expect(actualConfigValue).toBe(expectedConfigValue);
+
+        actualConfigValue = await testSubject.getConfigValue(keyToFetch);
+        expect(actualConfigValue).toBe(expectedConfigValue);
+
+        verifyMocks();
+    });
+
+    it('verifies custom config', async () => {
+        setupVerifiableFileExistsCall(ServiceConfiguration.profilePath, true);
+        const keyToFetch = 'logConfig';
+        const expectedConfigValue = 'config value';
+
+        setupVerifiableSchemaSetupCall();
+        setupVerifiableLoadCustomFileConfigCalls();
+
+        configMock.setup(c => c.get(keyToFetch)).returns(() => expectedConfigValue as any);
+
+        const actualConfigValue = await testSubject.getConfigValue(keyToFetch);
+
+        expect(actualConfigValue).toBe(expectedConfigValue);
+        expect(actualSchema).toMatchSnapshot();
+
+        verifyMocks();
+    });
+
+    it('throws on custom config validation failure', async () => {
+        setupVerifiableFileExistsCall(ServiceConfiguration.profilePath, true);
+        const keyToFetch = 'logConfig';
+        const expectedError = 'validation failed';
+
+        setupVerifiableSchemaSetupCall();
+        setupVerifiableCustomConfigLoadCall();
+        configMock
+            .setup(c => c.validate(It.isValue({ allowed: 'strict' })))
+            .returns(() => {
+                throw expectedError;
+            });
+
+        await expect(testSubject.getConfigValue(keyToFetch)).rejects.toBe(expectedError);
+
+        verifyMocks();
+    });
+
+    it('loads config again if file changed', async () => {
+        setupVerifiableFileExistsCall(ServiceConfiguration.profilePath, false);
+        const keyToFetch = 'logConfig';
+        const oldConfigValue = 'old config value';
+        const newConfigValue = 'new config value';
+        setupVerifiableSchemaSetupCall();
+        configMock.setup(c => c.get(keyToFetch)).returns(() => oldConfigValue as any);
+
+        await testSubject.getConfigValue(keyToFetch);
+
+        resetMocks();
+        configUpdaterCallback();
+
+        setupVerifiableFileExistsCall(ServiceConfiguration.profilePath, false);
+        setupVerifiableSchemaSetupCall();
+        configMock.setup(c => c.get(keyToFetch)).returns(() => newConfigValue as any);
+
+        const actualConfigValue = await testSubject.getConfigValue(keyToFetch);
+        expect(actualConfigValue).toBe(newConfigValue);
+
+        verifyMocks();
+    });
+
+    function verifyMocks(): void {
+        configMock.verifyAll();
+        convictMock.verifyAll();
+        fsMock.verifyAll();
+        configFileUpdater.verifyAll();
+    }
+
+    function resetMocks(): void {
+        configMock.reset();
+        convictMock.reset();
+        fsMock.reset();
+        configFileUpdater.reset();
+    }
+
+    function setupVerifiableconfigFileUpdaterSetupCalls(): void {
+        configFileUpdater
+            .setup(c => c.initialize())
+            .returns(() => Promise.resolve(undefined))
+            .verifiable(Times.once());
+
+        configFileUpdater
+            .setup(c => c.subscribe(It.isAny()))
+            .returns(callback => {
+                configUpdaterCallback = callback;
+            })
+            .verifiable(Times.once());
+    }
+
+    function setupVerifiableLoadCustomFileConfigCalls(): void {
+        setupVerifiableCustomConfigLoadCall();
+        configMock.setup(c => c.validate(It.isValue({ allowed: 'strict' }))).verifiable(Times.once());
+    }
+
+    function setupVerifiableCustomConfigLoadCall(): void {
+        configMock.setup(c => c.loadFile(ServiceConfiguration.profilePath)).verifiable(Times.once());
+    }
+    function setupLoadCustomFileConfigCallsNotCalled(): void {
+        configMock.setup(c => c.loadFile(It.isAny())).verifiable(Times.never());
+        configMock.setup(c => c.validate(It.isAny())).verifiable(Times.never());
+    }
+
+    function setupVerifiableSchemaSetupCall(): void {
+        convictMock
+            .setup(c => c<RuntimeConfig>(It.isAny()))
+            .callback((s: convict.Schema<RuntimeConfig>) => {
+                actualSchema = s;
+            })
+            .returns(() => configMock.object)
+            .verifiable(Times.once());
+    }
+    function setupVerifiableFileExistsCall(profilePath: string, fileExistsValue: boolean): void {
+        fsMock
+            .setup(f => f.exists(profilePath, It.isAny()))
+            .callback((filePath: string, cb: (exists: boolean) => void) => {
+                cb(fileExistsValue);
+            })
+            .verifiable(Times.once());
+    }
+});

--- a/packages/runtime-config-provider/src/configuration/service-configuration.ts
+++ b/packages/runtime-config-provider/src/configuration/service-configuration.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as convict from 'convict';
+import * as fs from 'fs';
+import { inject, injectable } from 'inversify';
+import { isNil } from 'lodash';
+import { ConfigFileUpdater } from './config-file-updater';
+
+export interface TaskRuntimeConfig {
+    taskTimeoutInMinutes: number;
+}
+
+export interface QueueRuntimeConfig {
+    maxQueueSize: number;
+}
+
+export interface LogRuntimeConfig {
+    logInConsole: boolean;
+}
+
+export interface ScanRunTimeConfig {
+    minLastReferenceSeenInDays: number;
+    pageRescanIntervalInDays: number;
+    failedPageRescanIntervalInHours: number;
+    maxScanRetryCount: number;
+}
+
+export interface RuntimeConfig {
+    logConfig: LogRuntimeConfig;
+    taskConfig: TaskRuntimeConfig;
+    queueConfig: QueueRuntimeConfig;
+    scanConfig: ScanRunTimeConfig;
+}
+
+@injectable()
+export class ServiceConfiguration {
+    public static readonly profilePath = './runtime-config/runtime-config.json';
+    private loadConfigPromise: Promise<convict.Config<RuntimeConfig>>;
+    private initialized: boolean;
+
+    constructor(
+        @inject(ConfigFileUpdater) private readonly configFileUpdater: ConfigFileUpdater,
+        private readonly fileSystem: typeof fs = fs,
+        private readonly convictModule: typeof convict,
+    ) {}
+
+    public async getConfigValue<K extends keyof RuntimeConfig | null | undefined = undefined>(
+        key?: K,
+    ): Promise<K extends null | undefined ? RuntimeConfig : RuntimeConfig[K]> {
+        const config = await this.getConvictConfig();
+
+        return config.get(key);
+    }
+
+    private async initialize(): Promise<void> {
+        if (this.initialized !== true) {
+            await this.configFileUpdater.initialize();
+            this.configFileUpdater.subscribe(async () => {
+                this.loadConfigPromise = undefined;
+            });
+
+            this.initialized = true;
+        }
+    }
+
+    private async getConvictConfig(): Promise<convict.Config<RuntimeConfig>> {
+        await this.initialize();
+
+        if (isNil(this.loadConfigPromise)) {
+            this.loadConfigPromise = new Promise((resolve, reject) => {
+                const config = this.convictModule<RuntimeConfig>(this.getRuntimeConfigSchema());
+
+                this.fileSystem.exists(ServiceConfiguration.profilePath, exists => {
+                    if (exists === true) {
+                        config.loadFile(ServiceConfiguration.profilePath);
+                        config.validate({ allowed: 'strict' });
+                    } else {
+                        console.log(`Unable to load custom configuration. Using default config  - ${config}`);
+                    }
+                    resolve(config);
+                });
+            });
+        }
+
+        return this.loadConfigPromise;
+    }
+
+    private getRuntimeConfigSchema(): convict.Schema<RuntimeConfig> {
+        return {
+            logConfig: {
+                logInConsole: {
+                    format: 'Boolean',
+                    default: true,
+                    doc: 'Property to decide if console logging is enabled',
+                },
+            },
+            queueConfig: {
+                maxQueueSize: {
+                    format: 'int',
+                    default: 10,
+                    doc: 'Maximum message the queue can have',
+                },
+            },
+            taskConfig: {
+                taskTimeoutInMinutes: {
+                    format: 'int',
+                    default: 3,
+                    doc: 'Timeout value after which the task has to be terminated',
+                },
+            },
+
+            scanConfig: {
+                minLastReferenceSeenInDays: {
+                    format: 'int',
+                    default: 3,
+                    doc: 'Minimum days since we last saw a page. Pages older than this time will not be scanned.',
+                },
+                pageRescanIntervalInDays: {
+                    format: 'int',
+                    default: 3,
+                    doc: 'Minimum days since we last scanned. Pages newer than this time will not be scanned.',
+                },
+                failedPageRescanIntervalInHours: {
+                    format: 'int',
+                    default: 3,
+                    doc: 'Minimum hours since the last scan failed. Pages newer than this time will not be scanned.',
+                },
+                maxScanRetryCount: {
+                    format: 'int',
+                    default: 3,
+                    doc: 'Maximum number of retries allowed for a page scan',
+                },
+            },
+        };
+    }
+}

--- a/packages/runtime-config-provider/src/index.ts
+++ b/packages/runtime-config-provider/src/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export { setupRuntimeConfigContainer } from './setup-runtime-config-container';
+export {
+    ServiceConfiguration,
+    LogRuntimeConfig,
+    QueueRuntimeConfig,
+    RuntimeConfig,
+    ScanRunTimeConfig,
+    TaskRuntimeConfig,
+} from './configuration/service-configuration';

--- a/packages/runtime-config-provider/src/ioc-types.ts
+++ b/packages/runtime-config-provider/src/ioc-types.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BlobServiceClient } from '@azure/storage-blob';
+
+export const runtimeConfigIocTypes = {
+    BlobServiceClientFactory: 'BlobServiceClientFactory',
+};
+
+export type BlobServiceClientFactory = () => BlobServiceClient;

--- a/packages/runtime-config-provider/src/setup-runtime-config-container.spec.ts
+++ b/packages/runtime-config-provider/src/setup-runtime-config-container.spec.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { BlobServiceClient } from '@azure/storage-blob';
+import { Container } from 'inversify';
+import { ConfigFileUpdater } from './configuration/config-file-updater';
+import { ServiceConfiguration } from './configuration/service-configuration';
+import { BlobServiceClientFactory, runtimeConfigIocTypes } from './ioc-types';
+import { setupRuntimeConfigContainer } from './setup-runtime-config-container';
+
+describe('setupRuntimeConfigContainer', () => {
+    let container: Container;
+    const storageAccountName: string = 'test-storage';
+    beforeEach(() => {
+        process.env.storageAccountName = storageAccountName;
+
+        container = new Container({ autoBindInjectable: true });
+    });
+
+    it('resolves BlobServiceClient', async () => {
+        setupRuntimeConfigContainer(container);
+
+        const blobServiceClientProvider: BlobServiceClientFactory = container.get(runtimeConfigIocTypes.BlobServiceClientFactory);
+        const blobServiceClient = blobServiceClientProvider();
+
+        expect(blobServiceClient).toBeInstanceOf(BlobServiceClient);
+
+        expect(blobServiceClient.url).toBe(`https://${storageAccountName}.blob.core.windows.net/`);
+    });
+
+    it('resolves singleton instances', async () => {
+        setupRuntimeConfigContainer(container);
+
+        const configUpdater = container.get(ConfigFileUpdater);
+        const serviceConfig = container.get(ServiceConfiguration);
+
+        expect(configUpdater).toBeInstanceOf(ConfigFileUpdater);
+        expect(serviceConfig).toBeInstanceOf(ServiceConfiguration);
+
+        expect(configUpdater).toBe(container.get(ConfigFileUpdater));
+        expect(serviceConfig).toBe(container.get(ServiceConfiguration));
+    });
+});

--- a/packages/runtime-config-provider/src/setup-runtime-config-container.ts
+++ b/packages/runtime-config-provider/src/setup-runtime-config-container.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DefaultAzureCredential } from '@azure/identity';
+import { BlobServiceClient } from '@azure/storage-blob';
+import { Container } from 'inversify';
+import { ConfigFileUpdater } from './configuration/config-file-updater';
+import { ServiceConfiguration } from './configuration/service-configuration';
+import { BlobServiceClientFactory, runtimeConfigIocTypes } from './ioc-types';
+
+export function setupRuntimeConfigContainer(container: Container): void {
+    container
+        .bind<ConfigFileUpdater>(ConfigFileUpdater)
+        .toSelf()
+        .inSingletonScope();
+
+    container
+        .bind<ServiceConfiguration>(ServiceConfiguration)
+        .toSelf()
+        .inSingletonScope();
+
+    container.bind<BlobServiceClientFactory>(runtimeConfigIocTypes.BlobServiceClientFactory).toFactory(context => {
+        return () => {
+            return new BlobServiceClient(`https://${process.env.storageAccountName}.blob.core.windows.net`, new DefaultAzureCredential());
+        };
+    });
+}

--- a/packages/runtime-config-provider/tsconfig.json
+++ b/packages/runtime-config-provider/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,33 @@
     tslib "^1.9.3"
     url-parse "^1.4.7"
 
+"@azure/core-asynciterator-polyfill@^1.0.0-preview.1":
+  version "1.0.0-preview.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0-preview.1.tgz#ad7c726cfd73c946dbfbc3e485338ccf678fc75a"
+  integrity sha512-hMp0y+j/odkAyTa5TYewn4hUlFdEe3sR9uTd2Oq+se61RtuDsqM7UWrNNlyylPyjIENSZHJVWN7jte/jvvMN2Q==
+
+"@azure/core-http@^1.0.0-preview.1":
+  version "1.0.0-preview.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-1.0.0-preview.1.tgz#e88b0a0d37847d13ea74b47fd5b58d1e2cedacb7"
+  integrity sha512-/1QsA8WMl67I8HM5d8Z5kLmw8WU8GLBZekckRa69lT6NmU5nQ9IgCM/IwS3mdoljnv4TFgiGK8cb5x3wCJEssA==
+  dependencies:
+    "@types/tunnel" "^0.0.0"
+    axios "^0.19.0"
+    form-data "^2.3.2"
+    process "^0.11.10"
+    tough-cookie "^2.4.3"
+    tslib "^1.9.3"
+    tunnel "0.0.6"
+    uuid "^3.3.2"
+    xml2js "^0.4.19"
+
+"@azure/core-paging@^1.0.0-preview.1":
+  version "1.0.0-preview.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-paging/-/core-paging-1.0.0-preview.1.tgz#b7762a5a5d97069bcb8b7ced824848124faa1085"
+  integrity sha512-mZHkadyAbhV1+brHEsWICnURW6E72D2HReM+8MWDn5oVJdlxD51w14PeqsOZC4UDYv4x2Eww5+PFRTEOrNB1Uw==
+  dependencies:
+    "@azure/core-asynciterator-polyfill" "^1.0.0-preview.1"
+
 "@azure/cosmos@^2.1.2":
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-2.1.7.tgz#8fcd609417a77603b0007a519ef1b24690bfa9d4"
@@ -26,6 +53,18 @@
     stream-http "^2.8.3"
     tslib "^1.9.3"
     tunnel "0.0.5"
+
+"@azure/identity@^1.0.0-preview.1":
+  version "1.0.0-preview.1"
+  resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-1.0.0-preview.1.tgz#a33315cf12367b631ab34f4ef08b6e3b0073fc78"
+  integrity sha512-AM/OXOVojj+A850c3Un5RTJSBh2cugYZqbicW2TzsuQAjDaAh8DnBseW1x9BhfZQ/RWk2Vh/GJ3SHK0X0Ab7dA==
+  dependencies:
+    "@azure/core-http" "^1.0.0-preview.1"
+    events "^3.0.0"
+    jws "~3.2.2"
+    qs "6.7.0"
+    tslib "^1.9.3"
+    uuid "^3.3.2"
 
 "@azure/keyvault@^0.1.0":
   version "0.1.0"
@@ -63,6 +102,22 @@
     uuid "^3.2.1"
     xml2js "^0.4.19"
 
+"@azure/ms-rest-js@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.0.3.tgz#9c393230380f330ed930e33bc9e17e2b62b827b6"
+  integrity sha512-Lcgs/a6H1srWyLKHF/OaoP8j7/i7RuNHehhXMNH5hb2Nnk5Wq0WK3z9DqF2oBMw3QPicAHFb/3nZxCRKNdXy/g==
+  dependencies:
+    "@types/node-fetch" "^2.3.7"
+    "@types/tunnel" "0.0.1"
+    abort-controller "^3.0.0"
+    form-data "^2.5.0"
+    node-fetch "^2.6.0"
+    tough-cookie "^3.0.1"
+    tslib "^1.10.0"
+    tunnel "0.0.6"
+    uuid "^3.3.2"
+    xml2js "^0.4.19"
+
 "@azure/ms-rest-nodeauth@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-1.1.1.tgz#b77a20dcf59b405cac62f6d1f86c2a061aa6bed9"
@@ -71,6 +126,16 @@
     "@azure/ms-rest-azure-env" "^1.1.2"
     "@azure/ms-rest-js" "^1.8.6"
     adal-node "^0.1.28"
+
+"@azure/storage-blob@12.0.0-preview.1":
+  version "12.0.0-preview.1"
+  resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.0.0-preview.1.tgz#ad9d88f7a699cf1743b81d5ae20811a6aabbef9c"
+  integrity sha512-/TfRMTyxndWxVgndHVTMshZt85eXXTVILOUXICTXX3ulBWx9Ogyb477evg7JLkiQhBMwVL5CuNmQx5TEXpZWpA==
+  dependencies:
+    "@azure/core-http" "^1.0.0-preview.1"
+    "@azure/core-paging" "^1.0.0-preview.1"
+    events "^3.0.0"
+    tslib "^1.9.3"
 
 "@azure/storage-queue@^10.1.0":
   version "10.1.0"
@@ -1266,6 +1331,13 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
   integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
 
+"@types/node-fetch@^2.3.7":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.0.tgz#1c55616a4591bdd15a389fbd0da4a55b9502add5"
+  integrity sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "12.6.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.3.tgz#44d507c5634f85e7164707ca36bba21b5213d487"
@@ -1300,10 +1372,17 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/tunnel@0.0.0":
+"@types/tunnel@0.0.0", "@types/tunnel@^0.0.0":
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.0.tgz#c2a42943ee63c90652a5557b8c4e56cda77f944e"
   integrity sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/tunnel@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.1.tgz#0d72774768b73df26f25df9184273a42da72b19c"
+  integrity sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
   dependencies:
     "@types/node" "*"
 
@@ -1490,6 +1569,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 acorn-globals@^4.1.0:
   version "4.3.2"
@@ -1849,9 +1935,9 @@ aws4@^1.6.0, aws4@^1.8.0:
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 axe-core@3.2.2, axe-core@^3.1.2, axe-core@^3.2.2:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.0.tgz#3b32d7e54390d89ff4891b20394d33ad7a192776"
-  integrity sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.1.tgz#3d1fa78cca8ead1b78c350581501e4e37b97b826"
+  integrity sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ==
 
 axe-puppeteer@^1.0.0:
   version "1.0.0"
@@ -3289,6 +3375,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
@@ -3629,7 +3720,7 @@ fork-ts-checker-webpack-plugin@^0.5.2:
     minimatch "^3.0.4"
     tapable "^1.0.0"
 
-form-data@^2.3.2:
+form-data@^2.3.2, form-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.0.tgz#094ec359dc4b55e7d62e0db4acd76e89fe874d37"
   integrity sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==
@@ -5194,7 +5285,7 @@ jwa@^1.4.1:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@3.x.x:
+jws@3.x.x, jws@~3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
   integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
@@ -5866,7 +5957,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -6722,9 +6813,9 @@ punycode@^2.1.0, punycode@^2.1.1:
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 puppeteer@1.5.0, puppeteer@^1.12.2, puppeteer@^1.18.1:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.18.1.tgz#4a66f3bdab01115ededf70443ec904c99917a815"
-  integrity sha512-luUy0HPSuWPsPZ1wAp6NinE0zgetWtudf5zwZ6dHjMWfYpTQcmKveFRox7VBNhQ98OjNA9PQ9PzQyX8k/KrxTg==
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.19.0.tgz#e3b7b448c2c97933517078d7a2c53687361bebea"
+  integrity sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"
@@ -6739,6 +6830,11 @@ q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+qs@6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
@@ -7908,7 +8004,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@>=2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
   integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
@@ -7993,7 +8089,7 @@ ts-loader@^5.3.3:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
#### Description of changes

I still havn't removed the serviceConfiguration class from common package & its usages.
The new package runtime-config-provider provides serviceConfig class that listens to blob changes & returns the latest config.

I will send another PR to start using this package.

For review, Core changes are in: BlobReader, ConfigFileUpdater. ServiceConfiguration class is almost same as the class in common package, except that it listens to ConfigFileUpdater.


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
