### PR TITLE
Generalize CODEOWNERS to use whole-team instead of service-specific team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repository.
-*   @Microsoft/accessibility-insights-service-code-owners
+*   @microsoft/accessibility-insights-code-owners


### PR DESCRIPTION
#### Description of changes

We've started updating all the accessibility insights repos to use a shared CODEOWNERS team, rather than maintaining separate ones per project. This brings accessibility-insights-service up to date with this new policy.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
