### PR TITLE
Fix for TypeError: fetch is not a function

### DIFF
--- a/packages/job-manager/webpack.config.js
+++ b/packages/job-manager/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = env => {
         ],
         resolve: {
             extensions: ['.ts', '.js', '.json'],
+            mainFields: ['main'], //This is fix for this issue https://www.gitmemory.com/issue/bitinn/node-fetch/450/494475397
         },
         target: 'node',
     };

--- a/packages/runner/webpack.config.js
+++ b/packages/runner/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = env => {
         ],
         resolve: {
             extensions: ['.ts', '.js', '.json'],
+            mainFields: ['main'], //This is fix for this issue https://www.gitmemory.com/issue/bitinn/node-fetch/450/494475397
         },
         target: 'node',
     };

--- a/packages/scan-request-sender/webpack.config.js
+++ b/packages/scan-request-sender/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = env => {
         ],
         resolve: {
             extensions: ['.ts', '.js', '.json'],
+            mainFields: ['main'], //This is fix for this issue https://www.gitmemory.com/issue/bitinn/node-fetch/450/494475397
         },
         target: 'node',
     };


### PR DESCRIPTION
#### Description of changes
The problem is that Webpack favors modules import over CommonJS by default. This is different from Node which results in mixing import and require.

When Node sees require("node-fetch), it'll pick the main config while Webpack picks module.
So we need to reconfigure webpack to pick main config.
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
