### PR TITLE
Fix infinite loop in worker "wait till all running tasks are done"

### DIFF
--- a/packages/job-manager/src/worker/worker.spec.ts
+++ b/packages/job-manager/src/worker/worker.spec.ts
@@ -224,7 +224,7 @@ describe(Worker, () => {
             .returns(async () => {
                 if (poolMetricsInfoCallbackCount > 1) {
                     poolMetricsInfo.load.activeTasks = 0;
-                    poolMetricsInfo.load.runningTasks = 0;
+                    poolMetricsInfo.load.runningTasks = 1;
 
                     return Promise.resolve(poolMetricsInfo);
                 } else {

--- a/packages/job-manager/src/worker/worker.ts
+++ b/packages/job-manager/src/worker/worker.ts
@@ -38,7 +38,7 @@ export class Worker {
                 const scanMessages = await this.getMessages(tasksIncrementCount);
                 if (scanMessages.length === 0) {
                     this.logger.logInfo(`The storage queue '${this.queue.scanQueue}' has no message to process.`);
-                    if (poolMetricsInfo.load.activeTasks === 0 && poolMetricsInfo.load.runningTasks === 0) {
+                    if (poolMetricsInfo.load.activeTasks === 0 && poolMetricsInfo.load.runningTasks === 1) {
                         this.logger.logInfo(`Exiting the ${this.jobId} job since there are no active/running tasks.`);
                         break;
                     }


### PR DESCRIPTION
#### Description of changes

`if (poolMetricsInfo.load.activeTasks === 0 && poolMetricsInfo.load.runningTasks === 0)`
Will always be false because running task will be at least 1 which is the job-manager task itself so this is gonna cause infinite loop and the job will never end, it should be 
`if (poolMetricsInfo.load.activeTasks === 0 && poolMetricsInfo.load.runningTasks === 1)`

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
