### PR TITLE
chore: update templates to use headings and comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,29 +7,37 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
 
-**Area**
+<!-- A clear and concise description of what the bug is. -->
+
+## Area
+
 - [ ] Install script
 - [ ] Update script
 - [ ] Service
 
-**To Reproduce**
+## To Reproduce
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Expected behavior
 
-**Log files**
-If applicable, any log files / console output that might help explain what the issue might be.
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Log files
 
-**Additional context**
-Add any other context about the problem here.
+<!-- If applicable, any log files / console output that might help explain what the issue might be. -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Is your feature request related to a problem? Please describe.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Describe the solution you'd like
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- A clear and concise description of what you want to happen. -->
+
+## Describe alternatives you've considered
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -7,4 +7,7 @@ assignees: ''
 
 ---
 
-Make sure to provide enough context. If you have spoken to a team member please mention them here. Add any items (screenshots etc) that will help.
+<!--
+Make sure to provide enough context. If you have spoken to a team member please mention them here.
+Add any items (screenshots etc) that will help.
+-->


### PR DESCRIPTION
#### Description of changes

Updated the help text in GitHub bug report, feature request, and general question templates as comments so they don't appear in the issue that gets filed if the user doesn't remove it.

**Note:** I also changed the section headings in the bug report and feature request templates to markdown headings (##) for consistency with AI Web repo. If there is a preference for using emphasis (**) instead, I can change these back.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
