### PR TITLE
Pownkel/vmss resource group retry

### DIFF
--- a/packages/resource-deployment/scripts/batch-pool-enable-msi.sh
+++ b/packages/resource-deployment/scripts/batch-pool-enable-msi.sh
@@ -80,7 +80,8 @@ assignSystemIdentity() {
 
         # Wait until we are certain the resource group exists
         waiting=false
-        end=$((SECONDS + 600))
+        timeout=7200
+        end=$((SECONDS + $timeout))
         resourceGroupExists=$(az group exists --name "$vmssResourceGroup")
         while [ "$resourceGroupExists" = false ] && [ $SECONDS -le $end ]; do
             if [ "$waiting" != true ]; then
@@ -99,6 +100,8 @@ assignSystemIdentity() {
             echo "Resource group $vmssResourceGroup does not exist"
             exit 1
         fi
+
+        echo "Resource group found after $((SECONDS - (end - timeout)))"
 
         vmssNameQuery="[?tags.PoolName=='$pool' && tags.BatchAccountName=='$batchAccountName' && resourceGroup=='$vmssResourceGroup'].name"
         vmssName=$(az vmss list --query "$vmssNameQuery" -o tsv)

--- a/packages/resource-deployment/scripts/batch-pool-enable-msi.sh
+++ b/packages/resource-deployment/scripts/batch-pool-enable-msi.sh
@@ -80,7 +80,7 @@ assignSystemIdentity() {
 
         # Wait until we are certain the resource group exists
         waiting=false
-        timeout=7200
+        timeout=1800 # timeout after half an hour
         end=$((SECONDS + $timeout))
         resourceGroupExists=$(az group exists --name "$vmssResourceGroup")
         while [ "$resourceGroupExists" = false ] && [ $SECONDS -le $end ]; do
@@ -97,11 +97,11 @@ assignSystemIdentity() {
 
         # Exit if timed out
         if [ "$resourceGroupExists" = false ]; then
-            echo "Resource group $vmssResourceGroup does not exist"
+            echo "Could not find resource group $vmssResourceGroup after $timeout seconds"
             exit 1
         fi
 
-        echo "Resource group found after $((SECONDS - (end - timeout)))"
+        echo "Resource group $vmssResourceGroup found after $((SECONDS - (end - timeout))) seconds"
 
         vmssNameQuery="[?tags.PoolName=='$pool' && tags.BatchAccountName=='$batchAccountName' && resourceGroup=='$vmssResourceGroup'].name"
         vmssName=$(az vmss list --query "$vmssNameQuery" -o tsv)

--- a/packages/resource-deployment/scripts/batch-pool-enable-msi.sh
+++ b/packages/resource-deployment/scripts/batch-pool-enable-msi.sh
@@ -81,17 +81,17 @@ assignSystemIdentity() {
         # Wait until we are certain the resource group exists
         waiting=false
         end=$((SECONDS + 600))
-        resourceGroupExists=$(az group exists --name '$vmssResourceGroup')
+        resourceGroupExists=$(az group exists --name "$vmssResourceGroup")
         while [ "$resourceGroupExists" = false ] && [ $SECONDS -le $end ]; do
             if [ "$waiting" != true ]; then
                 waiting=true
-                echo "Waiting for resource group '$vmssResourceGroup'"
+                echo "Waiting for resource group $vmssResourceGroup"
                 printf " - Running .."
             fi
 
             sleep 5
             printf "."
-            resourceGroupExists=$(az group exists --name '$vmssResourceGroup')
+            resourceGroupExists=$(az group exists --name "$vmssResourceGroup")
         done
 
         # Exit if timed out


### PR DESCRIPTION
Verify that vmss resource group exists and can be accessed before trying to enable managed identity in installation script. If it fails, retry until a timeout.