### PR TITLE
Reduce number of calls to Cosmos DB in scan runner

### DIFF
--- a/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.db.spec.ts
+++ b/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.db.spec.ts
@@ -124,11 +124,10 @@ describe('OnDemandPageScanRunResultProvider.Db', () => {
             resultUpdate.scanResult = { state: 'pass', issueCount: 3 };
 
             await testSubject.writeScanRuns([result]);
-            await testSubject.updateScanRun(result);
-            const itemsInDb = await testSubject.readScanRuns([result.id]);
+            const itemsInDb = await testSubject.updateScanRun(result);
 
-            maskSystemProperties(itemsInDb);
-            expect(itemsInDb).toEqual([expectedSavedResult]);
+            maskSystemProperties([itemsInDb]);
+            expect(itemsInDb).toEqual(expectedSavedResult);
         });
 
         function maskSystemProperties(results: OnDemandPageScanResult[]): void {

--- a/packages/web-api-scan-job-manager/.vscode/launch.json
+++ b/packages/web-api-scan-job-manager/.vscode/launch.json
@@ -2,7 +2,6 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-
     "version": "0.2.0",
     "configurations": [
         {
@@ -12,10 +11,10 @@
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/src/index.ts",
-            "preLaunchTask": "tsc",
+            "preLaunchTask": "run",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "args": []
+            "smartStep": true
         }
     ]
 }

--- a/packages/web-api-scan-job-manager/.vscode/tasks.json
+++ b/packages/web-api-scan-job-manager/.vscode/tasks.json
@@ -4,19 +4,27 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "tsc",
-            "command": "tsc",
-            "isShellCommand": true,
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
+            "type": "shell",
+            "label": "run",
+            "dependsOn": "tsc",
+            "windows": {
+                "command": "xcopy .env ./dist /y"
             },
-            "args": [],
+            "osx": {
+                "command": "cp .env ./dist"
+            }
+        },
+        {
+            "type": "shell",
+            "label": "tsc",
+            "dependsOn": "clean",
+            "command": "tsc",
             "problemMatcher": ["$tsc"]
+        },
+        {
+            "type": "shell",
+            "label": "clean",
+            "command": "npx rimraf dist"
         }
     ]
 }

--- a/packages/web-api-scan-request-sender/.vscode/launch.json
+++ b/packages/web-api-scan-request-sender/.vscode/launch.json
@@ -2,20 +2,19 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Start debugging web-api-scan-request-sender",
+            "name": "Start debugging web-api-request-sender",
             "type": "node",
             "request": "launch",
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/src/index.ts",
-            "preLaunchTask": "tsc",
+            "preLaunchTask": "run",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "args": []
+            "smartStep": true
         }
     ]
 }

--- a/packages/web-api-scan-request-sender/.vscode/tasks.json
+++ b/packages/web-api-scan-request-sender/.vscode/tasks.json
@@ -4,19 +4,27 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "tsc",
-            "command": "tsc",
-            "isShellCommand": true,
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
+            "type": "shell",
+            "label": "run",
+            "dependsOn": "tsc",
+            "windows": {
+                "command": "xcopy .env ./dist /y"
             },
-            "args": [],
+            "osx": {
+                "command": "cp .env ./dist"
+            }
+        },
+        {
+            "type": "shell",
+            "label": "tsc",
+            "dependsOn": "clean",
+            "command": "tsc",
             "problemMatcher": ["$tsc"]
+        },
+        {
+            "type": "shell",
+            "label": "clean",
+            "command": "npx rimraf dist"
         }
     ]
 }

--- a/packages/web-api-scan-runner/.vscode/launch.json
+++ b/packages/web-api-scan-runner/.vscode/launch.json
@@ -2,7 +2,6 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-
     "version": "0.2.0",
     "configurations": [
         {
@@ -12,10 +11,10 @@
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/src/index.ts",
-            "preLaunchTask": "tsc",
+            "preLaunchTask": "run",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "args": []
+            "smartStep": true
         }
     ]
 }

--- a/packages/web-api-scan-runner/.vscode/tasks.json
+++ b/packages/web-api-scan-runner/.vscode/tasks.json
@@ -4,19 +4,27 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "tsc",
-            "command": "tsc",
-            "isShellCommand": true,
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
+            "type": "shell",
+            "label": "run",
+            "dependsOn": "tsc",
+            "windows": {
+                "command": "xcopy .env ./dist /y"
             },
-            "args": [],
+            "osx": {
+                "command": "cp .env ./dist"
+            }
+        },
+        {
+            "type": "shell",
+            "label": "tsc",
+            "dependsOn": "clean",
+            "command": "tsc",
             "problemMatcher": ["$tsc"]
+        },
+        {
+            "type": "shell",
+            "label": "clean",
+            "command": "npx rimraf dist"
         }
     ]
 }


### PR DESCRIPTION
#### Description of changes

Reduce number of calls to Cosmos DB in scan runner
Enable Cosmos DB document merge with properties reset
Fix dev debug experience

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #310, #311
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
