### PR TITLE
reducing the default batch size from 1000 to 250.

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -14,7 +14,7 @@ Object {
       "format": "int",
     },
     "maxWallClockTimeInHours": Object {
-      "default": 29,
+      "default": 5,
       "doc": "The amount of time the job manager instance will run.",
       "format": "int",
     },
@@ -45,7 +45,7 @@ Object {
       "format": "int",
     },
     "maxScanRequestBatchCount": Object {
-      "default": 1000,
+      "default": 250,
       "doc": "Maximum number of scan requests in a single HTTP client request.",
       "format": "int",
     },
@@ -148,7 +148,7 @@ Object {
       "format": "int",
     },
     "maxWallClockTimeInHours": Object {
-      "default": 29,
+      "default": 5,
       "doc": "The amount of time the job manager instance will run.",
       "format": "int",
     },
@@ -179,7 +179,7 @@ Object {
       "format": "int",
     },
     "maxScanRequestBatchCount": Object {
-      "default": 1000,
+      "default": 250,
       "doc": "Maximum number of scan requests in a single HTTP client request.",
       "format": "int",
     },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -202,7 +202,7 @@ export class ServiceConfiguration {
             restApiConfig: {
                 maxScanRequestBatchCount: {
                     format: 'int',
-                    default: 1000,
+                    default: 250,
                     doc: 'Maximum number of scan requests in a single HTTP client request.',
                 },
                 scanRequestProcessingDelayInSeconds: {

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -131,7 +131,7 @@ export class ServiceConfiguration {
                 },
                 maxWallClockTimeInHours: {
                     format: 'int',
-                    default: 29,
+                    default: 5,
                     doc: 'The amount of time the job manager instance will run.',
                 },
             },


### PR DESCRIPTION
#### Description of changes

Reducing batch request size from 1000 to 250, which will help us improve design going forward. 
If we decided to send request directly to storage queue, we need to make sure request size is not more than 80KB.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
