### PR TITLE
Track batch pool metrics when job manager queues tasks

### DIFF
--- a/packages/logger/src/app-insights-logger-client.spec.ts
+++ b/packages/logger/src/app-insights-logger-client.spec.ts
@@ -3,8 +3,8 @@
 import 'reflect-metadata';
 
 import * as appInsights from 'applicationinsights';
-import * as _ from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { AppInsightsLoggerClient } from './app-insights-logger-client';
 import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LogLevel } from './logger';
@@ -108,10 +108,12 @@ describe(AppInsightsLoggerClient, () => {
             appInsightsTelemetryClientMock.reset();
 
             appInsightsTelemetryClientMock
-                .setup(t => t.trackEvent(It.isValue({ name: 'HealthCheck', properties: { foo: 'bar' }, measurements: { foo: 1 } })))
+                .setup(t =>
+                    t.trackEvent(It.isValue({ name: 'HealthCheck', properties: { foo: 'bar' }, measurements: { scanWaitTime: 1 } })),
+                )
                 .verifiable();
 
-            testSubject.trackEvent('HealthCheck', { foo: 'bar' }, { foo: 1 });
+            testSubject.trackEvent('HealthCheck', { foo: 'bar' }, { scanWaitTime: 1 });
 
             verifyMocks();
         });

--- a/packages/logger/src/app-insights-logger-client.ts
+++ b/packages/logger/src/app-insights-logger-client.ts
@@ -7,7 +7,7 @@ import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LogLevel } from './logger';
 import { LoggerClient } from './logger-client';
 import { LoggerEvent } from './logger-event';
-import { BaseTelemetryMeasurements } from './logger-event-measurements';
+import { TelemetryMeasurements } from './logger-event-measurements';
 import { loggerTypes } from './logger-types';
 
 @injectable()
@@ -42,7 +42,7 @@ export class AppInsightsLoggerClient implements LoggerClient {
         this.appInsightsObject.defaultClient.trackMetric({ name: name, value: value });
     }
 
-    public trackEvent(name: LoggerEvent, properties?: { [name: string]: string }, measurements?: BaseTelemetryMeasurements): void {
+    public trackEvent(name: LoggerEvent, properties?: { [name: string]: string }, measurements?: TelemetryMeasurements[LoggerEvent]): void {
         this.appInsightsObject.defaultClient.trackEvent({ name: name, properties, measurements });
     }
 

--- a/packages/logger/src/console-logger-client.spec.ts
+++ b/packages/logger/src/console-logger-client.spec.ts
@@ -9,7 +9,7 @@ import * as util from 'util';
 import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { ConsoleLoggerClient } from './console-logger-client';
 import { LogLevel } from './logger';
-import { BaseTelemetryMeasurements } from './logger-event-measurements';
+import { ScanTaskStartedMeasurements } from './logger-event-measurements';
 
 // tslint:disable: no-null-keyword no-object-literal-type-assertion no-any no-void-expression no-empty
 
@@ -90,7 +90,7 @@ describe(ConsoleLoggerClient, () => {
             const baseProps: BaseTelemetryProperties = { foo: 'bar', source: 'test-source' };
             await testSubject.setup(baseProps);
             const eventProps = { eventProp1: 'prop value' };
-            const eventMeasurements: BaseTelemetryMeasurements = { foo: 1 };
+            const eventMeasurements: ScanTaskStartedMeasurements = { scanWaitTime: 1 };
 
             testSubject.trackEvent('HealthCheck', eventProps, eventMeasurements);
             const properties = `[properties - ${util.inspect({ ...baseProps, ...eventProps })}]`;

--- a/packages/logger/src/console-logger-client.ts
+++ b/packages/logger/src/console-logger-client.ts
@@ -9,7 +9,7 @@ import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LogLevel } from './logger';
 import { LoggerClient } from './logger-client';
 import { LoggerEvent } from './logger-event';
-import { BaseTelemetryMeasurements } from './logger-event-measurements';
+import { BaseTelemetryMeasurements, TelemetryMeasurements } from './logger-event-measurements';
 import { loggerTypes } from './logger-types';
 
 @injectable()
@@ -34,7 +34,7 @@ export class ConsoleLoggerClient implements LoggerClient {
         });
     }
 
-    public trackEvent(name: LoggerEvent, properties?: { [name: string]: string }, measurements?: BaseTelemetryMeasurements): void {
+    public trackEvent(name: LoggerEvent, properties?: { [name: string]: string }, measurements?: TelemetryMeasurements[LoggerEvent]): void {
         this.executeInDebugMode(() => {
             this.logInConsole(
                 `[Event]${this.getPrintablePropertiesString(properties)}${this.getPrintableMeasurementsString(measurements)}`,

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -10,4 +10,5 @@ export {
     BatchPoolMeasurements,
     ScanTaskStartedMeasurements,
     ScanTaskCompletedMeasurements,
+    TelemetryMeasurements,
 } from './logger-event-measurements';

--- a/packages/logger/src/logger-client.ts
+++ b/packages/logger/src/logger-client.ts
@@ -3,12 +3,12 @@
 import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LogLevel } from './logger';
 import { LoggerEvent } from './logger-event';
-import { BaseTelemetryMeasurements } from './logger-event-measurements';
+import { TelemetryMeasurements } from './logger-event-measurements';
 
 export interface LoggerClient {
     setup(baseProperties?: BaseTelemetryProperties): Promise<void>;
     trackMetric(name: string, value: number): void;
-    trackEvent(name: LoggerEvent, properties?: { [key: string]: string }, measurements?: BaseTelemetryMeasurements): void;
+    trackEvent(name: LoggerEvent, properties?: { [key: string]: string }, measurements?: TelemetryMeasurements[LoggerEvent]): void;
     log(message: string, logLevel: LogLevel, properties?: { [name: string]: string }): void;
     trackException(error: Error): void;
     flush(): void;

--- a/packages/logger/src/logger-event-measurements.ts
+++ b/packages/logger/src/logger-event-measurements.ts
@@ -26,3 +26,14 @@ export interface ScanTaskCompletedMeasurements extends BaseTelemetryMeasurements
     scanExecutionTime: number;
     scanWallClockTime: number;
 }
+
+export type TelemetryMeasurements = {
+    HealthCheck: null;
+    ScanRequestSubmitted: null;
+    ScanTasksQueued: BatchPoolMeasurements;
+    BatchScanRequestSubmitted: BatchScanRequestMeasurements;
+    ScanTaskStarted: ScanTaskStartedMeasurements;
+    ScanTaskCompleted: ScanTaskCompletedMeasurements;
+    ScanTaskSucceeded: null;
+    ScanTaskFailed: null;
+};

--- a/packages/logger/src/logger-event-measurements.ts
+++ b/packages/logger/src/logger-event-measurements.ts
@@ -30,7 +30,7 @@ export interface ScanTaskCompletedMeasurements extends BaseTelemetryMeasurements
 export type TelemetryMeasurements = {
     HealthCheck: null;
     ScanRequestSubmitted: null;
-    ScanTasksQueued: BatchPoolMeasurements;
+    BatchPoolStats: BatchPoolMeasurements;
     BatchScanRequestSubmitted: BatchScanRequestMeasurements;
     ScanTaskStarted: ScanTaskStartedMeasurements;
     ScanTaskCompleted: ScanTaskCompletedMeasurements;

--- a/packages/logger/src/logger-event.ts
+++ b/packages/logger/src/logger-event.ts
@@ -5,7 +5,14 @@ export declare type LoggerEvent =
     | 'HealthCheck'
     | 'BatchScanRequestSubmitted'
     | 'ScanRequestSubmitted'
+    | 'ScanTasksQueued'
     | 'ScanTaskStarted'
     | 'ScanTaskCompleted'
     | 'ScanTaskSucceeded'
     | 'ScanTaskFailed';
+
+[
+    {
+        url: 'https://www.bing.com',
+    },
+];

--- a/packages/logger/src/logger-event.ts
+++ b/packages/logger/src/logger-event.ts
@@ -5,7 +5,7 @@ export declare type LoggerEvent =
     | 'HealthCheck'
     | 'BatchScanRequestSubmitted'
     | 'ScanRequestSubmitted'
-    | 'ScanTasksQueued'
+    | 'BatchPoolStats'
     | 'ScanTaskStarted'
     | 'ScanTaskCompleted'
     | 'ScanTaskSucceeded'

--- a/packages/logger/src/logger-event.ts
+++ b/packages/logger/src/logger-event.ts
@@ -10,9 +10,3 @@ export declare type LoggerEvent =
     | 'ScanTaskCompleted'
     | 'ScanTaskSucceeded'
     | 'ScanTaskFailed';
-
-[
-    {
-        url: 'https://www.bing.com',
-    },
-];

--- a/packages/logger/src/logger.spec.ts
+++ b/packages/logger/src/logger.spec.ts
@@ -107,7 +107,7 @@ describe(Logger, () => {
 
         it('when properties/measurements passed', async () => {
             const properties = { foo: 'bar' };
-            const measurements = { foo: 1 };
+            const measurements = { scanWaitTime: 1 };
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -6,7 +6,7 @@ import { VError } from 'verror';
 import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LoggerClient } from './logger-client';
 import { LoggerEvent } from './logger-event';
-import { BaseTelemetryMeasurements } from './logger-event-measurements';
+import { TelemetryMeasurements } from './logger-event-measurements';
 
 export enum LogLevel {
     info,
@@ -40,7 +40,7 @@ export class Logger {
         this.invokeLoggerClient(client => client.trackMetric(name, value));
     }
 
-    public trackEvent(name: LoggerEvent, properties?: { [name: string]: string }, measurements?: BaseTelemetryMeasurements): void {
+    public trackEvent(name: LoggerEvent, properties?: { [name: string]: string }, measurements?: TelemetryMeasurements[LoggerEvent]): void {
         this.ensureInitialized();
 
         this.invokeLoggerClient(client => client.trackEvent(name, properties, measurements));

--- a/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
@@ -141,7 +141,7 @@ describe(Worker, () => {
         loggerMock
             .setup(lm =>
                 // tslint:disable-next-line: no-null-keyword
-                lm.trackEvent('ScanTasksQueued', null, expectedMeasurements),
+                lm.trackEvent('BatchPoolStats', null, expectedMeasurements),
             )
             .verifiable(Times.once());
 

--- a/packages/web-api-scan-job-manager/src/worker/worker.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.ts
@@ -73,7 +73,7 @@ export class Worker {
             };
 
             // tslint:disable-next-line: no-null-keyword
-            this.logger.trackEvent('ScanTasksQueued', null, batchPoolMeasurements);
+            this.logger.trackEvent('BatchPoolStats', null, batchPoolMeasurements);
 
             if (this.runOnce) {
                 break;


### PR DESCRIPTION
#### Description of changes

- Make measurements data more strongly typed so that anyone cannot pass random dictionary into the ``trackEvent()`` function as event data.
- Add batch pool stat track events in web-api work flow.
- Update relevant unit tests.
- Validated it locally & in Azure:

![image](https://user-images.githubusercontent.com/15974344/67345901-8bb98e00-f4f1-11e9-953c-01bfe0e2bec3.png)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
