### PR TITLE
Pownkel/scan complete event

### DIFF
--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -6,7 +6,7 @@ import { AxeResults } from 'axe-core';
 import { convertAxeToSarif } from 'axe-sarif-converter';
 import { GuidGenerator } from 'common';
 import { cloneDeep } from 'lodash';
-import { Logger, loggerTypes, ScanTaskCompletedMeasurements } from 'logger';
+import { Logger, loggerTypes, ScanTaskCompletedMeasurements, ScanTaskStartedMeasurements } from 'logger';
 import * as MockDate from 'mockdate';
 import { Browser } from 'puppeteer';
 import { AxeScanResults } from 'scanner';
@@ -245,12 +245,15 @@ describe(Runner, () => {
         const queueTime: number = 20;
         const executionTime: number = 30;
         const timestamps = setupTimeMocks(queueTime, executionTime, passedAxeScanResults);
-        const expectedMeasurements: ScanTaskCompletedMeasurements = {
+
+        const scanStartedMeasurements: ScanTaskStartedMeasurements = { scanWaitTime: queueTime * 1000 };
+        const scanCompletedMeasurements: ScanTaskCompletedMeasurements = {
             scanExecutionTime: executionTime * 1000,
             scanWallClockTime: (executionTime + queueTime) * 1000,
         };
 
-        loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, expectedMeasurements)).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskStarted', undefined, scanStartedMeasurements)).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable(Times.never());
 
@@ -279,12 +282,15 @@ describe(Runner, () => {
         const queueTime: number = 20;
         const executionTime: number = 30;
         const timestamps = setupTimeMocks(queueTime, executionTime, passedAxeScanResults);
-        const expectedMeasurements: ScanTaskCompletedMeasurements = {
+
+        const scanStartedMeasurements: ScanTaskStartedMeasurements = { scanWaitTime: queueTime * 1000 };
+        const scanCompletedMeasurements: ScanTaskCompletedMeasurements = {
             scanExecutionTime: executionTime * 1000,
             scanWallClockTime: (executionTime + queueTime) * 1000,
         };
 
-        loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, expectedMeasurements)).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskStarted', undefined, scanStartedMeasurements)).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable(Times.never());
 

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -6,7 +6,7 @@ import { AxeResults } from 'axe-core';
 import { convertAxeToSarif } from 'axe-sarif-converter';
 import { GuidGenerator } from 'common';
 import { cloneDeep } from 'lodash';
-import { Logger } from 'logger';
+import { Logger, loggerTypes, ScanTaskCompletedMeasurements } from 'logger';
 import * as MockDate from 'mockdate';
 import { Browser } from 'puppeteer';
 import { AxeScanResults } from 'scanner';
@@ -106,6 +106,7 @@ describe(Runner, () => {
         pageScanRunReportServiceMock = Mock.ofType(PageScanRunReportService, MockBehavior.Strict);
         guidGeneratorMock = Mock.ofType(GuidGenerator);
         guidGeneratorMock.setup(g => g.createGuid()).returns(() => reportGuid);
+        guidGeneratorMock.setup(g => g.getGuidTimestamp('id')).returns(() => new Date());
         dateNow = new Date(2019, 2, 3);
         MockDate.set(dateNow);
         convertAxeToSarifMock = Mock.ofInstance(convertAxeToSarif, MockBehavior.Strict);
@@ -240,6 +241,74 @@ describe(Runner, () => {
         await runner.run();
     });
 
+    it('sends telemetry event on successful scan', async () => {
+        const queueTime: number = 20;
+        const executionTime: number = 30;
+        const timestamps = setupTimeMocks(queueTime, executionTime, passedAxeScanResults);
+        const expectedMeasurements: ScanTaskCompletedMeasurements = {
+            scanExecutionTime: executionTime * 1000,
+            scanWallClockTime: (executionTime + queueTime) * 1000,
+        };
+
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, expectedMeasurements)).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable(Times.never());
+
+        setupWebDriverCalls();
+        setupReadScanResultCall(onDemandPageScanResult);
+        setupUpdateScanRunResultCall(getRunningJobStateScanResult());
+        scannerTaskMock
+            .setup(async s => s.scan(scanMetadata.url))
+            .returns(async () => {
+                MockDate.set(timestamps.scanCompleteTime);
+
+                return passedAxeScanResults;
+            })
+            .verifiable();
+        setupConvertAxeToSarifCall(passedAxeScanResults);
+        setupSaveSarifReportCall();
+        const scanResult = getScanResultWithNoViolations();
+        scanResult.run.timestamp = timestamps.scanCompleteTime.toJSON();
+        setupUpdateScanRunResultCall(scanResult);
+
+        await runner.run();
+        loggerMock.verifyAll();
+    });
+
+    it('sends telemetry event on scan error', async () => {
+        const queueTime: number = 20;
+        const executionTime: number = 30;
+        const timestamps = setupTimeMocks(queueTime, executionTime, passedAxeScanResults);
+        const expectedMeasurements: ScanTaskCompletedMeasurements = {
+            scanExecutionTime: executionTime * 1000,
+            scanWallClockTime: (executionTime + queueTime) * 1000,
+        };
+
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, expectedMeasurements)).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable();
+        loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable(Times.never());
+
+        setupWebDriverCalls();
+        setupReadScanResultCall(onDemandPageScanResult);
+        setupUpdateScanRunResultCall(getRunningJobStateScanResult());
+        scannerTaskMock
+            .setup(async s => s.scan(scanMetadata.url))
+            .returns(async () => {
+                MockDate.set(timestamps.scanCompleteTime);
+
+                return unscannableAxeScanResults;
+            })
+            .verifiable();
+        setupConvertAxeToSarifCall(unscannableAxeScanResults);
+        setupSaveSarifReportCall();
+        const scanResult = getFailingJobStateScanResult(unscannableAxeScanResults.error);
+        scanResult.run.timestamp = timestamps.scanCompleteTime.toJSON();
+        setupUpdateScanRunResultCall(scanResult);
+
+        await runner.run();
+        loggerMock.verifyAll();
+    });
+
     function setupConvertAxeToSarifCall(scanResults: AxeScanResults): void {
         convertAxeToSarifMock
             .setup(c => c(scanResults.results))
@@ -347,5 +416,33 @@ describe(Runner, () => {
             .setup(async o => o.close())
             .returns(async () => Promise.resolve())
             .verifiable(Times.once());
+    }
+
+    interface ScanRunTimestamps {
+        scanRequestTime: Date;
+        scanCompleteTime: Date;
+    }
+
+    function setupTimeMocks(queueTime: number, executionTime: number, scanResults: AxeScanResults): ScanRunTimestamps {
+        const scanRequestTime: Date = new Date();
+        const scanCompleteTime: Date = new Date();
+        scanRequestTime.setSeconds(scanRequestTime.getSeconds() - queueTime);
+
+        guidGeneratorMock.reset();
+        guidGeneratorMock.setup(g => g.createGuid()).returns(() => reportGuid);
+        guidGeneratorMock
+            .setup(g => g.getGuidTimestamp('id'))
+            .returns(() => scanRequestTime)
+            .verifiable();
+        scanCompleteTime.setSeconds(scanCompleteTime.getSeconds() + executionTime);
+
+        guidGeneratorMock.reset();
+        guidGeneratorMock.setup(g => g.createGuid()).returns(() => reportGuid);
+        guidGeneratorMock
+            .setup(g => g.getGuidTimestamp('id'))
+            .returns(() => scanRequestTime)
+            .verifiable();
+
+        return { scanRequestTime: scanRequestTime, scanCompleteTime: scanCompleteTime };
     }
 });

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -4,7 +4,7 @@ import { convertAxeToSarif, SarifLog } from 'axe-sarif-converter';
 import { GuidGenerator } from 'common';
 import { inject, injectable } from 'inversify';
 import { isNil } from 'lodash';
-import { Logger } from 'logger';
+import { Logger, ScanTaskCompletedMeasurements } from 'logger';
 import { Browser } from 'puppeteer';
 import { AxeScanResults } from 'scanner';
 import { OnDemandPageScanRunResultProvider, PageScanRunReportService } from 'service-library';
@@ -35,6 +35,8 @@ export class Runner {
     ) {}
 
     public async run(): Promise<void> {
+        const scanStartTimestamp: number = Date.now();
+
         let browser: Browser;
         let pageScanResult: OnDemandPageScanResult;
         const scanMetadata = this.scanMetadataConfig.getConfig();
@@ -53,7 +55,15 @@ export class Runner {
             const errorMessage = this.getErrorMessage(error);
             pageScanResult.run = this.createRunResult('failed', errorMessage);
             this.logger.logInfo(`Page scan run failed.`, { error: errorMessage });
+            this.logger.trackEvent('ScanTaskFailed');
         } finally {
+            const scanSubmittedTimestamp: number = this.guidGenerator.getGuidTimestamp(scanMetadata.id).getTime();
+            const scanCompletedTimestamp: number = Date.now();
+            const telemetryMeasurements: ScanTaskCompletedMeasurements = {
+                scanExecutionTime: scanCompletedTimestamp - scanStartTimestamp,
+                scanWallClockTime: scanCompletedTimestamp - scanSubmittedTimestamp,
+            };
+            this.logger.trackEvent('ScanTaskCompleted', undefined, telemetryMeasurements);
             try {
                 await this.webDriverTask.close();
             } catch (error) {
@@ -72,9 +82,11 @@ export class Runner {
 
         if (!isNil(axeScanResults.error)) {
             this.logger.logInfo(`Updating page scan run result state to failed`);
+            this.logger.trackEvent('ScanTaskFailed');
             pageScanResult.run = this.createRunResult('failed', axeScanResults.error);
         } else {
             this.logger.logInfo(`Updating page scan run result state to completed`);
+            this.logger.trackEvent('ScanTaskSucceeded');
             pageScanResult.run = this.createRunResult('completed');
             pageScanResult.scanResult = this.getScanStatus(axeScanResults);
             pageScanResult.reports = [await this.saveScanReport(axeScanResults)];


### PR DESCRIPTION
#### Description of changes

Added telemetry events for ScanTaskStarted, ScanTaskCompleted, ScanTaskSucceeded, and ScanTaskFailed to web api runner. Queue time, scan execution time, and end-to-end time are measured and logged as measurements to these events in milliseconds.
