### PR TITLE
Telemetry events added for web worker and request sender

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -11,4 +11,5 @@ export {
     ScanTaskStartedMeasurements,
     ScanTaskCompletedMeasurements,
     TelemetryMeasurements,
+    ScanUrlsAddedMeasurements,
 } from './logger-event-measurements';

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -12,4 +12,5 @@ export {
     ScanTaskCompletedMeasurements,
     TelemetryMeasurements,
     ScanUrlsAddedMeasurements,
+    ScanRequestQueuedMeasurements,
 } from './logger-event-measurements';

--- a/packages/logger/src/logger-event-measurements.ts
+++ b/packages/logger/src/logger-event-measurements.ts
@@ -27,6 +27,10 @@ export interface ScanTaskCompletedMeasurements extends BaseTelemetryMeasurements
     scanWallClockTime: number;
 }
 
+export interface ScanUrlsAddedMeasurements extends BaseTelemetryMeasurements {
+    addedUrls: number;
+}
+
 export type TelemetryMeasurements = {
     HealthCheck: null;
     ScanRequestSubmitted: null;
@@ -36,4 +40,5 @@ export type TelemetryMeasurements = {
     ScanTaskCompleted: ScanTaskCompletedMeasurements;
     ScanTaskSucceeded: null;
     ScanTaskFailed: null;
+    ScanUrlsAddedForProcessing: ScanUrlsAddedMeasurements;
 };

--- a/packages/logger/src/logger-event-measurements.ts
+++ b/packages/logger/src/logger-event-measurements.ts
@@ -31,6 +31,10 @@ export interface ScanUrlsAddedMeasurements extends BaseTelemetryMeasurements {
     addedUrls: number;
 }
 
+export interface ScanRequestQueuedMeasurements extends BaseTelemetryMeasurements {
+    queuedRequests: number;
+}
+
 export type TelemetryMeasurements = {
     HealthCheck: null;
     ScanRequestSubmitted: null;
@@ -41,4 +45,5 @@ export type TelemetryMeasurements = {
     ScanTaskSucceeded: null;
     ScanTaskFailed: null;
     ScanUrlsAddedForProcessing: ScanUrlsAddedMeasurements;
+    ScanRequestQueued: ScanRequestQueuedMeasurements;
 };

--- a/packages/logger/src/logger-event-measurements.ts
+++ b/packages/logger/src/logger-event-measurements.ts
@@ -44,6 +44,6 @@ export type TelemetryMeasurements = {
     ScanTaskCompleted: ScanTaskCompletedMeasurements;
     ScanTaskSucceeded: null;
     ScanTaskFailed: null;
-    ScanUrlsAddedForProcessing: ScanUrlsAddedMeasurements;
+    ScanRequestsAccepted: ScanUrlsAddedMeasurements;
     ScanRequestQueued: ScanRequestQueuedMeasurements;
 };

--- a/packages/logger/src/logger-event.ts
+++ b/packages/logger/src/logger-event.ts
@@ -6,7 +6,7 @@ export declare type LoggerEvent =
     | 'BatchScanRequestSubmitted'
     | 'ScanRequestSubmitted'
     | 'BatchPoolStats'
-    | 'ScanUrlsAddedForProcessing'
+    | 'ScanRequestsAccepted'
     | 'ScanRequestQueued'
     | 'ScanTaskStarted'
     | 'ScanTaskCompleted'

--- a/packages/logger/src/logger-event.ts
+++ b/packages/logger/src/logger-event.ts
@@ -6,6 +6,7 @@ export declare type LoggerEvent =
     | 'BatchScanRequestSubmitted'
     | 'ScanRequestSubmitted'
     | 'BatchPoolStats'
+    | 'ScanUrlsAddedForProcessing'
     | 'ScanTaskStarted'
     | 'ScanTaskCompleted'
     | 'ScanTaskSucceeded'

--- a/packages/logger/src/logger-event.ts
+++ b/packages/logger/src/logger-event.ts
@@ -7,6 +7,7 @@ export declare type LoggerEvent =
     | 'ScanRequestSubmitted'
     | 'BatchPoolStats'
     | 'ScanUrlsAddedForProcessing'
+    | 'ScanRequestQueued'
     | 'ScanTaskStarted'
     | 'ScanTaskCompleted'
     | 'ScanTaskSucceeded'

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
@@ -111,8 +111,8 @@ describe('Dispatcher', () => {
         setupReadyToScanPageForAllPages([queryDataProviderStub1, queryDataProviderStub2]);
         loggerMock
             // tslint:disable-next-line: no-null-keyword
-            .setup(lm => lm.trackEvent('ScanRequestQueued', null, { queuedRequests: allPages.length }))
-            .verifiable();
+            .setup(lm => lm.trackEvent('ScanRequestQueued', null, { queuedRequests: 2 }))
+            .verifiable(Times.exactly(4));
 
         await dispatcher.dispatchOnDemandScanRequests();
 

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
@@ -109,6 +109,10 @@ describe('Dispatcher', () => {
         const queryDataProviderStub2 = new QueryDataProviderStub<OnDemandPageScanRequest>([], 2);
 
         setupReadyToScanPageForAllPages([queryDataProviderStub1, queryDataProviderStub2]);
+        loggerMock
+            // tslint:disable-next-line: no-null-keyword
+            .setup(lm => lm.trackEvent('ScanRequestQueued', null, { queuedRequests: allPages.length }))
+            .verifiable();
 
         await dispatcher.dispatchOnDemandScanRequests();
 

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -6,7 +6,6 @@ import { inject, injectable } from 'inversify';
 import { Logger } from 'logger';
 import { PageScanRequestProvider } from 'service-library';
 import { OnDemandPageScanRequest } from 'storage-documents';
-
 import { OnDemandScanRequestSender } from './on-demand-scan-request-sender';
 
 @injectable()

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -125,10 +125,10 @@ describe(ScanBatchRequestFeedController, () => {
         setupPartitionKeyFactoryMock(documents);
         // tslint:disable-next-line: no-null-keyword
         loggerMock
-            .setup(lm => lm.trackEvent('ScanUrlsAddedForProcessing', { batchRequestId: documents[0].id }, { addedUrls: 2 }))
+            .setup(lm => lm.trackEvent('ScanRequestsAccepted', { batchRequestId: documents[0].id }, { addedUrls: 2 }))
             .verifiable(Times.once());
         loggerMock
-            .setup(lm => lm.trackEvent('ScanUrlsAddedForProcessing', { batchRequestId: documents[1].id }, { addedUrls: 2 }))
+            .setup(lm => lm.trackEvent('ScanRequestsAccepted', { batchRequestId: documents[1].id }, { addedUrls: 2 }))
             .verifiable(Times.once());
 
         await scanBatchRequestFeedController.invoke(context, documents);

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -124,7 +124,12 @@ describe(ScanBatchRequestFeedController, () => {
         setupPageScanRequestProviderMock(documents);
         setupPartitionKeyFactoryMock(documents);
         // tslint:disable-next-line: no-null-keyword
-        loggerMock.setup(lm => lm.trackEvent('ScanUrlsAddedForProcessing', null, { addedUrls: 2 })).verifiable(Times.exactly(2));
+        loggerMock
+            .setup(lm => lm.trackEvent('ScanUrlsAddedForProcessing', { batchRequestId: documents[0].id }, { addedUrls: 2 }))
+            .verifiable(Times.once());
+        loggerMock
+            .setup(lm => lm.trackEvent('ScanUrlsAddedForProcessing', { batchRequestId: documents[1].id }, { addedUrls: 2 }))
+            .verifiable(Times.once());
 
         await scanBatchRequestFeedController.invoke(context, documents);
     });

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -7,15 +7,9 @@ import { ServiceConfiguration } from 'common';
 import { Logger } from 'logger';
 import * as MockDate from 'mockdate';
 import { OnDemandPageScanRunResultProvider, PageScanRequestProvider, PartitionKeyFactory, ScanDataProvider } from 'service-library';
-import {
-    ItemType,
-    OnDemandPageScanBatchRequest,
-    OnDemandPageScanRequest,
-    OnDemandPageScanResult,
-    PartitionKey,
-    ScanRunBatchRequest,
-} from 'storage-documents';
+import { ItemType, OnDemandPageScanBatchRequest, OnDemandPageScanRequest, OnDemandPageScanResult, PartitionKey } from 'storage-documents';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { ScanBatchRequestFeedController } from './scan-batch-request-feed-controller';
 
 // tslint:disable: no-any no-unsafe-any
@@ -58,6 +52,7 @@ afterEach(() => {
     pageScanRequestProviderMock.verifyAll();
     scanDataProviderMock.verifyAll();
     partitionKeyFactoryMock.verifyAll();
+    loggerMock.verifyAll();
 });
 
 describe(ScanBatchRequestFeedController, () => {
@@ -98,7 +93,6 @@ describe(ScanBatchRequestFeedController, () => {
                     {
                         scanId: 'scan-2',
                         url: 'url-2',
-                        // tslint:disable-next-line: no-null-keyword
                         priority: 0,
                     },
                     {
@@ -129,6 +123,9 @@ describe(ScanBatchRequestFeedController, () => {
         setupOnDemandPageScanRunResultProviderMock(documents);
         setupPageScanRequestProviderMock(documents);
         setupPartitionKeyFactoryMock(documents);
+        // tslint:disable-next-line: no-null-keyword
+        loggerMock.setup(lm => lm.trackEvent('ScanUrlsAddedForProcessing', null, { addedUrls: 2 })).verifiable(Times.exactly(2));
+
         await scanBatchRequestFeedController.invoke(context, documents);
     });
 });

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -46,7 +46,7 @@ export class ScanBatchRequestFeedController extends WebController {
                     addedUrls: addedRequests,
                 };
 
-                this.logger.trackEvent('ScanUrlsAddedForProcessing', { batchRequestId: document.id }, scanUrlsAddedMeasurements);
+                this.logger.trackEvent('ScanRequestsAccepted', { batchRequestId: document.id }, scanUrlsAddedMeasurements);
             }),
         );
     }

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -46,8 +46,7 @@ export class ScanBatchRequestFeedController extends WebController {
                     addedUrls: addedRequests,
                 };
 
-                // tslint:disable-next-line: no-null-keyword
-                this.logger.trackEvent('ScanUrlsAddedForProcessing', null, scanUrlsAddedMeasurements);
+                this.logger.trackEvent('ScanUrlsAddedForProcessing', { batchRequestId: document.id }, scanUrlsAddedMeasurements);
             }),
         );
     }


### PR DESCRIPTION
#### Description of changes

- Track scan urls added for processing events in web workers.
- ``ScanUrlsAddedForProcessing`` events will be sent per ``OnDemandPageScanBatchRequest`` document processed. 


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
