### PR TITLE
Pownkel/throughput metrics

### DIFF
--- a/packages/logger/src/app-insights-logger-client.spec.ts
+++ b/packages/logger/src/app-insights-logger-client.spec.ts
@@ -81,10 +81,10 @@ describe(AppInsightsLoggerClient, () => {
             appInsightsTelemetryClientMock.reset();
 
             appInsightsTelemetryClientMock
-                .setup(t => t.trackMetric(It.isValue({ name: 'metric1', value: 10, properties: {} })))
+                .setup(t => t.trackMetric(It.isValue({ name: 'InProgressScanRequests', value: 10, properties: {} })))
                 .verifiable();
 
-            testSubject.trackMetric('metric1', 10);
+            testSubject.trackMetric('InProgressScanRequests', 10);
 
             verifyMocks();
         });
@@ -238,7 +238,7 @@ describe(AppInsightsLoggerClient, () => {
                 .setup(t =>
                     t.trackMetric(
                         It.isValue({
-                            name: 'metric1',
+                            name: 'InProgressScanRequests',
                             value: 10,
                             properties: customDimensionAssignments,
                         }),
@@ -246,7 +246,7 @@ describe(AppInsightsLoggerClient, () => {
                 )
                 .verifiable();
             testSubject.setCustomProperties(customDimensionAssignments);
-            testSubject.trackMetric('metric1', 10);
+            testSubject.trackMetric('InProgressScanRequests', 10);
             verifyMocks();
         });
 

--- a/packages/logger/src/app-insights-logger-client.spec.ts
+++ b/packages/logger/src/app-insights-logger-client.spec.ts
@@ -81,10 +81,10 @@ describe(AppInsightsLoggerClient, () => {
             appInsightsTelemetryClientMock.reset();
 
             appInsightsTelemetryClientMock
-                .setup(t => t.trackMetric(It.isValue({ name: 'InProgressScanRequests', value: 10, properties: {} })))
+                .setup(t => t.trackMetric(It.isValue({ name: 'QueuedScanRequests', value: 10, properties: {} })))
                 .verifiable();
 
-            testSubject.trackMetric('InProgressScanRequests', 10);
+            testSubject.trackMetric('QueuedScanRequests', 10);
 
             verifyMocks();
         });
@@ -95,10 +95,10 @@ describe(AppInsightsLoggerClient, () => {
             appInsightsTelemetryClientMock.reset();
 
             appInsightsTelemetryClientMock
-                .setup(t => t.trackMetric(It.isValue({ name: 'InProgressScanRequests', value: 1, properties: { foo: 'bar' } })))
+                .setup(t => t.trackMetric(It.isValue({ name: 'QueuedScanRequests', value: 1, properties: { foo: 'bar' } })))
                 .verifiable();
 
-            testSubject.trackMetric('InProgressScanRequests', 1, { foo: 'bar' });
+            testSubject.trackMetric('QueuedScanRequests', 1, { foo: 'bar' });
 
             verifyMocks();
         });
@@ -252,7 +252,7 @@ describe(AppInsightsLoggerClient, () => {
                 .setup(t =>
                     t.trackMetric(
                         It.isValue({
-                            name: 'InProgressScanRequests',
+                            name: 'QueuedScanRequests',
                             value: 10,
                             properties: customDimensionAssignments,
                         }),
@@ -260,7 +260,7 @@ describe(AppInsightsLoggerClient, () => {
                 )
                 .verifiable();
             testSubject.setCustomProperties(customDimensionAssignments);
-            testSubject.trackMetric('InProgressScanRequests', 10);
+            testSubject.trackMetric('QueuedScanRequests', 10);
             verifyMocks();
         });
 

--- a/packages/logger/src/app-insights-logger-client.spec.ts
+++ b/packages/logger/src/app-insights-logger-client.spec.ts
@@ -75,7 +75,7 @@ describe(AppInsightsLoggerClient, () => {
     });
 
     describe('trackMetric', () => {
-        it('when value passed', async () => {
+        it('when properties not passed', async () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup(null);
             appInsightsTelemetryClientMock.reset();
@@ -85,6 +85,20 @@ describe(AppInsightsLoggerClient, () => {
                 .verifiable();
 
             testSubject.trackMetric('InProgressScanRequests', 10);
+
+            verifyMocks();
+        });
+
+        it('when properties passed', async () => {
+            setupCallsForTelemetrySetup();
+            await testSubject.setup(null);
+            appInsightsTelemetryClientMock.reset();
+
+            appInsightsTelemetryClientMock
+                .setup(t => t.trackMetric(It.isValue({ name: 'InProgressScanRequests', value: 1, properties: { foo: 'bar' } })))
+                .verifiable();
+
+            testSubject.trackMetric('InProgressScanRequests', 1, { foo: 'bar' });
 
             verifyMocks();
         });

--- a/packages/logger/src/app-insights-logger-client.ts
+++ b/packages/logger/src/app-insights-logger-client.ts
@@ -8,6 +8,7 @@ import { LogLevel } from './logger';
 import { LoggerClient } from './logger-client';
 import { LoggerEvent } from './logger-event';
 import { TelemetryMeasurements } from './logger-event-measurements';
+import { LoggerMetric } from './logger-metric';
 import { LoggerProperties } from './logger-properties';
 import { loggerTypes } from './logger-types';
 
@@ -41,7 +42,7 @@ export class AppInsightsLoggerClient implements LoggerClient {
         this.appInsightsObject.start();
     }
 
-    public trackMetric(name: string, value: number): void {
+    public trackMetric(name: LoggerMetric, value: number): void {
         this.appInsightsObject.defaultClient.trackMetric({
             name: name,
             value: value,

--- a/packages/logger/src/app-insights-logger-client.ts
+++ b/packages/logger/src/app-insights-logger-client.ts
@@ -42,11 +42,11 @@ export class AppInsightsLoggerClient implements LoggerClient {
         this.appInsightsObject.start();
     }
 
-    public trackMetric(name: LoggerMetric, value: number): void {
+    public trackMetric(name: LoggerMetric, value: number, properties?: { [name: string]: string }): void {
         this.appInsightsObject.defaultClient.trackMetric({
             name: name,
             value: value,
-            properties: { ...this.customProperties },
+            properties: this.getMergedProperties(properties),
         });
     }
 

--- a/packages/logger/src/console-logger-client.spec.ts
+++ b/packages/logger/src/console-logger-client.spec.ts
@@ -40,7 +40,7 @@ describe(ConsoleLoggerClient, () => {
             testSubject = new ConsoleLoggerClient(serviceConfigMock.object, consoleMock.object);
 
             await testSubject.setup();
-            testSubject.trackMetric('InProgressScanRequests', 1);
+            testSubject.trackMetric('QueuedScanRequests', 1);
             testSubject.trackEvent('HealthCheck');
             testSubject.log('trace1', LogLevel.info);
             testSubject.trackException(new Error('exception'));
@@ -53,9 +53,9 @@ describe(ConsoleLoggerClient, () => {
         it('log data', async () => {
             await testSubject.setup(null);
 
-            testSubject.trackMetric('InProgressScanRequests', 1);
+            testSubject.trackMetric('QueuedScanRequests', 1);
 
-            consoleMock.verify(c => c.log('[Metric] === InProgressScanRequests - 1'), Times.once());
+            consoleMock.verify(c => c.log('[Metric] === QueuedScanRequests - 1'), Times.once());
         });
 
         it('log data with base properties with circular reference', async () => {
@@ -63,10 +63,10 @@ describe(ConsoleLoggerClient, () => {
             (baseProps as any).y = baseProps;
             await testSubject.setup(baseProps);
 
-            testSubject.trackMetric('InProgressScanRequests', 1);
+            testSubject.trackMetric('QueuedScanRequests', 1);
 
             consoleMock.verify(
-                c => c.log(`[Metric][properties - ${util.inspect({ ...baseProps })}] === InProgressScanRequests - 1`),
+                c => c.log(`[Metric][properties - ${util.inspect({ ...baseProps })}] === QueuedScanRequests - 1`),
                 Times.once(),
             );
         });
@@ -78,10 +78,10 @@ describe(ConsoleLoggerClient, () => {
             await testSubject.setup(baseProps);
             testSubject.setCustomProperties(customProps);
 
-            testSubject.trackMetric('InProgressScanRequests', 1);
+            testSubject.trackMetric('QueuedScanRequests', 1);
 
             consoleMock.verify(
-                c => c.log(`[Metric][properties - ${util.inspect({ ...mergedProps })}] === InProgressScanRequests - 1`),
+                c => c.log(`[Metric][properties - ${util.inspect({ ...mergedProps })}] === QueuedScanRequests - 1`),
                 Times.once(),
             );
         });
@@ -91,9 +91,9 @@ describe(ConsoleLoggerClient, () => {
             await testSubject.setup(baseProps);
             const metricProps = { metricProp1: 'prop value' };
 
-            testSubject.trackMetric('InProgressScanRequests', 1, metricProps);
+            testSubject.trackMetric('QueuedScanRequests', 1, metricProps);
             const properties = `[properties - ${util.inspect({ ...baseProps, ...metricProps })}]`;
-            const expectedLogMessage = `[Metric]${properties} === InProgressScanRequests - 1`;
+            const expectedLogMessage = `[Metric]${properties} === QueuedScanRequests - 1`;
 
             consoleMock.verify(c => c.log(expectedLogMessage), Times.once());
         });

--- a/packages/logger/src/console-logger-client.spec.ts
+++ b/packages/logger/src/console-logger-client.spec.ts
@@ -40,7 +40,7 @@ describe(ConsoleLoggerClient, () => {
             testSubject = new ConsoleLoggerClient(serviceConfigMock.object, consoleMock.object);
 
             await testSubject.setup();
-            testSubject.trackMetric('metric1', 1);
+            testSubject.trackMetric('InProgressScanRequests', 1);
             testSubject.trackEvent('HealthCheck');
             testSubject.log('trace1', LogLevel.info);
             testSubject.trackException(new Error('exception'));
@@ -53,9 +53,9 @@ describe(ConsoleLoggerClient, () => {
         it('log data', async () => {
             await testSubject.setup(null);
 
-            testSubject.trackMetric('metric1', 1);
+            testSubject.trackMetric('InProgressScanRequests', 1);
 
-            consoleMock.verify(c => c.log('[Metric] === metric1 - 1'), Times.once());
+            consoleMock.verify(c => c.log('[Metric] === InProgressScanRequests - 1'), Times.once());
         });
 
         it('log data with base properties with circular reference', async () => {
@@ -63,9 +63,12 @@ describe(ConsoleLoggerClient, () => {
             (baseProps as any).y = baseProps;
             await testSubject.setup(baseProps);
 
-            testSubject.trackMetric('metric1', 1);
+            testSubject.trackMetric('InProgressScanRequests', 1);
 
-            consoleMock.verify(c => c.log(`[Metric][properties - ${util.inspect({ ...baseProps })}] === metric1 - 1`), Times.once());
+            consoleMock.verify(
+                c => c.log(`[Metric][properties - ${util.inspect({ ...baseProps })}] === InProgressScanRequests - 1`),
+                Times.once(),
+            );
         });
 
         it('log data with custom runtime properties', async () => {
@@ -75,9 +78,12 @@ describe(ConsoleLoggerClient, () => {
             await testSubject.setup(baseProps);
             testSubject.setCustomProperties(customProps);
 
-            testSubject.trackMetric('metric1', 1);
+            testSubject.trackMetric('InProgressScanRequests', 1);
 
-            consoleMock.verify(c => c.log(`[Metric][properties - ${util.inspect({ ...mergedProps })}] === metric1 - 1`), Times.once());
+            consoleMock.verify(
+                c => c.log(`[Metric][properties - ${util.inspect({ ...mergedProps })}] === InProgressScanRequests - 1`),
+                Times.once(),
+            );
         });
     });
 

--- a/packages/logger/src/console-logger-client.spec.ts
+++ b/packages/logger/src/console-logger-client.spec.ts
@@ -85,6 +85,18 @@ describe(ConsoleLoggerClient, () => {
                 Times.once(),
             );
         });
+
+        it('log data with metric properties', async () => {
+            const baseProps: BaseTelemetryProperties = { foo: 'bar', source: 'test-source' };
+            await testSubject.setup(baseProps);
+            const metricProps = { metricProp1: 'prop value' };
+
+            testSubject.trackMetric('InProgressScanRequests', 1, metricProps);
+            const properties = `[properties - ${util.inspect({ ...baseProps, ...metricProps })}]`;
+            const expectedLogMessage = `[Metric]${properties} === InProgressScanRequests - 1`;
+
+            consoleMock.verify(c => c.log(expectedLogMessage), Times.once());
+        });
     });
 
     describe('trackEvent', () => {

--- a/packages/logger/src/console-logger-client.ts
+++ b/packages/logger/src/console-logger-client.ts
@@ -10,6 +10,7 @@ import { LogLevel } from './logger';
 import { LoggerClient } from './logger-client';
 import { LoggerEvent } from './logger-event';
 import { BaseTelemetryMeasurements, TelemetryMeasurements } from './logger-event-measurements';
+import { LoggerMetric } from './logger-metric';
 import { LoggerProperties } from './logger-properties';
 import { loggerTypes } from './logger-types';
 
@@ -29,7 +30,7 @@ export class ConsoleLoggerClient implements LoggerClient {
         this.isConsoleLogEnabled = (await this.serviceConfig.getConfigValue('logConfig')).logInConsole;
     }
 
-    public trackMetric(name: string, value: number): void {
+    public trackMetric(name: LoggerMetric, value: number): void {
         this.executeInDebugMode(() => {
             this.logInConsole(`[Metric]${this.getPrintablePropertiesString()}`, `${name} - ${value}`);
         });

--- a/packages/logger/src/console-logger-client.ts
+++ b/packages/logger/src/console-logger-client.ts
@@ -30,9 +30,9 @@ export class ConsoleLoggerClient implements LoggerClient {
         this.isConsoleLogEnabled = (await this.serviceConfig.getConfigValue('logConfig')).logInConsole;
     }
 
-    public trackMetric(name: LoggerMetric, value: number): void {
+    public trackMetric(name: LoggerMetric, value: number, properties?: { [name: string]: string }): void {
         this.executeInDebugMode(() => {
-            this.logInConsole(`[Metric]${this.getPrintablePropertiesString()}`, `${name} - ${value}`);
+            this.logInConsole(`[Metric]${this.getPrintablePropertiesString(properties)}`, `${name} - ${value}`);
         });
     }
 

--- a/packages/logger/src/logger-client.ts
+++ b/packages/logger/src/logger-client.ts
@@ -4,11 +4,12 @@ import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LogLevel } from './logger';
 import { LoggerEvent } from './logger-event';
 import { TelemetryMeasurements } from './logger-event-measurements';
+import { LoggerMetric } from './logger-metric';
 import { LoggerProperties } from './logger-properties';
 
 export interface LoggerClient {
     setup(baseProperties?: BaseTelemetryProperties): Promise<void>;
-    trackMetric(name: string, value: number): void;
+    trackMetric(name: LoggerMetric, value: number): void;
     trackEvent(name: LoggerEvent, properties?: { [key: string]: string }, measurements?: TelemetryMeasurements[LoggerEvent]): void;
     log(message: string, logLevel: LogLevel, properties?: { [name: string]: string }): void;
     trackException(error: Error): void;

--- a/packages/logger/src/logger-client.ts
+++ b/packages/logger/src/logger-client.ts
@@ -9,7 +9,7 @@ import { LoggerProperties } from './logger-properties';
 
 export interface LoggerClient {
     setup(baseProperties?: BaseTelemetryProperties): Promise<void>;
-    trackMetric(name: LoggerMetric, value: number): void;
+    trackMetric(name: LoggerMetric, value: number, properties?: { [name: string]: string }): void;
     trackEvent(name: LoggerEvent, properties?: { [key: string]: string }, measurements?: TelemetryMeasurements[LoggerEvent]): void;
     log(message: string, logLevel: LogLevel, properties?: { [name: string]: string }): void;
     trackException(error: Error): void;

--- a/packages/logger/src/logger-metric.ts
+++ b/packages/logger/src/logger-metric.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export declare type LoggerMetric = 'InProgressScanRequests';
+export declare type LoggerMetric = 'QueuedScanRequests' | 'ActiveScanRequests';

--- a/packages/logger/src/logger-metric.ts
+++ b/packages/logger/src/logger-metric.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export declare type LoggerMetric = 'InProgressScanRequests';

--- a/packages/logger/src/logger-properties.ts
+++ b/packages/logger/src/logger-properties.ts
@@ -4,4 +4,5 @@
 export interface LoggerProperties {
     scanId?: string;
     batchRequestId?: string;
+    priority?: string;
 }

--- a/packages/logger/src/logger.spec.ts
+++ b/packages/logger/src/logger.spec.ts
@@ -68,7 +68,7 @@ describe(Logger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 1)).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 1, undefined)).verifiable(Times.once()));
 
             testSubject.trackMetric('InProgressScanRequests');
 
@@ -79,9 +79,21 @@ describe(Logger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 10)).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 10, undefined)).verifiable(Times.once()));
 
             testSubject.trackMetric('InProgressScanRequests', 10);
+
+            verifyMocks();
+        });
+
+        it('when properties passed', async () => {
+            const properties = { foo: 'bar' };
+            setupCallsForTelemetrySetup();
+            await testSubject.setup();
+
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 1, properties)).verifiable(Times.once()));
+
+            testSubject.trackMetric('InProgressScanRequests', 1, properties);
 
             verifyMocks();
         });

--- a/packages/logger/src/logger.spec.ts
+++ b/packages/logger/src/logger.spec.ts
@@ -60,7 +60,7 @@ describe(Logger, () => {
     describe('trackMetric', () => {
         it('throw if called before setup', () => {
             expect(() => {
-                testSubject.trackMetric('metric1', 1);
+                testSubject.trackMetric('InProgressScanRequests', 1);
             }).toThrowError('Logger not setup');
         });
 
@@ -68,9 +68,9 @@ describe(Logger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('metric1', 1)).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 1)).verifiable(Times.once()));
 
-            testSubject.trackMetric('metric1');
+            testSubject.trackMetric('InProgressScanRequests');
 
             verifyMocks();
         });
@@ -79,9 +79,9 @@ describe(Logger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('metric1', 10)).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 10)).verifiable(Times.once()));
 
-            testSubject.trackMetric('metric1', 10);
+            testSubject.trackMetric('InProgressScanRequests', 10);
 
             verifyMocks();
         });

--- a/packages/logger/src/logger.spec.ts
+++ b/packages/logger/src/logger.spec.ts
@@ -60,7 +60,7 @@ describe(Logger, () => {
     describe('trackMetric', () => {
         it('throw if called before setup', () => {
             expect(() => {
-                testSubject.trackMetric('InProgressScanRequests', 1);
+                testSubject.trackMetric('QueuedScanRequests', 1);
             }).toThrowError('Logger not setup');
         });
 
@@ -68,9 +68,9 @@ describe(Logger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 1, undefined)).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('QueuedScanRequests', 1, undefined)).verifiable(Times.once()));
 
-            testSubject.trackMetric('InProgressScanRequests');
+            testSubject.trackMetric('QueuedScanRequests');
 
             verifyMocks();
         });
@@ -79,9 +79,9 @@ describe(Logger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 10, undefined)).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('QueuedScanRequests', 10, undefined)).verifiable(Times.once()));
 
-            testSubject.trackMetric('InProgressScanRequests', 10);
+            testSubject.trackMetric('QueuedScanRequests', 10);
 
             verifyMocks();
         });
@@ -91,9 +91,9 @@ describe(Logger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('InProgressScanRequests', 1, properties)).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m => m.setup(c => c.trackMetric('QueuedScanRequests', 1, properties)).verifiable(Times.once()));
 
-            testSubject.trackMetric('InProgressScanRequests', 1, properties);
+            testSubject.trackMetric('QueuedScanRequests', 1, properties);
 
             verifyMocks();
         });
@@ -119,7 +119,7 @@ describe(Logger, () => {
 
         it('when properties/measurements passed', async () => {
             const properties = { foo: 'bar' };
-            const measurements = { scanWaitTime: 1 };
+            const measurements = { scanWaitTime: 1, priority: 1 };
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -36,10 +36,10 @@ export class Logger {
         this.initialized = true;
     }
 
-    public trackMetric(name: LoggerMetric, value: number = 1): void {
+    public trackMetric(name: LoggerMetric, value: number = 1, properties?: { [name: string]: string }): void {
         this.ensureInitialized();
 
-        this.invokeLoggerClient(client => client.trackMetric(name, value));
+        this.invokeLoggerClient(client => client.trackMetric(name, value, properties));
     }
 
     public trackEvent(name: LoggerEvent, properties?: { [name: string]: string }, measurements?: TelemetryMeasurements[LoggerEvent]): void {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -7,6 +7,7 @@ import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LoggerClient } from './logger-client';
 import { LoggerEvent } from './logger-event';
 import { TelemetryMeasurements } from './logger-event-measurements';
+import { LoggerMetric } from './logger-metric';
 import { LoggerProperties } from './logger-properties';
 
 export enum LogLevel {
@@ -35,7 +36,7 @@ export class Logger {
         this.initialized = true;
     }
 
-    public trackMetric(name: string, value: number = 1): void {
+    public trackMetric(name: LoggerMetric, value: number = 1): void {
         this.ensureInitialized();
 
         this.invokeLoggerClient(client => client.trackMetric(name, value));

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -242,7 +242,7 @@ describe(Runner, () => {
         await runner.run();
     });
 
-    it('sends telemetry event on successful scan', async () => {
+    it('sends telemetry event/metric on successful scan', async () => {
         const queueTime: number = 20;
         const executionTime: number = 30;
         const timestamps = setupTimeMocks(queueTime, executionTime, passedAxeScanResults);
@@ -257,6 +257,7 @@ describe(Runner, () => {
         loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable(Times.never());
+        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1)).verifiable();
 
         setupWebDriverCalls();
         setupReadScanResultCall(onDemandPageScanResult);
@@ -279,7 +280,7 @@ describe(Runner, () => {
         loggerMock.verifyAll();
     });
 
-    it('sends telemetry event on scan error', async () => {
+    it('sends telemetry event/metric on scan error', async () => {
         const queueTime: number = 20;
         const executionTime: number = 30;
         const timestamps = setupTimeMocks(queueTime, executionTime, passedAxeScanResults);
@@ -294,6 +295,7 @@ describe(Runner, () => {
         loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable(Times.never());
+        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1)).verifiable();
 
         setupWebDriverCalls();
         setupReadScanResultCall(onDemandPageScanResult);

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -257,7 +257,7 @@ describe(Runner, () => {
         loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable(Times.never());
-        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1)).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1, { priority: '1' })).verifiable();
 
         setupWebDriverCalls();
         setupReadScanResultCall(onDemandPageScanResult);
@@ -295,7 +295,7 @@ describe(Runner, () => {
         loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable(Times.never());
-        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1)).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1, { priority: '1' })).verifiable();
 
         setupWebDriverCalls();
         setupReadScanResultCall(onDemandPageScanResult);

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -257,7 +257,9 @@ describe(Runner, () => {
         loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable(Times.never());
-        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1, { priority: '1' })).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('QueuedScanRequests', -1)).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('ActiveScanRequests', 1)).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('ActiveScanRequests', -1)).verifiable();
 
         setupWebDriverCalls();
         setupReadScanResultCall(onDemandPageScanResult);
@@ -295,7 +297,9 @@ describe(Runner, () => {
         loggerMock.setup(lm => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskFailed')).verifiable();
         loggerMock.setup(lm => lm.trackEvent('ScanTaskSucceeded')).verifiable(Times.never());
-        loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', -1, { priority: '1' })).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('QueuedScanRequests', -1)).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('ActiveScanRequests', 1)).verifiable();
+        loggerMock.setup(lm => lm.trackMetric('ActiveScanRequests', -1)).verifiable();
 
         setupWebDriverCalls();
         setupReadScanResultCall(onDemandPageScanResult);

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -67,6 +67,7 @@ export class Runner {
                 scanWallClockTime: scanCompletedTimestamp - scanSubmittedTimestamp,
             };
             this.logger.trackEvent('ScanTaskCompleted', undefined, telemetryMeasurements);
+            this.logger.trackMetric('InProgressScanRequests', -1);
             try {
                 await this.webDriverTask.close();
             } catch (error) {

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -67,7 +67,7 @@ export class Runner {
                 scanWallClockTime: scanCompletedTimestamp - scanSubmittedTimestamp,
             };
             this.logger.trackEvent('ScanTaskCompleted', undefined, telemetryMeasurements);
-            this.logger.trackMetric('InProgressScanRequests', -1);
+            this.logger.trackMetric('InProgressScanRequests', -1, { priority: scanMetadata.priority.toString() });
             try {
                 await this.webDriverTask.close();
             } catch (error) {

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -158,7 +158,7 @@ describe(ScanRequestController, () => {
 
             // tslint:disable-next-line: no-null-keyword
             loggerMock.setup(lm => lm.trackEvent('BatchScanRequestSubmitted', null, expectedMeasurements)).verifiable();
-            loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', 1, { priority: '1' })).verifiable();
+            loggerMock.setup(lm => lm.trackMetric('QueuedScanRequests', 1, { priority: '1' })).verifiable();
 
             scanRequestController = createScanRequestController(context);
             await scanRequestController.handleRequest();

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -138,7 +138,7 @@ describe(ScanRequestController, () => {
             guidGeneratorMock.verifyAll();
         });
 
-        it('sends telemetry event', async () => {
+        it('sends telemetry event/metric', async () => {
             const guid1 = '1e9cefa6-538a-6df0-aaaa-ffffffffffff';
             const guid2 = '1e9cefa6-538a-6df0-bbbb-ffffffffffff';
             guidGeneratorMock.setup(g => g.createGuid()).returns(() => guid1);
@@ -158,6 +158,7 @@ describe(ScanRequestController, () => {
 
             // tslint:disable-next-line: no-null-keyword
             loggerMock.setup(lm => lm.trackEvent('BatchScanRequestSubmitted', null, expectedMeasurements)).verifiable();
+            loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', 1)).verifiable();
 
             scanRequestController = createScanRequestController(context);
             await scanRequestController.handleRequest();

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -158,7 +158,7 @@ describe(ScanRequestController, () => {
 
             // tslint:disable-next-line: no-null-keyword
             loggerMock.setup(lm => lm.trackEvent('BatchScanRequestSubmitted', null, expectedMeasurements)).verifiable();
-            loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', 1)).verifiable();
+            loggerMock.setup(lm => lm.trackMetric('InProgressScanRequests', 1, { priority: '1' })).verifiable();
 
             scanRequestController = createScanRequestController(context);
             await scanRequestController.handleRequest();

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -25,6 +25,7 @@ interface RunRequestValidationResult {
 
 @injectable()
 export class ScanRequestController extends ApiController {
+    private static readonly defaultPriority = 0;
     public readonly apiVersion = '1.0';
     public readonly apiName = 'web-api-post-scans';
     private config: RestApiConfig;
@@ -90,7 +91,7 @@ export class ScanRequestController extends ApiController {
             if (runRequestValidationResult.valid) {
                 // preserve GUID origin for a single batch scope
                 const scanId = this.guidGenerator.createGuidFromBaseGuid(batchId);
-                const priority = isNil(scanRunRequest.priority) ? 0 : scanRunRequest.priority;
+                const priority = isNil(scanRunRequest.priority) ? ScanRequestController.defaultPriority : scanRunRequest.priority;
                 scanRequestsToBeStoredInDb.push({
                     scanId: scanId,
                     priority: priority,
@@ -103,9 +104,10 @@ export class ScanRequestController extends ApiController {
                 });
 
                 if (requestCountByPriority[priority.toString()] === undefined) {
-                    requestCountByPriority[priority.toString()] = 0;
+                    requestCountByPriority[priority.toString()] = 1;
+                } else {
+                    requestCountByPriority[priority.toString()] += 1;
                 }
-                requestCountByPriority[priority.toString()] += 1;
             } else {
                 scanResponses.push({
                     url: scanRunRequest.url,

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -76,7 +76,7 @@ export class ScanRequestController extends ApiController {
         this.logger.trackEvent('BatchScanRequestSubmitted', null, measurements);
         let priority: string;
         for (priority of Object.keys(processedData.requestCountByPriority)) {
-            this.logger.trackMetric('InProgressScanRequests', processedData.requestCountByPriority[priority], { priority: priority });
+            this.logger.trackMetric('QueuedScanRequests', processedData.requestCountByPriority[priority], { priority: priority });
         }
     }
 

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -73,6 +73,7 @@ export class ScanRequestController extends ApiController {
 
         // tslint:disable-next-line: no-null-keyword
         this.logger.trackEvent('BatchScanRequestSubmitted', null, measurements);
+        this.logger.trackMetric('InProgressScanRequests', totalUrls - invalidUrls);
     }
 
     private getProcessedRequestData(batchId: string, scanRunRequests: ScanRunRequest[]): ProcessedBatchRequestData {


### PR DESCRIPTION
Add InProgressScanRequests metric to track request throughput. Graphing the sum of this metric will give the total number of scan requests being processed (both in the queue and running scans) at a given time:

<img width="1642" alt="Throughput chart" src="https://user-images.githubusercontent.com/55459788/67607632-0bd23480-f73a-11e9-9a7f-0d4c96b97be5.PNG">

