### PR TITLE
Storing parsed scan error object in storage document

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -2,6 +2,23 @@
 
 exports[`ServiceConfiguration verifies custom config 1`] = `
 Object {
+  "availabilityTestConfig": Object {
+    "maxScanWaitTimeInSeconds": Object {
+      "default": 600,
+      "doc": "Maximum wait time for fetching scan status of the submitted request",
+      "format": "int",
+    },
+    "scanWaitIntervalInSeconds": Object {
+      "default": 60,
+      "doc": "Time to wait before checking the url scan status again",
+      "format": "int",
+    },
+    "urlToScan": Object {
+      "default": "https://www.bing.com",
+      "doc": "Url to scan for availability testing",
+      "format": "url",
+    },
+  },
   "jobManagerConfig": Object {
     "activeToRunningTasksRatio": Object {
       "default": 3,
@@ -47,11 +64,6 @@ Object {
     "maxScanRequestBatchCount": Object {
       "default": 250,
       "doc": "Maximum number of scan requests in a single HTTP client request.",
-      "format": "int",
-    },
-    "maxScanRequestWaitTimeInSeconds": Object {
-      "default": 600,
-      "doc": "Maximum wait time for fetching scan status of the submitted request",
       "format": "int",
     },
     "minScanPriorityValue": Object {
@@ -141,6 +153,23 @@ Object {
 
 exports[`ServiceConfiguration verifies dev config 1`] = `
 Object {
+  "availabilityTestConfig": Object {
+    "maxScanWaitTimeInSeconds": Object {
+      "default": 600,
+      "doc": "Maximum wait time for fetching scan status of the submitted request",
+      "format": "int",
+    },
+    "scanWaitIntervalInSeconds": Object {
+      "default": 60,
+      "doc": "Time to wait before checking the url scan status again",
+      "format": "int",
+    },
+    "urlToScan": Object {
+      "default": "https://www.bing.com",
+      "doc": "Url to scan for availability testing",
+      "format": "url",
+    },
+  },
   "jobManagerConfig": Object {
     "activeToRunningTasksRatio": Object {
       "default": 3,
@@ -186,11 +215,6 @@ Object {
     "maxScanRequestBatchCount": Object {
       "default": 250,
       "doc": "Maximum number of scan requests in a single HTTP client request.",
-      "format": "int",
-    },
-    "maxScanRequestWaitTimeInSeconds": Object {
-      "default": 600,
-      "doc": "Maximum wait time for fetching scan status of the submitted request",
       "format": "int",
     },
     "minScanPriorityValue": Object {

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -35,7 +35,6 @@ export interface ScanRunTimeConfig {
 export interface RestApiConfig {
     maxScanRequestBatchCount: number;
     scanRequestProcessingDelayInSeconds: number;
-    maxScanRequestWaitTimeInSeconds: number;
     minScanPriorityValue: number;
     maxScanPriorityValue: number;
 }
@@ -47,6 +46,13 @@ export interface RuntimeConfig {
     scanConfig: ScanRunTimeConfig;
     jobManagerConfig: JobManagerConfig;
     restApiConfig: RestApiConfig;
+    availabilityTestConfig: AvailabilityTestConfig;
+}
+
+export interface AvailabilityTestConfig {
+    urlToScan: string;
+    scanWaitIntervalInSeconds: number;
+    maxScanWaitTimeInSeconds: number;
 }
 
 @injectable()
@@ -211,11 +217,6 @@ export class ServiceConfiguration {
                     default: 15,
                     doc: 'The scan request processing delay interval in seconds for a new submitted request.',
                 },
-                maxScanRequestWaitTimeInSeconds: {
-                    format: 'int',
-                    default: 600,
-                    doc: 'Maximum wait time for fetching scan status of the submitted request',
-                },
                 minScanPriorityValue: {
                     format: 'int',
                     default: -1000,
@@ -229,6 +230,23 @@ export class ServiceConfiguration {
                     doc:
                         'Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.\
                         This range correlates with Azure Batch pool task priority range.',
+                },
+            },
+            availabilityTestConfig: {
+                urlToScan: {
+                    format: 'url',
+                    default: 'https://www.bing.com',
+                    doc: 'Url to scan for availability testing',
+                },
+                maxScanWaitTimeInSeconds: {
+                    format: 'int',
+                    default: 600,
+                    doc: 'Maximum wait time for fetching scan status of the submitted request',
+                },
+                scanWaitIntervalInSeconds: {
+                    format: 'int',
+                    default: 60,
+                    doc: 'Time to wait before checking the url scan status again',
                 },
             },
         };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,5 +13,7 @@ export {
     ServiceConfiguration,
     JobManagerConfig,
     RestApiConfig,
+    AvailabilityTestConfig,
+    LogRuntimeConfig,
 } from './configuration/service-configuration';
 export { setupRuntimeConfigContainer } from './setup-runtime-config-container';

--- a/packages/scanner/src/axe-scan-results.ts
+++ b/packages/scanner/src/axe-scan-results.ts
@@ -2,9 +2,25 @@
 // Licensed under the MIT License.
 import { AxeResults } from 'axe-core';
 
+export type ScanErrorTypes =
+    | 'UrlNavigationTimeout'
+    | 'SslError'
+    | 'ResourceLoadFailure'
+    | 'InvalidUrl'
+    | 'EmptyPage'
+    | 'HttpErrorCode'
+    | 'NavigationError'
+    | 'InvalidContentType';
+
+export interface ScanError {
+    errorType: ScanErrorTypes;
+    responseStatusCode?: number;
+    message: string;
+}
+
 export interface AxeScanResults {
     results?: AxeResults;
-    error?: string;
+    error?: string | ScanError;
     unscannable?: boolean;
     scannedUrl?: string;
 }

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -2,4 +2,4 @@
 // Licensed under the MIT License.
 export { registerScannerToContainer } from './register-scanner-to-container';
 export { Scanner } from './scanner';
-export { AxeScanResults } from './axe-scan-results';
+export { AxeScanResults, ScanError, ScanErrorTypes } from './axe-scan-results';

--- a/packages/scanner/src/page.ts
+++ b/packages/scanner/src/page.ts
@@ -139,17 +139,13 @@ export class Page {
 
         if (/TimeoutError: Navigation Timeout Exceeded:/i.test(errorMessage)) {
             scanError.errorType = 'UrlNavigationTimeout';
-        }
-        if (errorMessage.includes('net::ERR_CERT_AUTHORITY_INVALID') || errorMessage.includes('SSL_ERROR_UNKNOWN')) {
+        } else if (errorMessage.includes('net::ERR_CERT_AUTHORITY_INVALID') || errorMessage.includes('SSL_ERROR_UNKNOWN')) {
             scanError.errorType = 'SslError';
-        }
-        if (errorMessage.includes('net::ERR_CONNECTION_REFUSED') || errorMessage.includes('NS_ERROR_CONNECTION_REFUSED')) {
+        } else if (errorMessage.includes('net::ERR_CONNECTION_REFUSED') || errorMessage.includes('NS_ERROR_CONNECTION_REFUSED')) {
             scanError.errorType = 'ResourceLoadFailure';
-        }
-        if (errorMessage.includes('Cannot navigate to invalid URL') || errorMessage.includes('Invalid url')) {
+        } else if (errorMessage.includes('Cannot navigate to invalid URL') || errorMessage.includes('Invalid url')) {
             scanError.errorType = 'InvalidUrl';
-        }
-        if (errorMessage.includes('net::ERR_ABORTED') || errorMessage.includes('NS_BINDING_ABORTED')) {
+        } else if (errorMessage.includes('net::ERR_ABORTED') || errorMessage.includes('NS_BINDING_ABORTED')) {
             scanError.errorType = 'EmptyPage';
         }
 

--- a/packages/service-library/src/web-api/api-controller.spec.ts
+++ b/packages/service-library/src/web-api/api-controller.spec.ts
@@ -336,7 +336,6 @@ describe(ApiController, () => {
                 scanRequestProcessingDelayInSeconds: 2,
                 minScanPriorityValue: -1,
                 maxScanPriorityValue: 1,
-                maxScanRequestWaitTimeInSeconds: 3,
             };
 
             const serviceConfigMock = Mock.ofType(ServiceConfiguration);

--- a/packages/service-library/src/web-api/scan-run-error-codes.ts
+++ b/packages/service-library/src/web-api/scan-run-error-codes.ts
@@ -11,7 +11,8 @@ export declare type ScanRunErrorCodeName =
     | 'ResourceLoadFailure'
     | 'InvalidUrl'
     | 'EmptyPage'
-    | 'NavigationError';
+    | 'NavigationError'
+    | 'InvalidContentType';
 
 export interface ScanRunErrorCode {
     // This type is part of the REST API client response.
@@ -38,7 +39,7 @@ export class ScanRunErrorCodes {
     public static httpErrorCode: ScanRunErrorCode = {
         code: 'HttpErrorCode',
         codeId: 9003,
-        message: 'Accessing the scan URL resulted in an error.',
+        message: 'Page returned an unsuccessful response code',
     };
 
     public static sslError: ScanRunErrorCode = {
@@ -70,4 +71,22 @@ export class ScanRunErrorCodes {
         codeId: 9008,
         message: 'Unknown error navigating to scan URL',
     };
+
+    public static invalidContentType: ScanRunErrorCode = {
+        code: 'InvalidContentType',
+        codeId: 9009,
+        message: 'Only html content type pages are supported for scanning',
+    };
 }
+
+export const scanErrorNameToErrorMap: { [key in ScanRunErrorCodeName]: ScanRunErrorCode } = {
+    InternalError: ScanRunErrorCodes.internalError,
+    UrlNavigationTimeout: ScanRunErrorCodes.urlNavigationTimeout,
+    SslError: ScanRunErrorCodes.sslError,
+    HttpErrorCode: ScanRunErrorCodes.httpErrorCode,
+    ResourceLoadFailure: ScanRunErrorCodes.resourceLoadFailure,
+    InvalidUrl: ScanRunErrorCodes.invalidUrl,
+    EmptyPage: ScanRunErrorCodes.emptyPage,
+    NavigationError: ScanRunErrorCodes.navigationError,
+    InvalidContentType: ScanRunErrorCodes.invalidContentType,
+};

--- a/packages/storage-documents/src/issue-scan-result.ts
+++ b/packages/storage-documents/src/issue-scan-result.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { ResultLevel } from './states';
 import { StorageDocument } from './storage-document';
+import { ScanError } from './on-demand-page-scan-result';
 
 export interface PhysicalLocation {
     fileLocation: {
@@ -42,6 +43,6 @@ export interface IssueScanResult extends StorageDocument {
 
 export interface IssueScanResults {
     results?: IssueScanResult[];
-    error?: string;
+    error?: string | ScanError;
     unscannable?: boolean;
 }

--- a/packages/storage-documents/src/issue-scan-result.ts
+++ b/packages/storage-documents/src/issue-scan-result.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanError } from './on-demand-page-scan-result';
 import { ResultLevel } from './states';
 import { StorageDocument } from './storage-document';
-import { ScanError } from './on-demand-page-scan-result';
 
 export interface PhysicalLocation {
     fileLocation: {

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -7,6 +7,22 @@ export declare type ReportFormat = 'sarif';
 export declare type ScanState = 'pending' | 'pass' | 'fail';
 export declare type OnDemandPageScanRunState = 'pending' | 'accepted' | 'queued' | 'running' | 'completed' | 'failed';
 
+export type ScanErrorTypes =
+    | 'UrlNavigationTimeout'
+    | 'SslError'
+    | 'ResourceLoadFailure'
+    | 'InvalidUrl'
+    | 'EmptyPage'
+    | 'HttpErrorCode'
+    | 'NavigationError'
+    | 'InvalidContentType';
+
+export interface ScanError {
+    errorType: ScanErrorTypes;
+    responseStatusCode?: number;
+    message: string;
+}
+
 /**
  * The web page scan run result document.
  */
@@ -35,5 +51,5 @@ export interface OnDemandPageScanReport {
 export interface OnDemandPageScanRunResult {
     state: OnDemandPageScanRunState;
     timestamp?: string;
-    error?: string;
+    error?: string | ScanError;
 }

--- a/packages/storage-documents/src/run-result.ts
+++ b/packages/storage-documents/src/run-result.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanError } from './on-demand-page-scan-result';
 import { RunState } from './states';
 
 export interface RunResult {
     runTime: string;
     state: RunState;
-    error?: string;
+    error?: string | ScanError;
     retries?: number;
     unscannable?: boolean;
 }

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -14,6 +14,7 @@ import {
     OnDemandPageScanRunResult,
     OnDemandPageScanRunState,
     OnDemandScanResult,
+    ScanError,
 } from 'storage-documents';
 import { ScanMetadataConfig } from '../scan-metadata-config';
 import { ScannerTask } from '../tasks/scanner-task';
@@ -111,7 +112,7 @@ export class Runner {
         return originPageScanResult;
     }
 
-    private createRunResult(state: OnDemandPageScanRunState, error?: string): OnDemandPageScanRunResult {
+    private createRunResult(state: OnDemandPageScanRunState, error?: string | ScanError): OnDemandPageScanRunResult {
         return {
             state,
             timestamp: new Date().toJSON(),

--- a/packages/web-api/src/converters/scan-run-error-converter.spec.ts
+++ b/packages/web-api/src/converters/scan-run-error-converter.spec.ts
@@ -5,72 +5,80 @@ import 'reflect-metadata';
 import { ScanRunErrorCodes } from 'service-library';
 import { ScanRunErrorConverter } from './scan-run-error-converter';
 
-// tslint:disable: no-unsafe-any no-any
-
-let scanRunErrorConverter: ScanRunErrorConverter;
+// tslint:disable: no-unsafe-any no-any no-null-keyword
 
 describe(ScanRunErrorConverter, () => {
-    it('convert to default internal error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        let errorCode = scanRunErrorConverter.getScanRunErrorCode(undefined);
+    let testSubject: ScanRunErrorConverter;
+    beforeEach(() => {
+        testSubject = new ScanRunErrorConverter();
+    });
+
+    it('should return internal error for null or undefined', () => {
+        let errorCode = testSubject.getScanRunErrorCode(null);
         expect(errorCode).toEqual(ScanRunErrorCodes.internalError);
 
-        errorCode = scanRunErrorConverter.getScanRunErrorCode('unknown error');
+        errorCode = testSubject.getScanRunErrorCode(undefined);
         expect(errorCode).toEqual(ScanRunErrorCodes.internalError);
     });
 
-    it('convert to url navigation timeout error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        const errorCode = scanRunErrorConverter.getScanRunErrorCode(
-            '{ TimeoutError: Navigation Timeout Exceeded: 30000ms exceeded\n    at Promise.then (',
-        );
-        expect(errorCode).toEqual(ScanRunErrorCodes.urlNavigationTimeout);
+    it('should resolve scanError to scanErrorCode', () => {
+        const errorCode = testSubject.getScanRunErrorCode({
+            errorType: 'InvalidContentType',
+            message: 'some message',
+            responseStatusCode: 200,
+        });
+
+        expect(errorCode).toEqual(ScanRunErrorCodes.invalidContentType);
     });
 
-    it('convert to ssl error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        const errorCode = scanRunErrorConverter.getScanRunErrorCode(
-            'Puppeteer navigation to http://www.bing.com failed: net::ERR_CERT_AUTHORITY_INVALID',
-        );
-        expect(errorCode).toEqual(ScanRunErrorCodes.sslError);
-    });
+    describe('resolve legacy error', () => {
+        it('convert to default internal error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode('unknown error');
+            expect(errorCode).toEqual(ScanRunErrorCodes.internalError);
+        });
 
-    it('convert to main resource load failure error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        const errorCode = scanRunErrorConverter.getScanRunErrorCode(
-            'Puppeteer navigation to http://www.bing.com failed: net::ERR_CONNECTION_REFUSED',
-        );
-        expect(errorCode).toEqual(ScanRunErrorCodes.resourceLoadFailure);
-    });
+        it('convert to url navigation timeout error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode(
+                '{ TimeoutError: Navigation Timeout Exceeded: 30000ms exceeded\n    at Promise.then (',
+            );
+            expect(errorCode).toEqual(ScanRunErrorCodes.urlNavigationTimeout);
+        });
 
-    it('convert to invalid url error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        const errorCode = scanRunErrorConverter.getScanRunErrorCode(
-            'Puppeteer navigation to http://www.bing.com failed: Cannot navigate to invalid URL',
-        );
-        expect(errorCode).toEqual(ScanRunErrorCodes.invalidUrl);
-    });
+        it('convert to ssl error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode(
+                'Puppeteer navigation to http://www.bing.com failed: net::ERR_CERT_AUTHORITY_INVALID',
+            );
+            expect(errorCode).toEqual(ScanRunErrorCodes.sslError);
+        });
 
-    it('convert to empty page error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        const errorCode = scanRunErrorConverter.getScanRunErrorCode('Puppeteer navigation to http://www.bing.com failed: net::ERR_ABORTED');
-        expect(errorCode).toEqual(ScanRunErrorCodes.emptyPage);
-    });
+        it('convert to main resource load failure error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode(
+                'Puppeteer navigation to http://www.bing.com failed: net::ERR_CONNECTION_REFUSED',
+            );
+            expect(errorCode).toEqual(ScanRunErrorCodes.resourceLoadFailure);
+        });
 
-    it('convert to navigation error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        const errorCode = scanRunErrorConverter.getScanRunErrorCode(
-            'Puppeteer navigation to http://www.bing.com failed: unknown error message',
-        );
-        expect(errorCode).toEqual(ScanRunErrorCodes.navigationError);
-    });
+        it('convert to invalid url error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode(
+                'Puppeteer navigation to http://www.bing.com failed: Cannot navigate to invalid URL',
+            );
+            expect(errorCode).toEqual(ScanRunErrorCodes.invalidUrl);
+        });
 
-    it('convert to http error code', () => {
-        scanRunErrorConverter = new ScanRunErrorConverter();
-        const errorCode = scanRunErrorConverter.getScanRunErrorCode(
-            'The URL http://bing.com returned unsuccessful response: 404 page not found',
-        );
-        expect(errorCode.codeId).toEqual(ScanRunErrorCodes.httpErrorCode.codeId);
-        expect(errorCode.message).toEqual(`${ScanRunErrorCodes.httpErrorCode.message}: 404 page not found`);
+        it('convert to empty page error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode('Puppeteer navigation to http://www.bing.com failed: net::ERR_ABORTED');
+            expect(errorCode).toEqual(ScanRunErrorCodes.emptyPage);
+        });
+
+        it('convert to navigation error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode('Puppeteer navigation to http://www.bing.com failed: unknown error message');
+            expect(errorCode).toEqual(ScanRunErrorCodes.navigationError);
+        });
+
+        it('convert to http error code', () => {
+            const errorCode = testSubject.getScanRunErrorCode('The URL http://bing.com returned unsuccessful response: 404 page not found');
+            expect(errorCode.codeId).toEqual(ScanRunErrorCodes.httpErrorCode.codeId);
+            expect(errorCode.message).toEqual(`${ScanRunErrorCodes.httpErrorCode.message}: 404 page not found`);
+        });
     });
 });

--- a/packages/web-workers/src/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration-steps.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 // tslint:disable-next-line:no-submodule-imports
 import { DurableOrchestrationContext, IOrchestrationFunctionContext } from 'durable-functions/lib/src/classes';
 
-import { RestApiConfig } from 'common';
+import { AvailabilityTestConfig, RestApiConfig } from 'common';
 import { isNil } from 'lodash';
 import { ContextAwareLogger } from 'logger';
 import * as moment from 'moment';
@@ -35,12 +35,10 @@ describe(OrchestrationStepsImpl, () => {
     let context: IOrchestrationFunctionContext;
     let orchestrationContext: IMock<DurableOrchestrationContext>;
     let testSubject: OrchestrationStepsImpl;
-    const restApiConfig: RestApiConfig = {
-        maxScanRequestBatchCount: 10,
-        scanRequestProcessingDelayInSeconds: 20,
-        maxScanRequestWaitTimeInSeconds: 30,
-        minScanPriorityValue: 40,
-        maxScanPriorityValue: 50,
+    const availabilityTestConfig: AvailabilityTestConfig = {
+        scanWaitIntervalInSeconds: 10,
+        maxScanWaitTimeInSeconds: 20,
+        urlToScan: 'https://www.bing.com',
     };
     let contextAwareLoggerMock: IMock<ContextAwareLogger>;
     const scanUrl = 'https://www.bing.com';
@@ -68,7 +66,7 @@ describe(OrchestrationStepsImpl, () => {
             df: orchestrationContext.object,
         });
 
-        testSubject = new OrchestrationStepsImpl(context, restApiConfig, contextAwareLoggerMock.object);
+        testSubject = new OrchestrationStepsImpl(context, availabilityTestConfig, contextAwareLoggerMock.object);
     });
 
     afterEach(() => {
@@ -325,11 +323,11 @@ describe(OrchestrationStepsImpl, () => {
         beforeEach(() => {
             generatorExecutor = new GeneratorExecutor<string>(testSubject.waitForScanCompletion(scanId));
 
-            restApiConfig.scanRequestProcessingDelayInSeconds = 10;
-            restApiConfig.maxScanRequestWaitTimeInSeconds = 10 * 2 + 1;
-            nextTime1 = moment.utc(currentUtcDateTime).add(restApiConfig.scanRequestProcessingDelayInSeconds, 'seconds');
-            nextTime2 = nextTime1.clone().add(restApiConfig.scanRequestProcessingDelayInSeconds, 'seconds');
-            nextTime3 = nextTime2.clone().add(restApiConfig.scanRequestProcessingDelayInSeconds, 'seconds');
+            availabilityTestConfig.scanWaitIntervalInSeconds = 10;
+            availabilityTestConfig.maxScanWaitTimeInSeconds = 10 * 2 + 1;
+            nextTime1 = moment.utc(currentUtcDateTime).add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
+            nextTime2 = nextTime1.clone().add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
+            nextTime3 = nextTime2.clone().add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
 
             activityRequestData = {
                 activityName: ActivityAction.getScanResult,


### PR DESCRIPTION
#### Description of changes

- Fixed a bug in sending the navigation failure response code. (#415)
- Storing parsed error object instead of storing error string. I am also handling back compatibility.
- added availability test config - Using scan interval time of 1 min & configurable scan url.

(Triggered deployment on my private resource group for validation)