### PR TITLE
using context aware logger in cosmos clients

### DIFF
--- a/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.spec.ts
+++ b/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.spec.ts
@@ -31,7 +31,7 @@ describe('CosmosClientWrapper', () => {
         setupVerifiableGetDbCall();
         setupVerifiableGetCollectionCall();
         loggerMock = Mock.ofType(Logger);
-        testSubject = new CosmosClientWrapper(cosmosClientProviderStub, loggerMock.object);
+        testSubject = new CosmosClientWrapper(cosmosClientProviderStub);
     });
 
     describe('readItem()', () => {
@@ -47,7 +47,7 @@ describe('CosmosClientWrapper', () => {
             collectionMock.setup(c => c.item('id')).returns(() => itemMock.object);
             itemMock.setup(async i => i.read({ partitionKey: partitionKey })).returns(async () => Promise.reject(responseError));
 
-            const result = await testSubject.readItem('id', dbName, collectionName, partitionKey);
+            const result = await testSubject.readItem('id', dbName, collectionName, loggerMock.object, partitionKey);
 
             expect(result).toEqual(expectedResult);
             itemMock.verifyAll();
@@ -70,7 +70,7 @@ describe('CosmosClientWrapper', () => {
                 .setup(async i => i.read({ partitionKey: partitionKey }))
                 .returns(async () => Promise.resolve({ body: responseItem as any, item: undefined }));
 
-            const result = await testSubject.readItem(responseItem.id, dbName, collectionName, partitionKey);
+            const result = await testSubject.readItem(responseItem.id, dbName, collectionName, loggerMock.object, partitionKey);
 
             expect(result).toEqual(expectedResult);
             itemMock.verifyAll();
@@ -93,7 +93,7 @@ describe('CosmosClientWrapper', () => {
                 .setup(async i => i.read(undefined))
                 .returns(async () => Promise.resolve({ body: responseItem as any, item: undefined }));
 
-            const result = await testSubject.readItem(responseItem.id, dbName, collectionName);
+            const result = await testSubject.readItem(responseItem.id, dbName, collectionName, loggerMock.object);
 
             expect(result).toEqual(expectedResult);
             itemMock.verifyAll();
@@ -130,7 +130,7 @@ describe('CosmosClientWrapper', () => {
                 .setup(async qi => qi.executeNext())
                 .returns(async () => Promise.resolve({ result: items, statusCode: 200, headers: { 'x-ms-continuation': 'abdf12345fd' } }));
 
-            const result = await testSubject.readItems(dbName, collectionName, query);
+            const result = await testSubject.readItems(dbName, collectionName, query, loggerMock.object);
 
             expect(result).toEqual(expectedResult);
             itemMock.verifyAll();
@@ -171,7 +171,7 @@ describe('CosmosClientWrapper', () => {
                     return Promise.resolve({ result: <any[]>[], statusCode: 200, headers: { 'x-ms-continuation': 'abdf12345fd' } });
                 });
 
-            const result = await testSubject.readItems(dbName, collectionName, query);
+            const result = await testSubject.readItems(dbName, collectionName, query, loggerMock.object);
 
             expect(result).toEqual(expectedResult);
             itemMock.verifyAll();
@@ -187,7 +187,7 @@ describe('CosmosClientWrapper', () => {
                 .returns(async () => Promise.resolve({} as any))
                 .verifiable();
 
-            await testSubject.deleteItem('id', dbName, collectionName, partitionKey);
+            await testSubject.deleteItem('id', dbName, collectionName, partitionKey, loggerMock.object);
 
             itemMock.verifyAll();
             verifyMocks();
@@ -211,7 +211,7 @@ describe('CosmosClientWrapper', () => {
 
             itemsMock.setup(async i => i.upsert<DbItemMock>(item, undefined)).returns(async () => Promise.reject(responseError));
 
-            const result = await testSubject.upsertItem<DbItemMock>(item, dbName, collectionName);
+            const result = await testSubject.upsertItem<DbItemMock>(item, dbName, collectionName, loggerMock.object);
 
             expect(result).toEqual(expectedResult);
             verifyMocks();
@@ -241,7 +241,7 @@ describe('CosmosClientWrapper', () => {
                 .setup(async i => i.upsert<DbItemMock>(item, options))
                 .returns(async () => Promise.resolve({ body: responseItem as any, item: undefined }));
 
-            const result = await testSubject.upsertItem<DbItemMock>(item, dbName, collectionName);
+            const result = await testSubject.upsertItem<DbItemMock>(item, dbName, collectionName, loggerMock.object);
 
             expect(result).toEqual(expectedResult);
             verifyMocks();
@@ -266,7 +266,7 @@ describe('CosmosClientWrapper', () => {
                 .setup(async i => i.upsert<DbItemMock>(item, undefined))
                 .returns(async () => Promise.resolve({ body: responseItem as any, item: undefined }));
 
-            const result = await testSubject.upsertItem<DbItemMock>(item, dbName, collectionName);
+            const result = await testSubject.upsertItem<DbItemMock>(item, dbName, collectionName, loggerMock.object);
 
             expect(result).toEqual(expectedResult);
             verifyMocks();
@@ -300,7 +300,7 @@ describe('CosmosClientWrapper', () => {
                 setupVerifiableUpsertItemCallWithOptions(item, options);
             });
 
-            await testSubject.upsertItems(items, dbName, collectionName, partitionKey);
+            await testSubject.upsertItems(items, dbName, collectionName, loggerMock.object, partitionKey);
 
             verifyMocks();
         });
@@ -328,7 +328,7 @@ describe('CosmosClientWrapper', () => {
                 setupVerifiableUpsertItemCallWithOptions(item, options);
             });
 
-            await testSubject.upsertItems(items, dbName, collectionName, partitionKey);
+            await testSubject.upsertItems(items, dbName, collectionName, loggerMock.object, partitionKey);
 
             verifyMocks();
         });
@@ -356,7 +356,7 @@ describe('CosmosClientWrapper', () => {
                 setupVerifiableUpsertItemCallWithOptions(item, options);
             });
 
-            await testSubject.upsertItems(items, dbName, collectionName, partitionKey);
+            await testSubject.upsertItems(items, dbName, collectionName, loggerMock.object, partitionKey);
 
             verifyMocks();
         });
@@ -377,7 +377,7 @@ describe('CosmosClientWrapper', () => {
 
             loggerMock.setup(o => o.logError(`[storage-client] The Cosmos DB 'upsertItem' operation failed.`, It.isAny())).verifiable();
 
-            await expect(testSubject.upsertItems(items, dbName, collectionName)).rejects.toEqual(errorResponse);
+            await expect(testSubject.upsertItems(items, dbName, collectionName, loggerMock.object)).rejects.toEqual(errorResponse);
 
             verifyMocks();
         });

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -107,7 +107,7 @@ function setupBlobServiceClientProvider(container: interfaces.Container): void {
 }
 
 function createCosmosContainerClient(container: interfaces.Container, dbName: string, collectionName: string): CosmosContainerClient {
-    return new CosmosContainerClient(container.get(CosmosClientWrapper), dbName, collectionName, container.get(Logger));
+    return new CosmosContainerClient(container.get(CosmosClientWrapper), dbName, collectionName);
 }
 
 function setupAuthenticationMethod(container: interfaces.Container): void {

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 export { Logger } from './logger';
 export { ContextAwareLogger } from './context-aware-logger';
-export { LogLevel } from './base-logger';
+export { BaseLogger, LogLevel } from './base-logger';
 export { loggerTypes } from './logger-types';
 export { registerLoggerToContainer } from './register-logger-to-container';
 export { BaseTelemetryProperties } from './base-telemetry-properties';

--- a/packages/runner/src/tasks/page-state-updater-task.spec.ts
+++ b/packages/runner/src/tasks/page-state-updater-task.spec.ts
@@ -4,6 +4,7 @@
 import 'reflect-metadata';
 
 import { CosmosContainerClient } from 'azure-services';
+import { Logger } from 'logger';
 import { PageObjectFactory } from 'service-library';
 import { ItemType, PageScanResult, RunResult, RunState, ScanLevel, WebsitePage } from 'storage-documents';
 import { IMock, Mock, Times } from 'typemoq';
@@ -14,6 +15,7 @@ import { PageStateUpdaterTask } from './page-state-updater-task';
 let pageObjectFactoryMock: IMock<PageObjectFactory>;
 let cosmosContainerClientMock: IMock<CosmosContainerClient>;
 let pageStateUpdaterTask: PageStateUpdaterTask;
+let loggerMock: IMock<Logger>;
 
 const scanMetadata: ScanMetadata = {
     websiteId: 'websiteId',
@@ -26,7 +28,8 @@ const scanMetadata: ScanMetadata = {
 beforeEach(() => {
     pageObjectFactoryMock = Mock.ofType<PageObjectFactory>();
     cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
-    pageStateUpdaterTask = new PageStateUpdaterTask(cosmosContainerClientMock.object, pageObjectFactoryMock.object);
+    loggerMock = Mock.ofType(Logger);
+    pageStateUpdaterTask = new PageStateUpdaterTask(cosmosContainerClientMock.object, pageObjectFactoryMock.object, loggerMock.object);
 });
 
 afterEach(() => {
@@ -48,7 +51,7 @@ describe('PageStateUpdaterTask', () => {
             .returns(() => websitePage)
             .verifiable(Times.once());
         cosmosContainerClientMock
-            .setup(async o => o.mergeOrWriteDocument(websitePage))
+            .setup(async o => o.mergeOrWriteDocument(websitePage, loggerMock.object))
             .returns(async () => Promise.resolve({ statusCode: 202, item: websitePage }))
             .verifiable(Times.once());
 
@@ -80,7 +83,7 @@ describe('PageStateUpdaterTask', () => {
             .returns(() => websitePage)
             .verifiable(Times.once());
         cosmosContainerClientMock
-            .setup(async o => o.mergeOrWriteDocument(websitePage))
+            .setup(async o => o.mergeOrWriteDocument(websitePage, loggerMock.object))
             .returns(async () => Promise.resolve({ statusCode: 202, item: websitePage }))
             .verifiable(Times.once());
 
@@ -102,7 +105,7 @@ describe('PageStateUpdaterTask', () => {
             .returns(() => websitePage)
             .verifiable(Times.once());
         cosmosContainerClientMock
-            .setup(async o => o.mergeOrWriteDocument(websitePage))
+            .setup(async o => o.mergeOrWriteDocument(websitePage, loggerMock.object))
             .returns(async () => Promise.resolve({ statusCode: 202, item: websitePage }))
             .verifiable(Times.once());
 
@@ -125,7 +128,7 @@ describe('PageStateUpdaterTask', () => {
             .returns(() => websitePage)
             .verifiable(Times.once());
         cosmosContainerClientMock
-            .setup(async o => o.mergeOrWriteDocument(websitePage))
+            .setup(async o => o.mergeOrWriteDocument(websitePage, loggerMock.object))
             .returns(async () => Promise.resolve({ statusCode: 202, item: websitePage }))
             .verifiable(Times.once());
 

--- a/packages/runner/src/tasks/page-state-updater-task.ts
+++ b/packages/runner/src/tasks/page-state-updater-task.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
+import { Logger } from 'logger';
 import { PageObjectFactory } from 'service-library';
 import { PageScanResult, RunState, WebsitePage } from 'storage-documents';
 import { CrawlerScanResults } from '../crawler/crawler-scan-results';
@@ -12,6 +13,7 @@ export class PageStateUpdaterTask {
     constructor(
         @inject(cosmosContainerClientTypes.A11yIssuesCosmosContainerClient) private readonly cosmosContainerClient: CosmosContainerClient,
         @inject(PageObjectFactory) private readonly pageObjectFactory: PageObjectFactory,
+        @inject(Logger) private readonly logger: Logger,
     ) {}
 
     public async setRunningState(scanMetadata: ScanMetadata, runTime: Date): Promise<void> {
@@ -21,7 +23,7 @@ export class PageStateUpdaterTask {
             runTime: runTime.toJSON(),
         };
 
-        await this.cosmosContainerClient.mergeOrWriteDocument(websitePage);
+        await this.cosmosContainerClient.mergeOrWriteDocument(websitePage, this.logger);
     }
 
     public async setPageLinks(crawlerScanResults: CrawlerScanResults, scanMetadata: ScanMetadata): Promise<void> {
@@ -32,7 +34,7 @@ export class PageStateUpdaterTask {
             const scanResult = crawlerScanResults.results.find(result => result.scanUrl === scanMetadata.scanUrl);
             websitePage.links = scanResult !== undefined ? scanResult.links : [];
 
-            await this.cosmosContainerClient.mergeOrWriteDocument(websitePage);
+            await this.cosmosContainerClient.mergeOrWriteDocument(websitePage, this.logger);
         }
     }
 
@@ -50,7 +52,7 @@ export class PageStateUpdaterTask {
             unscannable,
         };
 
-        await this.cosmosContainerClient.mergeOrWriteDocument(websitePage);
+        await this.cosmosContainerClient.mergeOrWriteDocument(websitePage, this.logger);
     }
 
     private createWebsitePageInstance(scanMetadata: ScanMetadata): WebsitePage {

--- a/packages/runner/src/tasks/storage-task.ts
+++ b/packages/runner/src/tasks/storage-task.ts
@@ -2,22 +2,24 @@
 // Licensed under the MIT License.
 import { CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
+import { Logger } from 'logger';
 
 @injectable()
 export class StorageTask {
     constructor(
         @inject(cosmosContainerClientTypes.A11yIssuesCosmosContainerClient) private readonly cosmosContainerClient: CosmosContainerClient,
+        @inject(Logger) private readonly logger: Logger,
     ) {}
 
     public async writeResults<T>(results: T[], partitionKey?: string): Promise<void> {
-        await this.cosmosContainerClient.writeDocuments<T>(results, partitionKey);
+        await this.cosmosContainerClient.writeDocuments<T>(results, this.logger, partitionKey);
     }
 
     public async writeResult<T>(result: T, partitionKey?: string): Promise<void> {
-        await this.cosmosContainerClient.writeDocument<T>(result, partitionKey);
+        await this.cosmosContainerClient.writeDocument<T>(result, this.logger, partitionKey);
     }
 
     public async mergeResults<T>(results: T[], partitionKey?: string): Promise<void> {
-        await this.cosmosContainerClient.mergeOrWriteDocuments<T>(results, partitionKey);
+        await this.cosmosContainerClient.mergeOrWriteDocuments<T>(results, this.logger, partitionKey);
     }
 }

--- a/packages/runner/src/tasks/website-state-updater-task.spec.ts
+++ b/packages/runner/src/tasks/website-state-updater-task.spec.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
 
     let targetWebsiteServerItem: Website;
     cosmosContainerClientMock
-        .setup(async o => o.writeDocument<Website>(It.isAny(), websitePartitioningKey))
+        .setup(async o => o.writeDocument<Website>(It.isAny(), loggerMock.object, websitePartitioningKey))
         .callback(item => {
             targetWebsiteServerItem = item;
         })
@@ -71,7 +71,7 @@ describe('WebsiteStateUpdaterTask', () => {
         const websiteCreatedItem = <Website>(<unknown>{ type: 'Website', operation: 'created' });
         const websiteServerItem = createWebsiteServerItem(404);
         cosmosContainerClientMock
-            .setup(async o => o.readDocument<Website>('websiteDocumentId', websitePartitioningKey))
+            .setup(async o => o.readDocument<Website>('websiteDocumentId', loggerMock.object, websitePartitioningKey))
             .returns(async () => Promise.resolve(websiteServerItem))
             .verifiable(Times.once());
         websiteFactoryMock
@@ -94,7 +94,7 @@ describe('WebsiteStateUpdaterTask', () => {
         const websiteUpdatedItem = <Website>(<unknown>{ type: 'Website', operation: 'updated' });
         const websiteServerItem = createWebsiteServerItem(200);
         cosmosContainerClientMock
-            .setup(async o => o.readDocument<Website>('websiteDocumentId', websitePartitioningKey))
+            .setup(async o => o.readDocument<Website>('websiteDocumentId', loggerMock.object, websitePartitioningKey))
             .returns(async () => Promise.resolve(websiteServerItem))
             .verifiable(Times.once());
         websiteFactoryMock
@@ -118,7 +118,7 @@ async function setupTryExecuteOperationCallback(): Promise<CosmosOperationRespon
     return new Promise(async (resolve, reject) => {
         let operationResult: CosmosOperationResponse<Website>;
         cosmosContainerClientMock
-            .setup(async o => o.tryExecuteOperation(It.isAny(), retryOptions, pageScanResult, scanMetadata, It.isAny()))
+            .setup(async o => o.tryExecuteOperation(It.isAny(), retryOptions, loggerMock.object, pageScanResult, scanMetadata, It.isAny()))
             .callback(async (operation, options, scanResult, metadata, timestamp) => {
                 try {
                     operationResult = await operation(scanResult, metadata, timestamp);

--- a/packages/runner/src/tasks/website-state-updater-task.spec.ts
+++ b/packages/runner/src/tasks/website-state-updater-task.spec.ts
@@ -32,6 +32,8 @@ let loggerMock: IMock<Logger>;
 const websitePartitioningKey = 'website';
 
 beforeEach(() => {
+    loggerMock = Mock.ofType(Logger);
+
     cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
     websiteFactoryMock = Mock.ofType<WebsiteFactory>();
 
@@ -50,8 +52,6 @@ beforeEach(() => {
         .setup(o => o.createWebsiteDocumentId(scanMetadata.baseUrl))
         .returns(() => 'websiteDocumentId')
         .verifiable(Times.once());
-
-    loggerMock = Mock.ofType(Logger);
 
     websiteStateUpdaterTask = new WebsiteStateUpdaterTask(
         cosmosContainerClientMock.object,
@@ -119,7 +119,7 @@ async function setupTryExecuteOperationCallback(): Promise<CosmosOperationRespon
         let operationResult: CosmosOperationResponse<Website>;
         cosmosContainerClientMock
             .setup(async o => o.tryExecuteOperation(It.isAny(), retryOptions, loggerMock.object, pageScanResult, scanMetadata, It.isAny()))
-            .callback(async (operation, options, scanResult, metadata, timestamp) => {
+            .callback(async (operation, options, logger, scanResult, metadata, timestamp) => {
                 try {
                     operationResult = await operation(scanResult, metadata, timestamp);
                     resolve(operationResult);

--- a/packages/runner/src/tasks/website-state-updater-task.ts
+++ b/packages/runner/src/tasks/website-state-updater-task.ts
@@ -27,9 +27,10 @@ export class WebsiteStateUpdaterTask {
             async (scanResult: PageScanResult, metadata: ScanMetadata, timestamp: Date) => {
                 const targetWebsiteItem = await this.getWebsiteItemToUpdate(scanResult, metadata, timestamp);
 
-                return this.cosmosContainerClient.writeDocument<Website>(targetWebsiteItem, websiteRootPartitionKey);
+                return this.cosmosContainerClient.writeDocument<Website>(targetWebsiteItem, this.logger, websiteRootPartitionKey);
             },
             this.retryOptions,
+            this.logger,
             pageScanResult,
             scanMetadata,
             runTime,
@@ -39,7 +40,11 @@ export class WebsiteStateUpdaterTask {
     private async getWebsiteItemToUpdate(pageScanResult: PageScanResult, scanMetadata: ScanMetadata, runTime: Date): Promise<Website> {
         let targetWebsiteItem: Website;
         const websiteDocumentId = this.websiteFactory.createWebsiteDocumentId(scanMetadata.baseUrl);
-        const sourceWebsiteItem = await this.cosmosContainerClient.readDocument<Website>(websiteDocumentId, websiteRootPartitionKey);
+        const sourceWebsiteItem = await this.cosmosContainerClient.readDocument<Website>(
+            websiteDocumentId,
+            this.logger,
+            websiteRootPartitionKey,
+        );
 
         if (sourceWebsiteItem.statusCode === 200) {
             this.logger.logInfo(

--- a/packages/scan-request-sender/src/sender/dispatcher.spec.ts
+++ b/packages/scan-request-sender/src/sender/dispatcher.spec.ts
@@ -216,7 +216,7 @@ describe('Dispatcher', () => {
         continuationToken: string,
     ): void {
         pageDocumentProviderMock
-            .setup(async p => p.getReadyToScanPages(previousContinuationToken))
+            .setup(async p => p.getReadyToScanPages(loggerMock.object, previousContinuationToken))
             .returns(async () => Promise.resolve(createWebPagesRequestResponse(webPages, continuationToken)));
     }
 

--- a/packages/scan-request-sender/src/sender/dispatcher.spec.ts
+++ b/packages/scan-request-sender/src/sender/dispatcher.spec.ts
@@ -154,7 +154,7 @@ describe('Dispatcher', () => {
         setupVerifiableQueueSizeCall();
 
         pageDocumentProviderMock
-            .setup(async p => p.getReadyToScanPages(It.isAny()))
+            .setup(async p => p.getReadyToScanPages(loggerMock.object, It.isAny()))
             .returns(async () => Promise.resolve(getErrorResponse()))
             .verifiable(Times.once());
 

--- a/packages/scan-request-sender/src/sender/dispatcher.ts
+++ b/packages/scan-request-sender/src/sender/dispatcher.ts
@@ -35,6 +35,7 @@ export class Dispatcher {
         do {
             do {
                 const response: CosmosOperationResponse<WebsitePage[]> = await this.pageDocumentProvider.getReadyToScanPages(
+                    this.logger,
                     continuationToken,
                 );
                 client.ensureSuccessStatusCode(response);

--- a/packages/scan-request-sender/src/sender/scan-request-sender.spec.ts
+++ b/packages/scan-request-sender/src/sender/scan-request-sender.spec.ts
@@ -4,6 +4,7 @@
 import 'reflect-metadata';
 
 import { Queue, StorageConfig } from 'azure-services';
+import { Logger } from 'logger';
 import { PageDocumentProvider } from 'service-library';
 import { ItemType, RunState, ScanRequestMessage, WebsitePage, WebsitePageExtra } from 'storage-documents';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -14,15 +15,17 @@ describe('Scan request Sender', () => {
     let testSubject: ScanRequestSender;
     let storageConfigStub: StorageConfig;
     let pageDocumentProviderMock: IMock<PageDocumentProvider>;
+    let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
         storageConfigStub = {
             scanQueue: 'test-scan-queue',
         };
 
+        loggerMock = Mock.ofType(Logger);
         queueMock = Mock.ofType<Queue>();
         pageDocumentProviderMock = Mock.ofType<PageDocumentProvider>();
-        testSubject = new ScanRequestSender(pageDocumentProviderMock.object, queueMock.object, storageConfigStub);
+        testSubject = new ScanRequestSender(pageDocumentProviderMock.object, queueMock.object, storageConfigStub, loggerMock.object);
     });
 
     afterEach(() => {
@@ -42,7 +45,7 @@ describe('Scan request Sender', () => {
                 .verifiable(Times.once());
 
             pageDocumentProviderMock
-                .setup(async o => o.updatePageProperties(page, It.isAny()))
+                .setup(async o => o.updatePageProperties(page, It.isAny(), loggerMock.object))
                 .callback((p, d) => {
                     websitePageUpdateDelta = d;
                 })
@@ -68,7 +71,7 @@ describe('Scan request Sender', () => {
                 .verifiable(Times.once());
 
             pageDocumentProviderMock
-                .setup(async o => o.updatePageProperties(page, It.isAny()))
+                .setup(async o => o.updatePageProperties(page, It.isAny(), loggerMock.object))
                 .callback((p, d) => {
                     websitePageUpdateDelta = d;
                 })

--- a/packages/scan-request-sender/src/sender/scan-request-sender.ts
+++ b/packages/scan-request-sender/src/sender/scan-request-sender.ts
@@ -3,6 +3,7 @@
 import { Queue, StorageConfig } from 'azure-services';
 import { inject, injectable } from 'inversify';
 import * as _ from 'lodash';
+import { Logger } from 'logger';
 import { PageDocumentProvider } from 'service-library';
 import { RunState, ScanRequestMessage, WebsitePage, WebsitePageExtra } from 'storage-documents';
 
@@ -12,6 +13,7 @@ export class ScanRequestSender {
         @inject(PageDocumentProvider) private readonly pageDocumentProvider: PageDocumentProvider,
         @inject(Queue) private readonly queue: Queue,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
+        @inject(Logger) private readonly logger: Logger,
     ) {}
 
     public async sendRequestToScan(websitePage: WebsitePage[]): Promise<void> {
@@ -50,6 +52,6 @@ export class ScanRequestSender {
             },
         };
 
-        await this.pageDocumentProvider.updatePageProperties(websitePage, websitePageState);
+        await this.pageDocumentProvider.updatePageProperties(websitePage, websitePageState, this.logger);
     }
 }

--- a/packages/scan-request-sender/src/source/seed-source.spec.ts
+++ b/packages/scan-request-sender/src/source/seed-source.spec.ts
@@ -18,7 +18,7 @@ describe('Scan Source', () => {
     beforeEach(() => {
         cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
         cosmosContainerClientMock
-            .setup(async o => o.readAllDocument<ScanRequest>())
+            .setup(async o => o.readAllDocument<ScanRequest>(loggerMock.object))
             .returns(async () => Promise.resolve(getScanRequestTestData()))
             .verifiable(Times.once());
         loggerMock = Mock.ofType(Logger);

--- a/packages/scan-request-sender/src/source/seed-source.spec.ts
+++ b/packages/scan-request-sender/src/source/seed-source.spec.ts
@@ -16,12 +16,13 @@ describe('Scan Source', () => {
     let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
+        loggerMock = Mock.ofType(Logger);
+
         cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
         cosmosContainerClientMock
             .setup(async o => o.readAllDocument<ScanRequest>(loggerMock.object))
             .returns(async () => Promise.resolve(getScanRequestTestData()))
             .verifiable(Times.once());
-        loggerMock = Mock.ofType(Logger);
         testSubject = new SeedSource(cosmosContainerClientMock.object, loggerMock.object);
     });
     it('get websites to scan', async () => {

--- a/packages/scan-request-sender/src/source/seed-source.ts
+++ b/packages/scan-request-sender/src/source/seed-source.ts
@@ -14,7 +14,7 @@ export class SeedSource {
     ) {}
 
     public async getWebSites(): Promise<WebSite[]> {
-        const response = await this.cosmosContainerClient.readAllDocument<ScanRequest>();
+        const response = await this.cosmosContainerClient.readAllDocument<ScanRequest>(this.logger);
         client.ensureSuccessStatusCode(response);
         if (response.item.length > 0) {
             this.logger.logInfo(`[Sender] retrieve ${response.item[0].websites.length} website documents`);

--- a/packages/service-library/src/data-providers/page-document-provider.db.spec.ts
+++ b/packages/service-library/src/data-providers/page-document-provider.db.spec.ts
@@ -74,7 +74,6 @@ describe(PageDocumentProvider, () => {
                 dbHelper.cosmosClient,
                 dbHelper.dbContainer.dbName,
                 dbHelper.dbContainer.collectionName,
-                loggerMock.object,
             );
 
             beforeLastReferenceSeenTime = currentMoment()
@@ -173,7 +172,7 @@ describe(PageDocumentProvider, () => {
                 ]);
                 queryResults = [pageAfterMinLastReferenceSeen1, pageAfterMinLastReferenceSeen2];
 
-                const actualResults = await testSubject.getPagesNeverScanned(website, 10);
+                const actualResults = await testSubject.getPagesNeverScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             }, 3000);
@@ -195,7 +194,7 @@ describe(PageDocumentProvider, () => {
                 await dbHelper.upsertItems([pageWithLastRunNull, pageWithLastRunNotFound, pageWithLastRunInfo]);
                 queryResults = [pageWithLastRunNull, pageWithLastRunNotFound];
 
-                const actualResults = await testSubject.getPagesNeverScanned(website, 10);
+                const actualResults = await testSubject.getPagesNeverScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             }, 3000);
@@ -207,7 +206,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems([basePage1, basePage2, childPage]);
 
-                const actualResults = await testSubject.getPagesNeverScanned(website, 1);
+                const actualResults = await testSubject.getPagesNeverScanned(website, 1, loggerMock.object);
 
                 expect(actualResults.length).toBe(1);
             }, 3000);
@@ -221,7 +220,7 @@ describe(PageDocumentProvider, () => {
                 await dbHelper.upsertItems([basePage1, basePage2, childPage]);
                 queryResults = [basePage1, basePage2];
 
-                const actualResults = await testSubject.getPagesNeverScanned(website, 10);
+                const actualResults = await testSubject.getPagesNeverScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -236,7 +235,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems([basePage1, basePage2, childPage]);
 
-                const actualResults = await testSubject.getPagesNeverScanned(website, 5);
+                const actualResults = await testSubject.getPagesNeverScanned(website, 5, loggerMock.object);
 
                 expect(actualResults.length).toBe(3);
             }, 3000);
@@ -248,7 +247,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems([basePage1, basePage2, childPage]);
 
-                const actualResults = await testSubject.getPagesNeverScanned(website, 5);
+                const actualResults = await testSubject.getPagesNeverScanned(website, 5, loggerMock.object);
 
                 expect(actualResults.length).toBe(2);
             }, 3000);
@@ -290,7 +289,7 @@ describe(PageDocumentProvider, () => {
                 await dbHelper.upsertItems(queryResults);
                 await dbHelper.upsertItems(nonQueryResults);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -324,7 +323,7 @@ describe(PageDocumentProvider, () => {
                 await dbHelper.upsertItems(queryResults);
                 await dbHelper.upsertItems(nonQueryResults);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -367,7 +366,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems(queryResults);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithOrder([page3, page1, page2], actualResults);
             });
@@ -410,7 +409,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems(queryResults);
 
-                const actualResults = await testSubject.getPagesScanned(website, 2);
+                const actualResults = await testSubject.getPagesScanned(website, 2, loggerMock.object);
 
                 expect(actualResults.length).toBe(2);
             });
@@ -454,7 +453,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems([basePage1, basePage2, childPage]);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -510,7 +509,7 @@ describe(PageDocumentProvider, () => {
                 await dbHelper.upsertItems(queryResults);
                 await dbHelper.upsertItems(nonQueryResults);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -547,7 +546,7 @@ describe(PageDocumentProvider, () => {
                 await dbHelper.upsertItems(queryResults);
                 await dbHelper.upsertItems(nonQueryResults);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -596,7 +595,7 @@ describe(PageDocumentProvider, () => {
                 await dbHelper.upsertItems(queryResults);
                 await dbHelper.upsertItems(nonQueryResults);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -642,7 +641,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems([basePage1, basePage2, childPage]);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -686,7 +685,7 @@ describe(PageDocumentProvider, () => {
 
                 await dbHelper.upsertItems([basePage1, basePage2, childPage]);
 
-                const actualResults = await testSubject.getPagesScanned(website, 10);
+                const actualResults = await testSubject.getPagesScanned(website, 10, loggerMock.object);
 
                 verifyQueryResultsWithoutOrder(queryResults, actualResults);
             });
@@ -703,7 +702,7 @@ describe(PageDocumentProvider, () => {
                 const actualWebsiteIds = [] as string[];
                 await dbHelper.upsertItems(Array.from(allWebsites));
 
-                const actualQueryResults = await testSubject.getWebsites();
+                const actualQueryResults = await testSubject.getWebsites(loggerMock.object);
                 actualQueryResults.item.forEach(w => {
                     actualWebsiteIds.push(w.websiteId);
                 });

--- a/packages/service-library/src/data-providers/page-scan-request-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-request-provider.ts
@@ -3,6 +3,7 @@
 
 import { CosmosContainerClient, cosmosContainerClientTypes, CosmosOperationResponse } from 'azure-services';
 import { inject, injectable } from 'inversify';
+import { BaseLogger } from 'logger';
 import { ItemType, OnDemandPageScanBatchRequest, OnDemandPageScanRequest, PartitionKey } from 'storage-documents';
 
 @injectable()
@@ -13,6 +14,7 @@ export class PageScanRequestProvider {
     ) {}
 
     public async getRequests(
+        logger: BaseLogger,
         continuationToken?: string,
         itemsCount: number = 100,
     ): Promise<CosmosOperationResponse<OnDemandPageScanRequest[]>> {
@@ -20,19 +22,20 @@ export class PageScanRequestProvider {
 
         return this.cosmosContainerClient.queryDocuments<OnDemandPageScanRequest>(
             query,
+            logger,
             continuationToken,
             PartitionKey.pageScanRequestDocuments,
         );
     }
 
-    public async insertRequests(requests: OnDemandPageScanRequest[]): Promise<void> {
-        return this.cosmosContainerClient.writeDocuments(requests);
+    public async insertRequests(requests: OnDemandPageScanRequest[], logger: BaseLogger): Promise<void> {
+        return this.cosmosContainerClient.writeDocuments(requests, logger);
     }
 
-    public async deleteRequests(ids: string[]): Promise<void> {
+    public async deleteRequests(ids: string[], logger: BaseLogger): Promise<void> {
         await Promise.all(
             ids.map(async id => {
-                await this.cosmosContainerClient.deleteDocument(id, PartitionKey.pageScanRequestDocuments);
+                await this.cosmosContainerClient.deleteDocument(id, PartitionKey.pageScanRequestDocuments, logger);
             }),
         );
     }

--- a/packages/service-library/src/data-providers/scan-data-provider.spec.ts
+++ b/packages/service-library/src/data-providers/scan-data-provider.spec.ts
@@ -3,6 +3,7 @@
 import 'reflect-metadata';
 
 import { CosmosContainerClient } from 'azure-services';
+import { Logger } from 'logger';
 import { ItemType, OnDemandPageScanBatchRequest, PartitionKey, ScanRunBatchRequest } from 'storage-documents';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { ScanDataProvider } from './scan-data-provider';
@@ -11,6 +12,7 @@ import { ScanDataProvider } from './scan-data-provider';
 
 let scanDataProvider: ScanDataProvider;
 let cosmosContainerClientMock: IMock<CosmosContainerClient>;
+let loggerMock: IMock<Logger>;
 
 beforeEach(() => {
     cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
@@ -27,14 +29,15 @@ describe(ScanDataProvider, () => {
             },
         ];
 
+        loggerMock = Mock.ofType<Logger>();
         let document: OnDemandPageScanBatchRequest;
         cosmosContainerClientMock
-            .setup(async o => o.writeDocument(It.isAny()))
+            .setup(async o => o.writeDocument(It.isAny(), loggerMock.object))
             .callback(async d => (document = d))
             .verifiable(Times.once());
 
         const batchId = 'batchId-1';
-        await scanDataProvider.writeScanRunBatchRequest(batchId, scanRunBatchResponse);
+        await scanDataProvider.writeScanRunBatchRequest(batchId, scanRunBatchResponse, loggerMock.object);
 
         expect(document.scanRunBatchRequest).toEqual(scanRunBatchResponse);
         expect(document.id).toEqual(batchId);

--- a/packages/service-library/src/data-providers/scan-data-provider.ts
+++ b/packages/service-library/src/data-providers/scan-data-provider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
+import { BaseLogger } from 'logger';
 import { ItemType, OnDemandPageScanBatchRequest, PartitionKey, ScanRunBatchRequest } from 'storage-documents';
 
 @injectable()
@@ -11,7 +12,7 @@ export class ScanDataProvider {
         private readonly cosmosContainerClient: CosmosContainerClient,
     ) {}
 
-    public async writeScanRunBatchRequest(batchId: string, scanRunBatchResponse: ScanRunBatchRequest[]): Promise<void> {
+    public async writeScanRunBatchRequest(batchId: string, scanRunBatchResponse: ScanRunBatchRequest[], logger: BaseLogger): Promise<void> {
         const scanRunBatchRequest: OnDemandPageScanBatchRequest = {
             id: batchId,
             itemType: ItemType.scanRunBatchRequest,
@@ -19,12 +20,12 @@ export class ScanDataProvider {
             scanRunBatchRequest: scanRunBatchResponse,
         };
 
-        await this.cosmosContainerClient.writeDocument(scanRunBatchRequest);
+        await this.cosmosContainerClient.writeDocument(scanRunBatchRequest, logger);
 
         return;
     }
 
-    public async deleteBatchRequest(request: OnDemandPageScanBatchRequest): Promise<void> {
-        await this.cosmosContainerClient.deleteDocument(request.id, request.partitionKey);
+    public async deleteBatchRequest(request: OnDemandPageScanBatchRequest, logger: BaseLogger): Promise<void> {
+        await this.cosmosContainerClient.deleteDocument(request.id, request.partitionKey, logger);
     }
 }

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
@@ -229,7 +229,7 @@ describe('Dispatcher', () => {
         continuationToken: string,
     ): void {
         pageScanRequestProvider
-            .setup(async p => p.getRequests(previousContinuationToken))
+            .setup(async p => p.getRequests(loggerMock.object, previousContinuationToken))
             .returns(async () => Promise.resolve(createOnDemandPagesRequestResponse(onDemandPageScanRequests, continuationToken)));
     }
 

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
@@ -164,7 +164,7 @@ describe('Dispatcher', () => {
         setupVerifiableQueueSizeCall();
 
         pageScanRequestProvider
-            .setup(async p => p.getRequests(It.isAny()))
+            .setup(async p => p.getRequests(loggerMock.object, It.isAny()))
             .returns(async () => Promise.resolve(getErrorResponse()))
             .verifiable(Times.once());
 

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -34,6 +34,7 @@ export class OnDemandDispatcher {
         do {
             do {
                 const response: CosmosOperationResponse<OnDemandPageScanRequest[]> = await this.pageScanRequestProvider.getRequests(
+                    this.logger,
                     continuationToken,
                 );
                 client.ensureSuccessStatusCode(response);

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
@@ -3,6 +3,7 @@
 import 'reflect-metadata';
 
 import { Queue, StorageConfig } from 'azure-services';
+import { Logger } from 'logger';
 import * as MockDate from 'mockdate';
 import { OnDemandPageScanRunResultProvider, PageScanRequestProvider } from 'service-library';
 import {
@@ -22,6 +23,7 @@ describe('Scan request sender', () => {
     let pageScanRequestProvider: IMock<PageScanRequestProvider>;
     let onDemandPageScanRunResultProvider: IMock<OnDemandPageScanRunResultProvider>;
     let dateNow: Date;
+    let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
         dateNow = new Date();
@@ -31,6 +33,7 @@ describe('Scan request sender', () => {
             scanQueue: 'test-scan-queue',
         };
 
+        loggerMock = Mock.ofType(Logger);
         queueMock = Mock.ofType<Queue>();
         pageScanRequestProvider = Mock.ofType<PageScanRequestProvider>();
         onDemandPageScanRunResultProvider = Mock.ofType<OnDemandPageScanRunResultProvider>();
@@ -39,6 +42,7 @@ describe('Scan request sender', () => {
             onDemandPageScanRunResultProvider.object,
             queueMock.object,
             storageConfigStub,
+            loggerMock.object,
         );
     });
 
@@ -56,12 +60,12 @@ describe('Scan request sender', () => {
             const acceptedPageScanRunResultDoc = createResultDoc(request, 'queued');
 
             onDemandPageScanRunResultProvider
-                .setup(async resultProvider => resultProvider.readScanRuns([request.id]))
+                .setup(async resultProvider => resultProvider.readScanRuns([request.id], loggerMock.object))
                 .returns(async () => Promise.resolve([pageScanRunResultDoc]))
                 .verifiable(Times.once());
 
             onDemandPageScanRunResultProvider
-                .setup(async resultProvider => resultProvider.writeScanRuns([acceptedPageScanRunResultDoc]))
+                .setup(async resultProvider => resultProvider.writeScanRuns([acceptedPageScanRunResultDoc], loggerMock.object))
                 .returns(async () => Promise.resolve())
                 .verifiable(Times.once());
 
@@ -73,7 +77,7 @@ describe('Scan request sender', () => {
                 .verifiable(Times.once());
 
             pageScanRequestProvider
-                .setup(async doc => doc.deleteRequests([request.id]))
+                .setup(async doc => doc.deleteRequests([request.id], loggerMock.object))
                 .returns(async () => Promise.resolve())
                 .verifiable(Times.once());
         });
@@ -87,12 +91,12 @@ describe('Scan request sender', () => {
             const pageScanRunResultDoc = createResultDoc(request, 'queued');
 
             onDemandPageScanRunResultProvider
-                .setup(async resultProvider => resultProvider.readScanRuns([request.id]))
+                .setup(async resultProvider => resultProvider.readScanRuns([request.id], loggerMock.object))
                 .returns(async () => Promise.resolve([pageScanRunResultDoc]))
                 .verifiable(Times.once());
 
             onDemandPageScanRunResultProvider
-                .setup(async resultProvider => resultProvider.writeScanRuns([pageScanRunResultDoc]))
+                .setup(async resultProvider => resultProvider.writeScanRuns([pageScanRunResultDoc], loggerMock.object))
                 .returns(async () => Promise.resolve())
                 .verifiable(Times.never());
 
@@ -104,7 +108,7 @@ describe('Scan request sender', () => {
                 .verifiable(Times.never());
 
             pageScanRequestProvider
-                .setup(async doc => doc.deleteRequests([request.id]))
+                .setup(async doc => doc.deleteRequests([request.id], loggerMock.object))
                 .returns(async () => Promise.resolve())
                 .verifiable(Times.once());
         });

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { Queue, StorageConfig } from 'azure-services';
 import { inject, injectable } from 'inversify';
+import { Logger } from 'logger';
 import { OnDemandPageScanRunResultProvider, PageScanRequestProvider } from 'service-library';
 import { OnDemandPageScanRequest, OnDemandPageScanResult, OnDemandScanRequestMessage } from 'storage-documents';
 
@@ -12,12 +13,13 @@ export class OnDemandScanRequestSender {
         @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
         @inject(Queue) private readonly queue: Queue,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
+        @inject(Logger) private readonly logger: Logger,
     ) {}
 
     public async sendRequestToScan(onDemandPageScanRequests: OnDemandPageScanRequest[]): Promise<void> {
         await Promise.all(
             onDemandPageScanRequests.map(async page => {
-                const resultDocs = await this.onDemandPageScanRunResultProvider.readScanRuns([page.id]);
+                const resultDocs = await this.onDemandPageScanRunResultProvider.readScanRuns([page.id], this.logger);
                 const resultDoc = resultDocs.pop();
                 if (resultDoc !== undefined && resultDoc.run !== undefined && resultDoc.run.state === 'accepted') {
                     const message = this.createOnDemandScanRequestMessage(page);
@@ -25,7 +27,7 @@ export class OnDemandScanRequestSender {
                     await this.updateOnDemandPageResultDoc(resultDoc);
                 }
 
-                await this.pageScanRequestProvider.deleteRequests([page.id]);
+                await this.pageScanRequestProvider.deleteRequests([page.id], this.logger);
             }),
         );
     }
@@ -38,7 +40,7 @@ export class OnDemandScanRequestSender {
         resultDoc.run.state = 'queued';
         resultDoc.run.timestamp = new Date().toJSON();
 
-        await this.onDemandPageScanRunResultProvider.writeScanRuns([resultDoc]);
+        await this.onDemandPageScanRunResultProvider.writeScanRuns([resultDoc], this.logger);
     }
 
     private createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest): OnDemandScanRequestMessage {

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -349,7 +349,7 @@ describe(Runner, () => {
 
     function setupReadScanResultCall(scanResult: any): void {
         onDemandPageScanRunResultProviderMock
-            .setup(async d => d.readScanRun(scanMetadata.id))
+            .setup(async d => d.readScanRun(scanMetadata.id, loggerMock.object))
             .returns(async () => Promise.resolve(cloneDeep(scanResult)))
             .verifiable(Times.exactly(1));
     }
@@ -394,7 +394,7 @@ describe(Runner, () => {
         const clonedResult = cloneDeep(result);
 
         onDemandPageScanRunResultProviderMock
-            .setup(async d => d.updateScanRun(clonedResult))
+            .setup(async d => d.updateScanRun(clonedResult, loggerMock.object))
             .returns(async () => Promise.resolve(clonedResult))
             .verifiable();
     }

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -58,14 +58,14 @@ export class Runner {
         const scanSubmittedTimestamp: number = this.guidGenerator.getGuidTimestamp(scanMetadata.id).getTime();
 
         this.logger.logInfo(`Reading page scan run result.`);
-        pageScanResult = await this.onDemandPageScanRunResultProvider.readScanRun(scanMetadata.id);
+        pageScanResult = await this.onDemandPageScanRunResultProvider.readScanRun(scanMetadata.id, this.logger);
         this.logger.setCustomProperties({ scanId: scanMetadata.id, batchRequestId: pageScanResult.batchRequestId });
 
         this.logger.trackEvent('ScanTaskStarted', undefined, { scanWaitTime: (scanStartedTimestamp - scanSubmittedTimestamp) / 1000 });
 
         this.logger.logInfo(`Updating page scan run result state to running.`);
         pageScanResult = this.resetPageScanResultState(pageScanResult);
-        pageScanResult = await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
+        pageScanResult = await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult, this.logger);
 
         try {
             browser = await this.webDriverTask.launch();
@@ -90,7 +90,7 @@ export class Runner {
         }
 
         this.logger.logInfo(`Writing page scan run result to a storage.`);
-        await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
+        await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult, this.logger);
     }
 
     private async scan(pageScanResult: OnDemandPageScanResult): Promise<void> {

--- a/packages/web-api/src/controllers/base-scan-result-controller.ts
+++ b/packages/web-api/src/controllers/base-scan-result-controller.ts
@@ -21,7 +21,7 @@ export abstract class BaseScanResultController extends ApiController {
     }
 
     protected async getScanResultMapKeyByScanId(scanIds: string[]): Promise<Dictionary<OnDemandPageScanResult>> {
-        const scanResultItems = await this.onDemandPageScanRunResultProvider.readScanRuns(scanIds);
+        const scanResultItems = await this.onDemandPageScanRunResultProvider.readScanRuns(scanIds, this.contextAwareLogger);
 
         return keyBy(scanResultItems, item => item.id);
     }

--- a/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
@@ -66,7 +66,7 @@ describe(BatchScanResultController, () => {
         onDemandPageScanRunResultProviderMock = Mock.ofType<OnDemandPageScanRunResultProvider>();
         onDemandPageScanRunResultProviderMock
             // tslint:disable-next-line: no-unsafe-any
-            .setup(async o => o.readScanRuns(It.isAny()))
+            .setup(async o => o.readScanRuns(It.isAny(), contextAwareLoggerMockMock.object))
             .returns(async () => Promise.resolve([scanFetchedResponse]));
 
         guidGeneratorMock = Mock.ofType(GuidGenerator);

--- a/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
@@ -52,6 +52,8 @@ describe(BatchScanResultController, () => {
     };
 
     beforeEach(() => {
+        contextAwareLoggerMockMock = Mock.ofType<ContextAwareLogger>();
+
         context = <Context>(<unknown>{
             req: {
                 url: `${baseUrl}scans/$batch/`,
@@ -86,8 +88,6 @@ describe(BatchScanResultController, () => {
                     scanRequestProcessingDelayInSeconds: 120,
                 } as RestApiConfig;
             });
-
-        contextAwareLoggerMockMock = Mock.ofType<ContextAwareLogger>();
 
         scanResponseConverterMock = Mock.ofType<ScanResponseConverter>();
         scanResponseConverterMock

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -38,7 +38,7 @@ describe(ScanRequestController, () => {
         context.req.headers['content-type'] = 'application/json';
 
         scanDataProviderMock = Mock.ofType<ScanDataProvider>();
-        scanDataProviderMock.setup(async o => o.writeScanRunBatchRequest(It.isAny(), It.isAny()));
+        scanDataProviderMock.setup(async o => o.writeScanRunBatchRequest(It.isAny(), It.isAny(), contextAwareLoggerMock.object));
 
         guidGeneratorMock = Mock.ofType(GuidGenerator);
 
@@ -99,7 +99,9 @@ describe(ScanRequestController, () => {
                 { url: 'https://cde/path/', error: WebApiErrorCodes.outOfRangePriority.error },
             ];
             const expectedSavedRequest: ScanRunBatchRequest[] = [{ scanId: guid2, url: 'https://abs/path/', priority: 1 }];
-            scanDataProviderMock.setup(async o => o.writeScanRunBatchRequest(guid1, expectedSavedRequest)).verifiable(Times.once());
+            scanDataProviderMock
+                .setup(async o => o.writeScanRunBatchRequest(guid1, expectedSavedRequest, contextAwareLoggerMock.object))
+                .verifiable(Times.once());
 
             scanRequestController = createScanRequestController(context);
 
@@ -125,7 +127,9 @@ describe(ScanRequestController, () => {
             context.req.rawBody = JSON.stringify([{ url: 'https://abs/path/', priority: priority }]);
             const expectedResponse = [{ scanId: guid2, url: 'https://abs/path/' }];
             const expectedSavedRequest: ScanRunBatchRequest[] = [{ scanId: guid2, url: 'https://abs/path/', priority: priority }];
-            scanDataProviderMock.setup(async o => o.writeScanRunBatchRequest(guid1, expectedSavedRequest)).verifiable(Times.once());
+            scanDataProviderMock
+                .setup(async o => o.writeScanRunBatchRequest(guid1, expectedSavedRequest, contextAwareLoggerMock.object))
+                .verifiable(Times.once());
 
             scanRequestController = createScanRequestController(context);
 
@@ -185,7 +189,9 @@ describe(ScanRequestController, () => {
                 { scanId: guid2, url: 'https://abs/path/', priority: priority },
                 { scanId: guid3, url: 'https://bing.com/path/', priority: priority },
             ];
-            scanDataProviderMock.setup(async o => o.writeScanRunBatchRequest(guid1, expectedSaveRequest)).verifiable(Times.once());
+            scanDataProviderMock
+                .setup(async o => o.writeScanRunBatchRequest(guid1, expectedSaveRequest, contextAwareLoggerMock.object))
+                .verifiable(Times.once());
 
             scanRequestController = createScanRequestController(context);
 
@@ -212,7 +218,9 @@ describe(ScanRequestController, () => {
             const expectedResponse = { scanId: guid2, url: 'https://abs/path/' };
 
             const expectedSaveRequest: ScanRunBatchRequest[] = [{ scanId: guid2, url: 'https://abs/path/', priority: priority }];
-            scanDataProviderMock.setup(async o => o.writeScanRunBatchRequest(guid1, expectedSaveRequest)).verifiable(Times.once());
+            scanDataProviderMock
+                .setup(async o => o.writeScanRunBatchRequest(guid1, expectedSaveRequest, contextAwareLoggerMock.object))
+                .verifiable(Times.once());
 
             scanRequestController = createScanRequestController(context);
 

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -61,7 +61,7 @@ export class ScanRequestController extends ApiController {
         }
         const batchId = this.guidGenerator.createGuid();
         const processedData = this.getProcessedRequestData(batchId, payload);
-        await this.scanDataProvider.writeScanRunBatchRequest(batchId, processedData.scanRequestsToBeStoredInDb);
+        await this.scanDataProvider.writeScanRunBatchRequest(batchId, processedData.scanRequestsToBeStoredInDb, this.contextAwareLogger);
         this.context.res = {
             status: 202, // Accepted
             body: this.getResponse(processedData),

--- a/packages/web-api/src/controllers/scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.spec.ts
@@ -74,7 +74,7 @@ describe(ScanResultController, () => {
         context.req.headers['content-type'] = 'application/json';
 
         onDemandPageScanRunResultProviderMock = Mock.ofType<OnDemandPageScanRunResultProvider>();
-        onDemandPageScanRunResultProviderMock.setup(async o => o.readScanRuns(It.isAny()));
+        onDemandPageScanRunResultProviderMock.setup(async o => o.readScanRuns(It.isAny(), contextAwareLoggerMock.object));
 
         guidGeneratorMock = Mock.ofType(GuidGenerator);
         guidGeneratorMock
@@ -149,7 +149,7 @@ describe(ScanResultController, () => {
             scanResultController = createScanResultController(context);
             setupGetGuidTimestamp(new Date(0));
             onDemandPageScanRunResultProviderMock
-                .setup(async om => om.readScanRuns([scanId]))
+                .setup(async om => om.readScanRuns([scanId], contextAwareLoggerMock.object))
                 .returns(async () => {
                     return Promise.resolve([]);
                 })
@@ -168,7 +168,7 @@ describe(ScanResultController, () => {
             onDemandPageScanRunResultProviderMock.reset();
 
             onDemandPageScanRunResultProviderMock
-                .setup(async om => om.readScanRuns([scanId]))
+                .setup(async om => om.readScanRuns([scanId], contextAwareLoggerMock.object))
                 .returns(async () => {
                     return Promise.resolve([dbResponse]);
                 })

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -153,7 +153,9 @@ function setupOnDemandPageScanRunResultProviderMock(documents: OnDemandPageScanB
                     batchRequestId: document.id,
                 };
             });
-        onDemandPageScanRunResultProviderMock.setup(async o => o.writeScanRuns(dbDocuments)).verifiable(Times.once());
+        onDemandPageScanRunResultProviderMock
+            .setup(async o => o.writeScanRuns(dbDocuments, contextAwareLoggerMock.object))
+            .verifiable(Times.once());
     });
 }
 
@@ -170,8 +172,8 @@ function setupPageScanRequestProviderMock(documents: OnDemandPageScanBatchReques
                     partitionKey: PartitionKey.pageScanRequestDocuments,
                 };
             });
-        pageScanRequestProviderMock.setup(async o => o.insertRequests(dbDocuments)).verifiable(Times.once());
-        scanDataProviderMock.setup(async o => o.deleteBatchRequest(document)).verifiable(Times.once());
+        pageScanRequestProviderMock.setup(async o => o.insertRequests(dbDocuments, contextAwareLoggerMock.object)).verifiable(Times.once());
+        scanDataProviderMock.setup(async o => o.deleteBatchRequest(document, contextAwareLoggerMock.object)).verifiable(Times.once());
     });
 }
 
@@ -189,8 +191,10 @@ function setupPartitionKeyFactoryMock(documents: OnDemandPageScanBatchRequest[])
 }
 
 function setupMocksWithTimesNever(): void {
-    onDemandPageScanRunResultProviderMock.setup(async o => o.writeScanRuns(It.isAny())).verifiable(Times.never());
-    pageScanRequestProviderMock.setup(async o => o.insertRequests(It.isAny())).verifiable(Times.never());
-    scanDataProviderMock.setup(async o => o.deleteBatchRequest(It.isAny())).verifiable(Times.never());
+    onDemandPageScanRunResultProviderMock
+        .setup(async o => o.writeScanRuns(It.isAny(), contextAwareLoggerMock.object))
+        .verifiable(Times.never());
+    pageScanRequestProviderMock.setup(async o => o.insertRequests(It.isAny(), contextAwareLoggerMock.object)).verifiable(Times.never());
+    scanDataProviderMock.setup(async o => o.deleteBatchRequest(It.isAny(), contextAwareLoggerMock.object)).verifiable(Times.never());
     partitionKeyFactoryMock.setup(o => o.createPartitionKeyForDocument(It.isAny(), It.isAny())).verifiable(Times.never());
 }

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -78,7 +78,7 @@ export class ScanBatchRequestFeedController extends WebController {
         if (requests.length > 0) {
             await this.writeRequestsToPermanentContainer(requests, batchDocument.id);
             await this.writeRequestsToQueueContainer(requests, batchDocument.id);
-            await this.scanDataProvider.deleteBatchRequest(batchDocument);
+            await this.scanDataProvider.deleteBatchRequest(batchDocument, this.contextAwareLogger);
             this.contextAwareLogger.logInfo(
                 `[ScanBatchRequestFeedController] deleted batch request document ${batchDocument.id}`,
                 this.getLogPropertiesForRequests(requests, batchDocument.id),
@@ -104,7 +104,7 @@ export class ScanBatchRequestFeedController extends WebController {
             };
         });
 
-        await this.onDemandPageScanRunResultProvider.writeScanRuns(requestDocuments);
+        await this.onDemandPageScanRunResultProvider.writeScanRuns(requestDocuments, this.contextAwareLogger);
         this.contextAwareLogger.logInfo(
             `[ScanBatchRequestFeedController] Added requests to permanent container`,
             this.getLogPropertiesForRequests(requests, batchRequestId),
@@ -122,7 +122,7 @@ export class ScanBatchRequestFeedController extends WebController {
             };
         });
 
-        await this.pageScanRequestProvider.insertRequests(requestDocuments);
+        await this.pageScanRequestProvider.insertRequests(requestDocuments, this.contextAwareLogger);
         this.contextAwareLogger.logInfo(
             `[ScanBatchRequestFeedController] Added requests to queue container`,
             this.getLogPropertiesForRequests(requests, batchRequestId),


### PR DESCRIPTION
#### Description of changes
Currently we are using global logger in cosmos clients. this makes it difficult to debug for issues caused by a particular scan. As part of this PR, cosmos clients no longer takes logger in constructor.
We pass the logger every time we access any methods of cosmos clients.

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
