### PR TITLE
Add query timespan to serviceConfig

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -19,6 +19,9 @@ Object {
       "format": "url",
     },
   },
+  "e2eTestConfig": Object {
+    "testRunQueryTimespan": "PT30M",
+  },
   "jobManagerConfig": Object {
     "activeToRunningTasksRatio": Object {
       "default": 3,
@@ -169,6 +172,9 @@ Object {
       "doc": "Url to scan for availability testing",
       "format": "url",
     },
+  },
+  "e2eTestConfig": Object {
+    "testRunQueryTimespan": "PT30M",
   },
   "jobManagerConfig": Object {
     "activeToRunningTasksRatio": Object {

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -47,12 +47,17 @@ export interface RuntimeConfig {
     jobManagerConfig: JobManagerConfig;
     restApiConfig: RestApiConfig;
     availabilityTestConfig: AvailabilityTestConfig;
+    e2eTestConfig: E2ETestConfig;
 }
 
 export interface AvailabilityTestConfig {
     urlToScan: string;
     scanWaitIntervalInSeconds: number;
     maxScanWaitTimeInSeconds: number;
+}
+
+export interface E2ETestConfig {
+    testRunQueryTimespan: string;
 }
 
 @injectable()
@@ -248,6 +253,9 @@ export class ServiceConfiguration {
                     default: 60,
                     doc: 'Time to wait before checking the url scan status again',
                 },
+            },
+            e2eTestConfig: {
+                testRunQueryTimespan: 'PT30M',
             },
         };
     }

--- a/packages/web-api/src/controllers/health-check-controller.spec.ts
+++ b/packages/web-api/src/controllers/health-check-controller.spec.ts
@@ -17,6 +17,9 @@ describe(HealthCheckController, () => {
     let serviceConfigurationMock: IMock<ServiceConfiguration>;
     let loggerMock: IMock<MockableLogger>;
     let appInsightsClientMock: IMock<ApplicationInsightsClient>;
+    const e2eTestConfig = {
+        testRunQueryTimespan: 'timespan',
+    };
 
     beforeEach(() => {
         context = <Context>(<unknown>{
@@ -30,6 +33,7 @@ describe(HealthCheckController, () => {
         });
 
         serviceConfigurationMock = Mock.ofType<ServiceConfiguration>();
+        serviceConfigurationMock.setup(async s => s.getConfigValue('e2eTestConfig')).returns(async () => Promise.resolve(e2eTestConfig));
 
         loggerMock = Mock.ofType<MockableLogger>();
         appInsightsClientMock = Mock.ofType(ApplicationInsightsClient);

--- a/packages/web-api/src/controllers/health-check-controller.ts
+++ b/packages/web-api/src/controllers/health-check-controller.ts
@@ -11,7 +11,6 @@ import { ApplicationInsightsClientProvider, webApiTypeNames } from '../web-api-t
 export class HealthCheckController extends ApiController {
     public readonly apiVersion = '1.0';
     public readonly apiName = 'web-api-health-check';
-    private readonly queryTimespan = 'PT6H';
 
     public constructor(
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
@@ -34,8 +33,9 @@ export class HealthCheckController extends ApiController {
             testsFailed: 0,
         };
 
+        const e2eTestConfig = await this.serviceConfig.getConfigValue('e2eTestConfig');
         const queryString = 'customEvents | limit 5';
-        const queryResponse = await appInsightsClient.executeQuery(queryString, this.queryTimespan);
+        const queryResponse = await appInsightsClient.executeQuery(queryString, e2eTestConfig.testRunQueryTimespan);
         if (queryResponse.statusCode === 200) {
             this.logger.logInfo(`App insights api queried with result ${JSON.stringify(queryResponse)}`);
         } else {


### PR DESCRIPTION
#### Description of changes

Reduce timespan queried for e2e test runs and make this value configurable

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
