### PR TITLE
Log response body only

### DIFF
--- a/packages/health-client/src/health-checker.ts
+++ b/packages/health-client/src/health-checker.ts
@@ -43,7 +43,7 @@ setTimeout(async () => {
 
             const response = await client.checkHealth(`/release/${argv.releaseId}`);
             if (response.statusCode !== 200) {
-                throw new Error(JSON.stringify(response));
+                throw new Error(JSON.stringify(response.body));
             }
 
             console.log(`[health-client] Functional tests result: ${JSON.stringify(response.body)}`);


### PR DESCRIPTION
#### Description of changes

When request fails, if we log the whole response object it will include the request itself which contains the bearer token, we do not want the token to be logged in the pipeline. 
The response body has enough info already.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
