### PR TITLE
adding timeout for scaning

### DIFF
--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -293,12 +293,13 @@ components:
                         - UrlNavigationTimeout
                         - HttpErrorCode
                         - SslError
-                        - MainResourceLoadFailure
+                        - ResourceLoadFailure
                         - InvalidUrl
                         - EmptyPage
                         - NavigationError
                         - InvalidContentType
                         - UrlNotResolved
+                        - ScanTimeout
                 codeId:
                     type: integer
                     format: int32

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -150,10 +150,15 @@ Object {
       "doc": "Minimum days since we last scanned. Pages newer than this time will not be scanned.",
       "format": "int",
     },
+    "scanTimeoutInMin": Object {
+      "default": 3,
+      "doc": "Maximum allowed time for scanning a web page in minutes",
+      "format": "int",
+    },
   },
   "taskConfig": Object {
     "taskTimeoutInMinutes": Object {
-      "default": 3,
+      "default": 5,
       "doc": "Timeout value after which the task has to be terminated",
       "format": "int",
     },
@@ -311,10 +316,15 @@ Object {
       "doc": "Minimum days since we last scanned. Pages newer than this time will not be scanned.",
       "format": "int",
     },
+    "scanTimeoutInMin": Object {
+      "default": 3,
+      "doc": "Maximum allowed time for scanning a web page in minutes",
+      "format": "int",
+    },
   },
   "taskConfig": Object {
     "taskTimeoutInMinutes": Object {
-      "default": 3,
+      "default": 5,
       "doc": "Timeout value after which the task has to be terminated",
       "format": "int",
     },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -30,6 +30,7 @@ export interface ScanRunTimeConfig {
     failedPageRescanIntervalInHours: number;
     maxScanRetryCount: number;
     accessibilityRuleExclusionList: string[];
+    scanTimeoutInMin: number;
 }
 
 export interface RestApiConfig {
@@ -122,7 +123,7 @@ export class ServiceConfiguration {
             taskConfig: {
                 taskTimeoutInMinutes: {
                     format: 'int',
-                    default: 3,
+                    default: 5,
                     doc: 'Timeout value after which the task has to be terminated',
                 },
             },
@@ -206,6 +207,11 @@ export class ServiceConfiguration {
                         'landmark-unique',
                     ],
                     doc: 'Axe core rule exclusion list',
+                },
+                scanTimeoutInMin: {
+                    default: 3,
+                    format: 'int',
+                    doc: 'Maximum allowed time for scanning a web page in minutes',
                 },
             },
             restApiConfig: {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -17,3 +17,5 @@ export {
     LogRuntimeConfig,
 } from './configuration/service-configuration';
 export { setupRuntimeConfigContainer } from './setup-runtime-config-container';
+
+export { PromiseUtils } from './system/promise-utils';

--- a/packages/common/src/system/promise-utils.spec.ts
+++ b/packages/common/src/system/promise-utils.spec.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+import { PromiseUtils } from './promise-utils';
+
+describe(PromiseUtils, () => {
+    let testSubject: PromiseUtils;
+
+    beforeEach(() => {
+        testSubject = new PromiseUtils();
+    });
+
+    describe('waitFor', () => {
+        it('returns resolved promise', async () => {
+            const resolvedValue = 'resolved promise value';
+
+            const promise = new Promise<string>(resolve => {
+                resolve(resolvedValue);
+            });
+
+            const startTime = +new Date();
+            const result = await testSubject.waitFor(promise, 10000, () => Promise.resolve('timed out value'));
+
+            expect(result).toBe(resolvedValue);
+            expect(+new Date() - startTime).toBeLessThan(1000);
+        });
+
+        it('returns rejected promise', async () => {
+            const rejectedValue = 'rejected promise value';
+            let exceptionThrown = false;
+
+            const promise = new Promise<string>((resolve, reject) => {
+                reject(rejectedValue);
+            });
+
+            const startTime = +new Date();
+            try {
+                await testSubject.waitFor(promise, 10000, () => Promise.resolve('timed out value'));
+            } catch (error) {
+                exceptionThrown = true;
+                expect(error).toBe(rejectedValue);
+            }
+
+            expect(exceptionThrown).toBe(true);
+            expect(+new Date() - startTime).toBeLessThan(1000);
+        });
+
+        it('returns resolved timed out promise', async () => {
+            let resolvePromise: Function;
+            const timeoutValue = 'timed out value';
+
+            // tslint:disable-next-line: promise-must-complete
+            const promise = new Promise<string>(resolve => {
+                resolvePromise = resolve;
+            });
+
+            const result = await testSubject.waitFor(promise, 10, () => Promise.resolve(timeoutValue));
+
+            expect(result).toBe(timeoutValue);
+        });
+
+        it('returns rejected timed out promise', async () => {
+            let resolvePromise: Function;
+            const timeoutValue = 'timed out value';
+            let exceptionThrown = false;
+
+            // tslint:disable-next-line: promise-must-complete
+            const promise = new Promise<string>(resolve => {
+                resolvePromise = resolve;
+            });
+
+            try {
+                await testSubject.waitFor(promise, 10, () => Promise.reject(timeoutValue));
+            } catch (error) {
+                exceptionThrown = true;
+                resolvePromise();
+                expect(error).toBe(timeoutValue);
+            }
+
+            expect(exceptionThrown).toBe(true);
+        });
+    });
+});

--- a/packages/common/src/system/promise-utils.ts
+++ b/packages/common/src/system/promise-utils.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { injectable } from 'inversify';
+
+@injectable()
+export class PromiseUtils {
+    public async waitFor<T, Y>(promise: Promise<T>, timeoutInMilliSec: number, onTimeoutCallback: () => Promise<Y>): Promise<T | Y> {
+        let timeoutHandle: NodeJS.Timeout;
+        let hasTimedOut = false;
+
+        const timeoutPromise = new Promise<Y>((resolve, reject) => {
+            timeoutHandle = setTimeout(() => {
+                hasTimedOut = true;
+                resolve();
+            }, timeoutInMilliSec);
+        });
+
+        const racePromise = Promise.race([promise, timeoutPromise]);
+
+        try {
+            await racePromise;
+        } finally {
+            clearTimeout(timeoutHandle);
+        }
+
+        if (hasTimedOut) {
+            return onTimeoutCallback();
+        }
+
+        return promise;
+    }
+}

--- a/packages/scanner/src/axe-scan-results.ts
+++ b/packages/scanner/src/axe-scan-results.ts
@@ -11,7 +11,8 @@ export type ScanErrorTypes =
     | 'HttpErrorCode'
     | 'NavigationError'
     | 'InvalidContentType'
-    | 'UrlNotResolved';
+    | 'UrlNotResolved'
+    | 'ScanTimeout';
 
 export interface ScanError {
     errorType: ScanErrorTypes;

--- a/packages/scanner/src/factories/axe-puppeteer-factory.spec.ts
+++ b/packages/scanner/src/factories/axe-puppeteer-factory.spec.ts
@@ -19,6 +19,7 @@ describe('AxePuppeteerFactory', () => {
             minLastReferenceSeenInDays: 5,
             pageRescanIntervalInDays: 6,
             accessibilityRuleExclusionList: [],
+            scanTimeoutInMin: 1,
         };
         serviceConfigMock = Mock.ofType(ServiceConfiguration);
         serviceConfigMock.setup(async s => s.getConfigValue('scanConfig')).returns(async () => scanConfig);

--- a/packages/scanner/src/scanner.spec.ts
+++ b/packages/scanner/src/scanner.spec.ts
@@ -4,49 +4,113 @@
 import 'reflect-metadata';
 
 import { AxeResults } from 'axe-core';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { MockableLogger } from './test-utilities/mockable-logger';
 
+import { PromiseUtils, ScanRunTimeConfig, ServiceConfiguration } from 'common';
 import { AxeScanResults } from './axe-scan-results';
 import { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';
 import { Page } from './page';
 import { Scanner } from './scanner';
+
+// tslint:disable: no-object-literal-type-assertion no-unsafe-any
 
 describe('Scanner', () => {
     let pageMock: IMock<Page>;
     let scanner: Scanner;
     let axeBrowserFactoryMock: IMock<AxePuppeteerFactory>;
     let loggerMock: IMock<MockableLogger>;
+    let serviceConfigMock: IMock<ServiceConfiguration>;
+    let promiseUtilsMock: IMock<PromiseUtils>;
+    let scanConfig: ScanRunTimeConfig;
 
     beforeEach(() => {
         axeBrowserFactoryMock = Mock.ofType();
         pageMock = Mock.ofType2<Page>(Page, [axeBrowserFactoryMock.object]);
         loggerMock = Mock.ofType(MockableLogger);
-        scanner = new Scanner(pageMock.object, loggerMock.object);
+        serviceConfigMock = Mock.ofType(ServiceConfiguration);
+        promiseUtilsMock = Mock.ofType(PromiseUtils);
+
+        scanConfig = {
+            scanTimeoutInMin: 5,
+        } as ScanRunTimeConfig;
+
+        scanner = new Scanner(pageMock.object, loggerMock.object, promiseUtilsMock.object, serviceConfigMock.object);
     });
 
     it('should create instance', () => {
         expect(scanner).not.toBeNull();
     });
 
-    it('should launch browser page with given url and scan the page with axe-core', async () => {
-        const url = 'some url';
-        const axeResultsStub = ('axe results' as any) as AxeResults;
-        setupNewPageCall(url);
-        setupPageScanCall(url, axeResultsStub);
-        await scanner.scan(url);
+    describe('scan', () => {
+        beforeEach(() => {
+            serviceConfigMock.setup(s => s.getConfigValue('scanConfig')).returns(() => Promise.resolve(scanConfig));
+        });
 
-        verifyMocks();
-    });
+        it('should launch browser page with given url and scan the page with axe-core', async () => {
+            const url = 'some url';
+            const axeResultsStub = ('axe results' as any) as AxeResults;
+            setupNewPageCall(url);
+            setupPageScanCall(url, axeResultsStub);
 
-    it('should close browser if exception occurs', async () => {
-        const url = 'some url';
-        const errorMessage: string = `An error occurred while scanning website page ${url}.`;
-        setupNewPageCall(url);
-        setupPageErrorScanCall(url, errorMessage);
-        setupPageCloseCall();
-        const scanResult: AxeScanResults = await scanner.scan(url);
-        expect(scanResult.error).not.toBeNull();
+            setupWaitForPromisetoReturnOriginalPromise();
+            await scanner.scan(url);
+
+            verifyMocks();
+        });
+
+        it('should close browser if exception occurs', async () => {
+            const url = 'some url';
+            const errorMessage: string = `An error occurred while scanning website page ${url}.`;
+            setupNewPageCall(url);
+            setupPageErrorScanCall(url, errorMessage);
+            setupPageCloseCall();
+            setupWaitForPromisetoReturnOriginalPromise();
+
+            const scanResult: AxeScanResults = await scanner.scan(url);
+            expect(scanResult.error).not.toBeNull();
+
+            verifyMocks();
+        });
+
+        it('should return timeout promise', async () => {
+            const url = 'some url';
+            const errorMessage: string = `An error occurred while scanning website page ${url}.`;
+            setupNewPageCall(url);
+            setupPageErrorScanCall(url, errorMessage);
+            setupPageCloseCall();
+            setupWaitForPromiseToReturnTimeoutPromise();
+
+            const scanResult: AxeScanResults = await scanner.scan(url);
+            expect(scanResult).toEqual({
+                error: {
+                    errorType: 'ScanTimeout',
+                    message: `Scan timed out after ${scanConfig.scanTimeoutInMin} minutes`,
+                },
+                pageResponseCode: undefined,
+            } as AxeScanResults);
+
+            pageMock.reset();
+            verifyMocks();
+        });
+
+        function setupWaitForPromisetoReturnOriginalPromise(): void {
+            promiseUtilsMock
+                .setup(s => s.waitFor(It.isAny(), scanConfig.scanTimeoutInMin * 60000, It.isAny()))
+                .returns(async (scanPromiseObj, timeout, timeoutCb) => {
+                    return scanPromiseObj;
+                })
+                .verifiable();
+        }
+
+        function setupWaitForPromiseToReturnTimeoutPromise(): void {
+            promiseUtilsMock
+                .setup(s => s.waitFor(It.isAny(), scanConfig.scanTimeoutInMin * 60000, It.isAny()))
+                .returns(async (scanPromiseObj, timeout, timeoutCb) => {
+                    return timeoutCb();
+                })
+                .verifiable();
+        }
     });
 
     function setupNewPageCall(url: string): void {
@@ -74,5 +138,6 @@ describe('Scanner', () => {
 
     function verifyMocks(): void {
         pageMock.verifyAll();
+        promiseUtilsMock.verifyAll();
     }
 });

--- a/packages/service-library/src/data-providers/page-document-provider.db.spec.ts
+++ b/packages/service-library/src/data-providers/page-document-provider.db.spec.ts
@@ -64,6 +64,7 @@ describe(PageDocumentProvider, () => {
                 maxScanRetryCount: 4,
                 minLastReferenceSeenInDays: 5,
                 accessibilityRuleExclusionList: [],
+                scanTimeoutInMin: 1,
             };
             serviceConfigMock = Mock.ofType(ServiceConfiguration);
             serviceConfigMock.setup(async s => s.getConfigValue('scanConfig')).returns(async () => scanConfig);

--- a/packages/service-library/src/data-providers/page-document-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-document-provider.spec.ts
@@ -37,6 +37,7 @@ describe('PageDocumentProvider', () => {
             minLastReferenceSeenInDays: 5,
             pageRescanIntervalInDays: 6,
             accessibilityRuleExclusionList: [],
+            scanTimeoutInMin: 1,
         };
 
         cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();

--- a/packages/service-library/src/web-api/scan-run-error-codes.ts
+++ b/packages/service-library/src/web-api/scan-run-error-codes.ts
@@ -13,7 +13,8 @@ export declare type ScanRunErrorCodeName =
     | 'EmptyPage'
     | 'NavigationError'
     | 'InvalidContentType'
-    | 'UrlNotResolved';
+    | 'UrlNotResolved'
+    | 'ScanTimeout';
 
 export interface ScanRunErrorCode {
     // This type is part of the REST API client response.
@@ -84,6 +85,12 @@ export class ScanRunErrorCodes {
         codeId: 9010,
         message: 'URL cannot be reached',
     };
+
+    public static scanTimedOut: ScanRunErrorCode = {
+        code: 'ScanTimeout',
+        codeId: 9011,
+        message: 'Unable to complete scan before maximum timeout value',
+    };
 }
 
 export const scanErrorNameToErrorMap: { [key in ScanRunErrorCodeName]: ScanRunErrorCode } = {
@@ -97,4 +104,5 @@ export const scanErrorNameToErrorMap: { [key in ScanRunErrorCodeName]: ScanRunEr
     NavigationError: ScanRunErrorCodes.navigationError,
     InvalidContentType: ScanRunErrorCodes.invalidContentType,
     UrlNotResolved: ScanRunErrorCodes.urlNotResolved,
+    ScanTimeout: ScanRunErrorCodes.scanTimedOut,
 };

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -16,7 +16,8 @@ export type ScanErrorTypes =
     | 'HttpErrorCode'
     | 'NavigationError'
     | 'InvalidContentType'
-    | 'UrlNotResolved';
+    | 'UrlNotResolved'
+    | 'ScanTimeout';
 
 export interface ScanError {
     errorType: ScanErrorTypes;


### PR DESCRIPTION
#### Description of changes
This PR adds a timeout around scanning. If configured timeout is reached, the scanner completes with a successful promise object that contains error object set to scanTimeout.

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
