### PR TITLE
Validate the timestamp in the guid

### DIFF
--- a/packages/functional-tests/src/test-groups/scan-status-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-status-test-group.ts
@@ -27,12 +27,12 @@ export class ScanStatusTestGroup extends FunctionalTestGroup {
         this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, response);
     }
 
-    // Currently fails because of five minute wait (it assumes the scan id is valid and status was requested too early)
-    @test(TestEnvironment.none)
+    @test(TestEnvironment.all)
     public async testGetScanStatusWithInvalidScanId(): Promise<void> {
+        //Guid with a timestamp in 2607.
         const invalidGuid: string = '47cd7291-a928-6c96-bdb8-4be18b5a1305';
         const response = await this.a11yServiceClient.getScanStatus(invalidGuid);
 
-        this.expectWebApiErrorResponse(WebApiErrorCodes.resourceNotFound, response);
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, response);
     }
 }

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -59,6 +59,7 @@
         "reflect-metadata": "^0.1.13",
         "service-library": "1.0.0",
         "storage-documents": "1.0.0",
+        "moment": "2.24.0",
         "request": "^2.88.0",
         "functional-tests": "1.0.0"
     }

--- a/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
@@ -4,6 +4,7 @@ import 'reflect-metadata';
 
 import { Context } from '@azure/functions';
 import { GuidGenerator, RestApiConfig, ServiceConfiguration } from 'common';
+import * as moment from 'moment';
 import { OnDemandPageScanRunResultProvider, ScanBatchRequest, ScanResultResponse } from 'service-library';
 import { ItemType, OnDemandPageScanResult } from 'storage-documents';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -111,15 +112,16 @@ describe(BatchScanResultController, () => {
         guidGeneratorMock
             .setup(gm => gm.getGuidTimestamp(scanId))
             .returns(() => time)
-            .verifiable(Times.once());
+            .verifiable(Times.atLeast(1));
     }
 
     describe('handleRequest', () => {
         it('should return different response for different kind of scanIds', async () => {
             context.req.rawBody = JSON.stringify(batchRequestBody);
             batchScanResultController = createScanResultController(context);
-            const requestTooSoonTimeStamp = new Date();
-            requestTooSoonTimeStamp.setFullYear(requestTooSoonTimeStamp.getFullYear() + 1);
+            const requestTooSoonTimeStamp = moment()
+                .subtract(1)
+                .toDate();
             const validTimeStamp = new Date(0);
 
             setupGetGuidTimestamp(validScanId, validTimeStamp);

--- a/packages/web-api/src/controllers/scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.spec.ts
@@ -146,6 +146,20 @@ describe(ScanResultController, () => {
             expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
         });
 
+        it('should return a default response for requests made within 10 sec buffer', async () => {
+            scanResultController = createScanResultController(context);
+            const timeStamp = moment()
+                .add(1, 'second')
+                .toDate();
+            setupGetGuidTimestamp(timeStamp);
+
+            await scanResultController.handleRequest();
+
+            guidGeneratorMock.verifyAll();
+            expect(context.res.status).toEqual(200);
+            expect(context.res.body).toEqual(tooSoonRequestResponse);
+        });
+
         it('should return a default response for requests made too early', async () => {
             scanResultController = createScanResultController(context);
             const timeStamp = moment()


### PR DESCRIPTION
#### Description of changes

Validate the timestamp in the guid is in the past and return invalid guid response if it's not.
Also since we are using moment for time manipulation, I replaced some Date usage with moment.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
