### PR TITLE
Set HTTP response header 'X-Content-Type-Options' to 'nosniff'

### DIFF
--- a/packages/resource-deployment/scripts/function-app-create.sh
+++ b/packages/resource-deployment/scripts/function-app-create.sh
@@ -47,7 +47,7 @@ installAzureFunctionsCoreToolsOnLinux() {
 
     echo "Installing Azure Functions Core Tools..."
     # Install the Microsoft package repository GPG key, to validate package integrity
-    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >microsoft.gpg
+    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
     sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 
     # Verify your Ubuntu server is running one of the appropriate versions from the table below. To add the apt source, run
@@ -55,7 +55,7 @@ installAzureFunctionsCoreToolsOnLinux() {
     sudo apt-get update
 
     # Install the Core Tools package
-    sudo apt-get install azure-functions-core-tools
+    sudo apt-get install azure-functions-core-tools=2.7.1948-1
     echo "Azure Functions Core Tools installed successfully"
 }
 

--- a/packages/service-library/src/web-api/web-controller.spec.ts
+++ b/packages/service-library/src/web-api/web-controller.spec.ts
@@ -88,6 +88,7 @@ describe(WebController, () => {
     it('should add content-type response header if no any', async () => {
         await testSubject.invoke(context, 'valid');
         expect(testSubject.context.res.headers['content-type']).toEqual('application/json; charset=utf-8');
+        expect(testSubject.context.res.headers['X-Content-Type-Options']).toEqual('nosniff');
     });
 
     it('should add content-type response header if if other', async () => {
@@ -96,6 +97,7 @@ describe(WebController, () => {
         };
         await testSubject.invoke(context, 'valid');
         expect(testSubject.context.res.headers['content-type']).toEqual('application/json; charset=utf-8');
+        expect(testSubject.context.res.headers['X-Content-Type-Options']).toEqual('nosniff');
     });
 
     it('should skip adding content-type response header if any', async () => {

--- a/packages/service-library/src/web-api/web-controller.ts
+++ b/packages/service-library/src/web-api/web-controller.ts
@@ -58,11 +58,11 @@ export abstract class WebController {
             if (this.context.res.headers === undefined) {
                 this.context.res.headers = {
                     'content-type': jsonContentType,
-                    // 'X-Content-Type-Options': 'nosniff',
+                    'X-Content-Type-Options': 'nosniff',
                 };
             } else if (this.context.res.headers['content-type'] === undefined) {
                 this.context.res.headers['content-type'] = jsonContentType;
-                // this.context.res.headers['X-Content-Type-Options'] = 'nosniff';
+                this.context.res.headers['X-Content-Type-Options'] = 'nosniff';
             }
         }
     }

--- a/packages/service-library/src/web-api/web-controller.ts
+++ b/packages/service-library/src/web-api/web-controller.ts
@@ -58,9 +58,11 @@ export abstract class WebController {
             if (this.context.res.headers === undefined) {
                 this.context.res.headers = {
                     'content-type': jsonContentType,
+                    'X-Content-Type-Options': 'nosniff',
                 };
             } else if (this.context.res.headers['content-type'] === undefined) {
                 this.context.res.headers['content-type'] = jsonContentType;
+                this.context.res.headers['X-Content-Type-Options'] = 'nosniff';
             }
         }
     }

--- a/packages/service-library/src/web-api/web-controller.ts
+++ b/packages/service-library/src/web-api/web-controller.ts
@@ -58,11 +58,11 @@ export abstract class WebController {
             if (this.context.res.headers === undefined) {
                 this.context.res.headers = {
                     'content-type': jsonContentType,
-                    'X-Content-Type-Options': 'nosniff',
+                    // 'X-Content-Type-Options': 'nosniff',
                 };
             } else if (this.context.res.headers['content-type'] === undefined) {
                 this.context.res.headers['content-type'] = jsonContentType;
-                this.context.res.headers['X-Content-Type-Options'] = 'nosniff';
+                // this.context.res.headers['X-Content-Type-Options'] = 'nosniff';
             }
         }
     }


### PR DESCRIPTION
#### Description of changes
Set 'X-Content-Type-Options' to 'nosniff' 
Required as a part of our compliance process, on-boarding to web-scout tool.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
