### PR TITLE
Downgrade Azure Functions Core Tool to 2.7.1948-1

### DIFF
--- a/packages/resource-deployment/scripts/function-app-create.sh
+++ b/packages/resource-deployment/scripts/function-app-create.sh
@@ -55,7 +55,7 @@ installAzureFunctionsCoreToolsOnLinux() {
     sudo apt-get update
 
     # Install the Core Tools package
-    sudo apt-get install azure-functions-core-tools
+    sudo apt-get install azure-functions-core-tools=2.7.1948-1
     echo "Azure Functions Core Tools installed successfully"
 }
 


### PR DESCRIPTION
#### Description of changes
- So we are downgrading the Azure Function Core Tool version to avoid this issue for now: https://github.com/Azure/azure-functions-core-tools/issues/1793
- We should revert this change once this PR is merged: https://github.com/Azure/azure-functions-core-tools/issues/1793
 
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
