### PR TITLE
chore: Use node banner plugin only for CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js --colors",

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -43,7 +43,7 @@ function getCommonConfig(version, generateTypings) {
             ],
         },
         plugins: [
-            new webpack.BannerPlugin({ banner: (generateTypings ? '' : '#!/usr/bin/env node'), raw: true }),
+            new webpack.BannerPlugin({ banner: generateTypings ? '' : '#!/usr/bin/env node', raw: true }),
             new webpack.DefinePlugin({
                 __IMAGE_VERSION__: JSON.stringify(version),
             }),

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -43,7 +43,7 @@ function getCommonConfig(version, generateTypings) {
             ],
         },
         plugins: [
-            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true }),
+            new webpack.BannerPlugin({ banner: (generateTypings ? '' : '#!/usr/bin/env node'), raw: true }),
             new webpack.DefinePlugin({
                 __IMAGE_VERSION__: JSON.stringify(version),
             }),


### PR DESCRIPTION
#### Description of changes

- Remove '#!/usr/bin/env node' banner from the library.
- Increase tje minor version to push a new release.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
