### PR TITLE
chore: Add a parameter for axe source code file path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js --colors",

--- a/packages/cli/src/factories/axe-puppeteer-factory.spec.ts
+++ b/packages/cli/src/factories/axe-puppeteer-factory.spec.ts
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxePuppeteer } from 'axe-puppeteer';
+import * as fs from 'fs';
 import * as Puppeteer from 'puppeteer';
 import 'reflect-metadata';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { AxePuppeteerFactory } from './axe-puppeteer-factory';
 
 describe('AxePuppeteerFactory', () => {
-    let page: IMock<Puppeteer.Page>;
     let testSubject: AxePuppeteerFactory;
+    let page: IMock<Puppeteer.Page>;
+    let fsMock: IMock<typeof fs>;
     beforeEach(() => {
         page = Mock.ofType<Puppeteer.Page>();
-        testSubject = new AxePuppeteerFactory();
+        fsMock = Mock.ofInstance(fs, MockBehavior.Strict);
+        testSubject = new AxePuppeteerFactory(fsMock.object);
     });
     it('create axe puppeteer instance', async () => {
         const axePuppeteer = await testSubject.createAxePuppeteer(page.object);
@@ -20,6 +23,19 @@ describe('AxePuppeteerFactory', () => {
     });
     it('create axe puppeteer instance, sourcePath is empty', async () => {
         const axePuppeteer = await testSubject.createAxePuppeteer(page.object, '');
+        expect(axePuppeteer).toBeDefined();
+        expect(axePuppeteer).toBeInstanceOf(AxePuppeteer);
+    });
+    it('create axe puppeteer instance, sourcePath is not empty', async () => {
+        const path = 'path';
+        // tslint:disable-next-line:no-shadowed-variable
+        const content = 'content';
+        fsMock
+            .setup(fsm => fsm.readFileSync(path))
+            // tslint:disable-next-line: no-any
+            .returns(() => content as any)
+            .verifiable(Times.once());
+        const axePuppeteer = await testSubject.createAxePuppeteer(page.object, path);
         expect(axePuppeteer).toBeDefined();
         expect(axePuppeteer).toBeInstanceOf(AxePuppeteer);
     });

--- a/packages/cli/src/factories/axe-puppeteer-factory.spec.ts
+++ b/packages/cli/src/factories/axe-puppeteer-factory.spec.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import AxePuppeteer from 'axe-puppeteer';
+import { AxePuppeteer } from 'axe-puppeteer';
 import * as Puppeteer from 'puppeteer';
 import 'reflect-metadata';
 import { IMock, Mock } from 'typemoq';
@@ -15,6 +15,11 @@ describe('AxePuppeteerFactory', () => {
     });
     it('create axe puppeteer instance', async () => {
         const axePuppeteer = await testSubject.createAxePuppeteer(page.object);
+        expect(axePuppeteer).toBeDefined();
+        expect(axePuppeteer).toBeInstanceOf(AxePuppeteer);
+    });
+    it('create axe puppeteer instance, sourcePath is empty', async () => {
+        const axePuppeteer = await testSubject.createAxePuppeteer(page.object, '');
         expect(axePuppeteer).toBeDefined();
         expect(axePuppeteer).toBeInstanceOf(AxePuppeteer);
     });

--- a/packages/cli/src/factories/axe-puppeteer-factory.ts
+++ b/packages/cli/src/factories/axe-puppeteer-factory.ts
@@ -11,12 +11,11 @@ import { RuleExclusion } from './rule-exclusion';
 @injectable()
 export class AxePuppeteerFactory {
     public async createAxePuppeteer(page: Puppeteer.Page, sourcePath?: string): Promise<AxePuppeteer> {
-        let content;
         const ruleExclusionList = new RuleExclusion();
 
         if (!isNil(sourcePath) && !isEmpty(sourcePath)) {
             // tslint:disable-next-line: non-literal-fs-path
-            content = fs.readFileSync(sourcePath);
+            const content = fs.readFileSync(sourcePath);
 
             return new AxePuppeteer(page, content.toString()).disableRules(ruleExclusionList.accessibilityRuleExclusionList);
         }

--- a/packages/cli/src/factories/axe-puppeteer-factory.ts
+++ b/packages/cli/src/factories/axe-puppeteer-factory.ts
@@ -1,14 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxePuppeteer } from 'axe-puppeteer';
+import * as fs from 'fs';
 import { injectable } from 'inversify';
+import { isEmpty, isNil } from 'lodash';
+import * as path from 'path';
 import * as Puppeteer from 'puppeteer';
 import { RuleExclusion } from './rule-exclusion';
 
 @injectable()
 export class AxePuppeteerFactory {
-    public async createAxePuppeteer(page: Puppeteer.Page): Promise<AxePuppeteer> {
+    public async createAxePuppeteer(page: Puppeteer.Page, sourcePath?: string): Promise<AxePuppeteer> {
+        let content;
         const ruleExclusionList = new RuleExclusion();
+
+        if (!isNil(sourcePath) && !isEmpty(sourcePath)) {
+            // tslint:disable-next-line: non-literal-fs-path
+            content = fs.readFileSync(sourcePath);
+
+            return new AxePuppeteer(page, content.toString()).disableRules(ruleExclusionList.accessibilityRuleExclusionList);
+        }
 
         return new AxePuppeteer(page).disableRules(ruleExclusionList.accessibilityRuleExclusionList);
     }

--- a/packages/cli/src/factories/axe-puppeteer-factory.ts
+++ b/packages/cli/src/factories/axe-puppeteer-factory.ts
@@ -3,19 +3,20 @@
 import { AxePuppeteer } from 'axe-puppeteer';
 import * as fs from 'fs';
 import { injectable } from 'inversify';
-import { isEmpty, isNil } from 'lodash';
-import * as path from 'path';
+import { isEmpty } from 'lodash';
 import * as Puppeteer from 'puppeteer';
 import { RuleExclusion } from './rule-exclusion';
 
 @injectable()
 export class AxePuppeteerFactory {
+    constructor(private readonly fileSystemObj: typeof fs = fs) {}
+
     public async createAxePuppeteer(page: Puppeteer.Page, sourcePath?: string): Promise<AxePuppeteer> {
         const ruleExclusionList = new RuleExclusion();
 
-        if (!isNil(sourcePath) && !isEmpty(sourcePath)) {
+        if (!isEmpty(sourcePath)) {
             // tslint:disable-next-line: non-literal-fs-path
-            const content = fs.readFileSync(sourcePath);
+            const content = this.fileSystemObj.readFileSync(sourcePath);
 
             return new AxePuppeteer(page, content.toString()).disableRules(ruleExclusionList.accessibilityRuleExclusionList);
         }

--- a/packages/cli/src/scanner/ai-scanner.spec.ts
+++ b/packages/cli/src/scanner/ai-scanner.spec.ts
@@ -57,14 +57,14 @@ describe('AIScanner', () => {
 
     function setupPageScanCall(url: string, axeResults: AxeResults): void {
         pageMock
-            .setup(async p => p.scanForA11yIssues(url))
+            .setup(async p => p.scanForA11yIssues(url, undefined))
             .returns(async () => Promise.resolve({ results: axeResults }))
             .verifiable(Times.once());
     }
 
     function setupPageErrorScanCall(url: string, errorMessage: string): void {
         pageMock
-            .setup(async p => p.scanForA11yIssues(url))
+            .setup(async p => p.scanForA11yIssues(url, undefined))
             .returns(async () => Promise.resolve({ error: errorMessage }))
             .verifiable(Times.once());
     }

--- a/packages/cli/src/scanner/ai-scanner.ts
+++ b/packages/cli/src/scanner/ai-scanner.ts
@@ -10,14 +10,14 @@ import { Page } from './page';
 export class AIScanner {
     constructor(@inject(Page) private readonly page: Page) {}
 
-    public async scan(url: string, chromePath?: string): Promise<AxeScanResults> {
+    public async scan(url: string, chromePath?: string, sourcePath?: string): Promise<AxeScanResults> {
         try {
             console.log(`Starting accessibility scanning of URL ${url}.`);
 
             await this.page.create(chromePath);
             await this.page.enableBypassCSP();
 
-            return await this.page.scanForA11yIssues(url);
+            return await this.page.scanForA11yIssues(url, sourcePath);
         } catch (error) {
             console.log(error, `An error occurred while scanning website page ${url}.`);
 

--- a/packages/cli/src/scanner/page.spec.ts
+++ b/packages/cli/src/scanner/page.spec.ts
@@ -175,7 +175,7 @@ describe('Page', () => {
 
         axePuppeteerFactoryMock
             // tslint:disable-next-line: no-unsafe-any
-            .setup(async o => o.createAxePuppeteer(It.isAny()))
+            .setup(async o => o.createAxePuppeteer(It.isAny(), undefined))
             // tslint:disable-next-line: no-any
             .returns(async () => Promise.resolve({ analyze: async () => Promise.resolve(axeResults) } as any))
             .verifiable(Times.once());

--- a/packages/cli/src/scanner/page.ts
+++ b/packages/cli/src/scanner/page.ts
@@ -31,7 +31,7 @@ export class Page {
         return this.puppeteerPage.setBypassCSP(true);
     }
 
-    public async scanForA11yIssues(url: string): Promise<AxeScanResults> {
+    public async scanForA11yIssues(url: string, sourcePath?: string): Promise<AxeScanResults> {
         await this.puppeteerPage.setViewport({
             width: 1920,
             height: 1080,
@@ -90,7 +90,7 @@ export class Page {
             console.log(`Page still has network activity after the timeout ${networkLoadTimeoutInMilleSec} milliseconds`);
         }
 
-        const axePuppeteer: AxePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.puppeteerPage);
+        const axePuppeteer: AxePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.puppeteerPage, sourcePath);
         const axeResults = await axePuppeteer.analyze();
 
         const scanResults: AxeScanResults = {


### PR DESCRIPTION
#### Description of changes

Add a parameter for axe source code file path so we can use it in case calling the library through a GitHub action.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
