### PR TITLE
fix: wait till app insights log flush before process exit

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -160,7 +160,7 @@ Object {
     "exitOnComplete": Object {
       "default": false,
       "doc": "Temporary flag to unblock tasks that get stuck with open socket issue if happens",
-      "format": "boolean",
+      "format": "Boolean",
     },
     "taskTimeoutInMinutes": Object {
       "default": 5,
@@ -331,7 +331,7 @@ Object {
     "exitOnComplete": Object {
       "default": false,
       "doc": "Temporary flag to unblock tasks that get stuck with open socket issue if happens",
-      "format": "boolean",
+      "format": "Boolean",
     },
     "taskTimeoutInMinutes": Object {
       "default": 5,

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -157,6 +157,11 @@ Object {
     },
   },
   "taskConfig": Object {
+    "exitOnComplete": Object {
+      "default": false,
+      "doc": "Temporary flag to unblock tasks that get stuck with open socket issue if happens",
+      "format": "boolean",
+    },
     "taskTimeoutInMinutes": Object {
       "default": 5,
       "doc": "Timeout value after which the task has to be terminated",
@@ -323,6 +328,11 @@ Object {
     },
   },
   "taskConfig": Object {
+    "exitOnComplete": Object {
+      "default": false,
+      "doc": "Temporary flag to unblock tasks that get stuck with open socket issue if happens",
+      "format": "boolean",
+    },
     "taskTimeoutInMinutes": Object {
       "default": 5,
       "doc": "Timeout value after which the task has to be terminated",

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -7,6 +7,7 @@ import { isNil } from 'lodash';
 
 export interface TaskRuntimeConfig {
     taskTimeoutInMinutes: number;
+    exitOnComplete: boolean;
 }
 
 export interface QueueRuntimeConfig {
@@ -125,6 +126,11 @@ export class ServiceConfiguration {
                     format: 'int',
                     default: 5,
                     doc: 'Timeout value after which the task has to be terminated',
+                },
+                exitOnComplete: {
+                    format: 'boolean',
+                    default: false,
+                    doc: 'Temporary flag to unblock tasks that get stuck with open socket issue if happens',
                 },
             },
             jobManagerConfig: {

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -128,7 +128,7 @@ export class ServiceConfiguration {
                     doc: 'Timeout value after which the task has to be terminated',
                 },
                 exitOnComplete: {
-                    format: 'boolean',
+                    format: 'Boolean',
                     default: false,
                     doc: 'Temporary flag to unblock tasks that get stuck with open socket issue if happens',
                 },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -38,7 +38,7 @@
         "typescript": "^3.6.2"
     },
     "dependencies": {
-        "applicationinsights": "^1.6.0",
+        "applicationinsights": "^1.7.2",
         "common": "1.0.0",
         "dotenv": "^6.2.0",
         "inversify": "^5.0.1",

--- a/packages/logger/src/base-app-insights-logger-client.spec.ts
+++ b/packages/logger/src/base-app-insights-logger-client.spec.ts
@@ -24,12 +24,12 @@ class TestableBaseAppInsightsLoggerClient extends BaseAppInsightsLoggerClient {
                 commonProperties: null,
                 config: null,
                 channel: null,
-                trackTrace: (() => {}) as any,
-                trackMetric: (() => {}) as any,
-                trackException: (() => {}) as any,
-                flush: (() => {}) as any,
-                trackEvent: (() => {}) as any,
-                trackAvailability: (() => {}) as any,
+                trackTrace: (() => { }) as any,
+                trackMetric: (() => { }) as any,
+                trackException: (() => { }) as any,
+                flush: (async () => { }) as any,
+                trackEvent: (() => { }) as any,
+                trackAvailability: (() => { }) as any,
             } as appInsights.TelemetryClient,
             MockBehavior.Loose,
             false,
@@ -268,10 +268,15 @@ describe(BaseAppInsightsLoggerClient, () => {
             await testSubject.setup();
         });
 
-        it('flushes events', () => {
-            testSubject.telemetryClientMock.setup(t => t.flush()).verifiable();
+        it('flushes events', async () => {
+            let flushCb: Function;
+            testSubject.telemetryClientMock.setup(t => t.flush(It.isAny())).returns(options => {
+                flushCb = options.callback;
+                flushCb();
+            }).verifiable();
 
-            testSubject.flush();
+            await testSubject.flush();
+            expect(flushCb).toBeDefined();
             verifyMocks();
         });
     });

--- a/packages/logger/src/base-app-insights-logger-client.spec.ts
+++ b/packages/logger/src/base-app-insights-logger-client.spec.ts
@@ -10,7 +10,7 @@ import { BaseAppInsightsLoggerClient } from './base-app-insights-logger-client';
 import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { LogLevel } from './logger';
 
-// tslint:disable: no-null-keyword no-object-literal-type-assertion no-any no-void-expression no-empty
+// tslint:disable: no-null-keyword no-object-literal-type-assertion no-any no-void-expression no-empty no-unsafe-any
 
 class TestableBaseAppInsightsLoggerClient extends BaseAppInsightsLoggerClient {
     public additionalPropsToAdd = { adProp1: 'val1', adProp2: 'val2' };
@@ -24,12 +24,12 @@ class TestableBaseAppInsightsLoggerClient extends BaseAppInsightsLoggerClient {
                 commonProperties: null,
                 config: null,
                 channel: null,
-                trackTrace: (() => { }) as any,
-                trackMetric: (() => { }) as any,
-                trackException: (() => { }) as any,
-                flush: (async () => { }) as any,
-                trackEvent: (() => { }) as any,
-                trackAvailability: (() => { }) as any,
+                trackTrace: (() => {}) as any,
+                trackMetric: (() => {}) as any,
+                trackException: (() => {}) as any,
+                flush: (async () => {}) as any,
+                trackEvent: (() => {}) as any,
+                trackAvailability: (() => {}) as any,
             } as appInsights.TelemetryClient,
             MockBehavior.Loose,
             false,
@@ -270,10 +270,13 @@ describe(BaseAppInsightsLoggerClient, () => {
 
         it('flushes events', async () => {
             let flushCb: Function;
-            testSubject.telemetryClientMock.setup(t => t.flush(It.isAny())).returns(options => {
-                flushCb = options.callback;
-                flushCb();
-            }).verifiable();
+            testSubject.telemetryClientMock
+                .setup(t => t.flush(It.isAny()))
+                .returns(options => {
+                    flushCb = options.callback;
+                    flushCb();
+                })
+                .verifiable();
 
             await testSubject.flush();
             expect(flushCb).toBeDefined();

--- a/packages/logger/src/base-app-insights-logger-client.ts
+++ b/packages/logger/src/base-app-insights-logger-client.ts
@@ -61,12 +61,11 @@ export abstract class BaseAppInsightsLoggerClient implements LoggerClient {
     }
 
     public async flush(): Promise<void> {
-        return new Promise((resolve) => {
-
+        return new Promise(resolve => {
             this.telemetryClient.flush({
                 callback: () => {
                     resolve();
-                }
+                },
             });
         });
     }

--- a/packages/logger/src/base-app-insights-logger-client.ts
+++ b/packages/logger/src/base-app-insights-logger-client.ts
@@ -60,8 +60,15 @@ export abstract class BaseAppInsightsLoggerClient implements LoggerClient {
         this.telemetryClient.trackException({ exception: error, properties: { ...this.getAdditionalPropertiesToAddToEvent() } });
     }
 
-    public flush(): void {
-        this.telemetryClient.flush();
+    public async flush(): Promise<void> {
+        return new Promise((resolve) => {
+
+            this.telemetryClient.flush({
+                callback: () => {
+                    resolve();
+                }
+            });
+        });
     }
 
     public setCustomProperties(properties: { [key: string]: string }): void {

--- a/packages/logger/src/base-console-logger-client.ts
+++ b/packages/logger/src/base-console-logger-client.ts
@@ -22,7 +22,7 @@ export abstract class BaseConsoleLoggerClient implements LoggerClient {
     constructor(
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(loggerTypes.Console) private readonly consoleObject: typeof console,
-    ) {}
+    ) { }
 
     public async setup(baseProperties?: BaseTelemetryProperties): Promise<void> {
         this.baseProperties = baseProperties;
@@ -46,7 +46,7 @@ export abstract class BaseConsoleLoggerClient implements LoggerClient {
     }
 
     // tslint:disable-next-line: no-empty
-    public trackAvailability(name: string, telemetry: AvailabilityTelemetry): void {}
+    public trackAvailability(name: string, telemetry: AvailabilityTelemetry): void { }
 
     public log(message: string, logLevel: LogLevel, properties?: { [name: string]: string }): void {
         this.executeInDebugMode(() => {
@@ -61,7 +61,7 @@ export abstract class BaseConsoleLoggerClient implements LoggerClient {
     }
 
     // tslint:disable-next-line: no-empty
-    public flush(): void {}
+    public async flush(): Promise<void> { }
 
     public setCustomProperties(properties: LoggerProperties): void {
         this.baseProperties = { ...this.baseProperties, ...properties };

--- a/packages/logger/src/base-console-logger-client.ts
+++ b/packages/logger/src/base-console-logger-client.ts
@@ -22,7 +22,7 @@ export abstract class BaseConsoleLoggerClient implements LoggerClient {
     constructor(
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(loggerTypes.Console) private readonly consoleObject: typeof console,
-    ) { }
+    ) {}
 
     public async setup(baseProperties?: BaseTelemetryProperties): Promise<void> {
         this.baseProperties = baseProperties;
@@ -46,7 +46,7 @@ export abstract class BaseConsoleLoggerClient implements LoggerClient {
     }
 
     // tslint:disable-next-line: no-empty
-    public trackAvailability(name: string, telemetry: AvailabilityTelemetry): void { }
+    public trackAvailability(name: string, telemetry: AvailabilityTelemetry): void {}
 
     public log(message: string, logLevel: LogLevel, properties?: { [name: string]: string }): void {
         this.executeInDebugMode(() => {
@@ -61,7 +61,7 @@ export abstract class BaseConsoleLoggerClient implements LoggerClient {
     }
 
     // tslint:disable-next-line: no-empty
-    public async flush(): Promise<void> { }
+    public async flush(): Promise<void> {}
 
     public setCustomProperties(properties: LoggerProperties): void {
         this.baseProperties = { ...this.baseProperties, ...properties };

--- a/packages/logger/src/global-logger.spec.ts
+++ b/packages/logger/src/global-logger.spec.ts
@@ -405,10 +405,8 @@ describe(GlobalLogger, () => {
     });
 
     describe('flush', () => {
-        it('throw if called before setup', () => {
-            expect(() => {
-                testSubject.flush();
-            }).toThrowError(
+        it('throw if called before setup', async () => {
+            await expect(testSubject.flush()).rejects.toThrowError(
                 'The logger instance is not initialized. Ensure the setup() method is invoked by derived class implementation.',
             );
         });
@@ -417,9 +415,14 @@ describe(GlobalLogger, () => {
             setupCallsForTelemetrySetup();
             await testSubject.setup();
 
-            invokeAllLoggerClientMocks(m => m.setup(c => c.flush()).verifiable(Times.once()));
+            invokeAllLoggerClientMocks(m =>
+                m
+                    .setup(c => c.flush())
+                    .returns(() => Promise.resolve())
+                    .verifiable(Times.once()),
+            );
 
-            testSubject.flush();
+            await testSubject.flush();
         });
     });
 

--- a/packages/logger/src/logger-client.ts
+++ b/packages/logger/src/logger-client.ts
@@ -13,6 +13,6 @@ export interface LoggerClient {
     trackAvailability(name: string, telemetry: AvailabilityTelemetry): void;
     log(message: string, logLevel: LogLevel, properties?: { [name: string]: string }): void;
     trackException(error: Error): void;
-    flush(): void;
+    flush(): Promise<void>;
     setCustomProperties(properties: LoggerProperties): void;
 }

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -86,20 +86,25 @@ export abstract class Logger {
         this.trackException(new VError(parsedErrorObject, message));
     }
 
-    public flush(): void {
+    public async flush(): Promise<void> {
         this.ensureInitialized();
 
-        this.invokeLoggerClient(client => client.flush());
+        const promises = this.invokeLoggerClient(client => client.flush());
+        await Promise.all(promises);
     }
 
     public setCustomProperties(properties: LoggerProperties): void {
         this.invokeLoggerClient(client => client.setCustomProperties(properties));
     }
 
-    private invokeLoggerClient(action: (loggerClient: LoggerClient) => void): void {
+    private invokeLoggerClient<T>(action: (loggerClient: LoggerClient) => T): T[] {
+        const results: T[] = [];
+
         this.loggerClients.forEach(client => {
-            action(client);
+            results.push(action(client));
         });
+
+        return results;
     }
 
     private ensureInitialized(): void {

--- a/packages/resource-deployment/runtime-config/runtime-config.prod.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.prod.json
@@ -6,7 +6,8 @@
         "maxQueueSize": 20
     },
     "taskConfig": {
-        "taskTimeoutInMinutes": 5
+        "taskTimeoutInMinutes": 5,
+        "exitOnComplete": true
     },
 
     "scanConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,7 +2085,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-applicationinsights@^1.6.0:
+applicationinsights@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.7.2.tgz#c41f2485cc52589828783ed54f170c142e176c53"
   integrity sha512-AtofsH08vrGTMDwXVK6+1wITd8ou9gksFV95JLZo7lVL0wX7/W1qeAZ13DK/6P3VJVsSMJ0sjdVNn98C4XxGvw==
@@ -3413,7 +3413,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3454,11 +3454,6 @@ deep-eql@^3.0.1:
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
     type-detect "^4.0.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3538,11 +3533,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -4812,7 +4802,7 @@ humanize-url@^2.0.0:
   dependencies:
     normalize-url "^4.3.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4907,7 +4897,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6629,15 +6619,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
-  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -6729,22 +6710,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -6821,7 +6786,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -6861,7 +6826,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -7665,16 +7630,6 @@ raw-body@^2.4.1:
     http-errors "1.7.3"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
 
 react-dom@^16.12.0:
   version "16.12.0"
@@ -8697,11 +8652,6 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strip-outer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
@@ -8764,7 +8714,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
#### Description of changes

- We should wait for the app insights log flush before exiting, as it is asynchronous operation.
- Making process exit configurable, we only enable this on prod, so that we can investigate if this happens again in ppe.

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
