### PR TITLE
fix: setup request context logger before using

### DIFF
--- a/packages/service-library/src/web-api/web-controller-dispatcher.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { Context } from '@azure/functions';
 import { Container } from 'inversify';
-import { BaseTelemetryProperties, loggerTypes } from 'logger';
+import { BaseTelemetryProperties, Logger, loggerTypes } from 'logger';
 import { ProcessEntryPointBase } from '../process-entry-point-base';
 import { Newable } from './web-api-ioc-types';
 import { WebController } from './web-controller';
@@ -18,6 +18,9 @@ export class WebControllerDispatcher extends ProcessEntryPointBase {
         context: Context,
         ...args: unknown[]
     ): Promise<unknown> {
+        const logger = container.get(Logger);
+        await logger.setup();
+
         const controller = container.get(controllerType) as WebController;
 
         return controller.invoke(context, ...args);


### PR DESCRIPTION
#### Description of changes
This fixes the bug where the contextAwareLogger throws if setup is not called before logging.

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
