### PR TITLE
chore: refactor restart & recreate pools;

### DIFF
--- a/packages/resource-deployment/scripts/batch-account-create.sh
+++ b/packages/resource-deployment/scripts/batch-account-create.sh
@@ -28,16 +28,7 @@ Usage: $0 -r <resource group> [-t <batch template file (optional)>] -k <enable s
     exit 1
 }
 
-function waitForProcesses() {
-    local processesToWaitFor=$1
-
-    list="$processesToWaitFor[@]"
-    for pid in "${!list}"; do
-        echo "Waiting for process with pid $pid"
-        wait $pid
-        echo "Process with pid $pid exited"
-    done
-}
+. "${0%/*}/process-utilities.sh"
 
 function deployBatch() {
     # Deploy Azure Batch account using resource manager template

--- a/packages/resource-deployment/scripts/install-parallel.sh
+++ b/packages/resource-deployment/scripts/install-parallel.sh
@@ -72,30 +72,7 @@ Azure region - Azure region where the instances will be deployed. Available Azur
     exit 1
 }
 
-function waitForProcesses() {
-    local processesToWaitFor=$1
-
-    list="$processesToWaitFor[@]"
-    for pid in "${!list}"; do
-        echo "Waiting for process with pid $pid"
-        wait $pid
-        echo "Process with pid $pid exited"
-    done
-}
-
-function runInParallel() {
-    local processPaths=$1
-    local -a parallelizableProcesses
-
-    list="$processPaths[@]"
-    for processPath in "${!list}"; do
-        . "${processPath}" &
-        echo "Created process with pid $! for process path - $processPath"
-        parallelizableProcesses+=("$!")
-    done
-
-    waitForProcesses parallelizableProcesses
-}
+. "${0%/*}/process-utilities.sh"
 
 # Read script arguments
 while getopts ":r:s:l:e:o:p:c:t:v:k:" option; do

--- a/packages/resource-deployment/scripts/pool-startup/pool-startup-internal.sh
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup-internal.sh
@@ -15,6 +15,9 @@ waitForAptUpdates() {
     done
 }
 
+echo "restoring dpkg configuration"
+dpkg --configure -a
+
 echo "running - apt-get update"
 apt-get update
 

--- a/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
@@ -13,7 +13,7 @@ runWithRetry() {
     local maxRetryCount=5
 
     echo "restoring dpkg configuration"
-    dpkg --configure -ay
+    dpkg --configure -a
 
     until "${0%/*}/pool-startup-internal.sh"; do
         ((retryCount++))

--- a/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
@@ -12,15 +12,17 @@ runWithRetry() {
     local retryCount=0
     local maxRetryCount=5
 
+    echo "restoring dpkg configuration"
+    dpkg --configure -ay
+
     until "${0%/*}/pool-startup-internal.sh"; do
         ((retryCount++))
 
         if ((retryCount == maxRetryCount)); then
             echo "Maximum retry count reached. Pool startup script failed"
             exit 1
-        else
-            echo "Retry count - $retryCount. Pool startup script failed"
         fi
+        echo "Retry count - $retryCount. Pool startup script failed"
     done
 
     echo "Successfully completed pool startup script execution after retry count - $retryCount"

--- a/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
@@ -12,9 +12,6 @@ runWithRetry() {
     local retryCount=0
     local maxRetryCount=5
 
-    echo "restoring dpkg configuration"
-    dpkg --configure -a
-
     until "${0%/*}/pool-startup-internal.sh"; do
         ((retryCount++))
 

--- a/packages/resource-deployment/scripts/process-utilities.sh
+++ b/packages/resource-deployment/scripts/process-utilities.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -eo pipefail
+
+function waitForProcesses() {
+    local processesToWaitFor=$1
+
+    list="$processesToWaitFor[@]"
+    for pid in "${!list}"; do
+        echo "Waiting for process with pid $pid"
+        wait $pid
+        echo "Process with pid $pid exited"
+    done
+}
+
+function runInParallel() {
+    local processPaths=$1
+    local -a parallelizableProcesses
+
+    list="$processPaths[@]"
+    for processPath in "${!list}"; do
+        . "${processPath}" &
+        echo "Created process with pid $! for process path - $processPath"
+        parallelizableProcesses+=("$!")
+    done
+
+    waitForProcesses parallelizableProcesses
+}

--- a/packages/resource-deployment/scripts/restart-vm-pools.sh
+++ b/packages/resource-deployment/scripts/restart-vm-pools.sh
@@ -14,12 +14,7 @@ Usage: $0 -r <resource group>
     exit 1
 }
 
-
-restartBatchPools() {
-    # Login into Azure Batch account
-    echo "Logging into '$batchAccountName' Azure Batch account"
-    az batch account login --name "$batchAccountName" --resource-group "$resourceGroupName"
-
+function rebootNodes() {
     echo "Querying pools for $batchAccountName"
     local batchPoolIds=$(az batch pool list --account-name "$batchAccountName" --query "[*].id" -o tsv)
 
@@ -34,6 +29,12 @@ restartBatchPools() {
             az batch node reboot --node-id $nodeId --pool-id $poolId --account-name $batchAccountName --node-reboot-option taskcompletion 1>/dev/null
         done
     done
+}
+
+restartBatchPools() {
+    command="rebootNodes"
+    commandName="Reboot all nodes"
+    . "${0%/*}/run-command-when-batch-nodes-are-idle.sh"
 }
 
 # Read script arguments

--- a/packages/resource-deployment/scripts/run-command-on-all-vmss-for-pool.sh
+++ b/packages/resource-deployment/scripts/run-command-on-all-vmss-for-pool.sh
@@ -5,11 +5,6 @@
 
 set -eo pipefail
 
-# The script will enable system-assigned managed identity on Batch pool VMSS
-
-# export vmssResourceGroups
-# export systemAssignedIdentities
-
 export vmssResourceGroup
 export vmssName
 export vmssLocation

--- a/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
+++ b/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
@@ -67,12 +67,27 @@ waitForNodesToGoIdleByNodeType() {
     printf " - Running .."
     while [ $SECONDS -le $endTime ]; do
 
-        local runningCount=$(az batch pool node-counts list \
+        local totalCount=$(az batch pool node-counts list \
                                 --query "$nodeTypeContentSelector.running" \
                                 -o tsv
-                            ) 
-        
-        if [[ $runningCount == 0 ]]; then
+                            )
+        local idleCount=$(az batch pool node-counts list \
+                                --query "$nodeTypeContentSelector.idle" \
+                                -o tsv
+                            )  
+        local startTaskFailedCount=$(az batch pool node-counts list \
+                                --query "$nodeTypeContentSelector.startTaskFailed" \
+                                -o tsv
+                            )  
+
+        local unusableCount=$(az batch pool node-counts list \
+                                --query "$nodeTypeContentSelector.unusable" \
+                                -o tsv
+                            )  
+
+        local stableCount=$(( $idleCount + $startTaskFailedCount + $unusableCount ))
+
+        if [[ $stableCount == $totalCount ]]; then
             echo "$nodeType nodes under pool: $pool are idle."
             isIdle=true
             break;

--- a/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
+++ b/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
@@ -51,7 +51,7 @@ function disableJobSchedule {
 }
 
 function enableJobSchedule {
-    setJobScheduleStatus "disable"
+    setJobScheduleStatus "enable"
 }
 
 waitForNodesToGoIdleByNodeType() {

--- a/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
+++ b/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -eo pipefail
+
+exitWithUsageInfo() {
+    echo "
+Usage: $0 -r <resource group> -c <command to run> -n <command name>
+"
+    exit 1
+}
+
+# Read script arguments
+while getopts ":r:c:n:" option; do
+    case $option in
+    r) resourceGroupName=${OPTARG} ;;
+    c) command=${OPTARG} ;;
+    n) commandName=${OPTARG} ;;
+    *) exitWithUsageInfo ;;
+    esac
+done
+
+if [[ -z $resourceGroupName ]] || [[ -z $command ]] ||  [[ -z $commandName ]]; then
+    exitWithUsageInfo
+fi
+
+. "${0%/*}/get-resource-names.sh"
+
+echo "Invoked command to run when all pools are idle:
+resource group:$resourceGroupName
+commandName: $commandName
+"
+
+. "${0%/*}/process-utilities.sh"
+
+function setJobScheduleStatus {
+    local status=$1
+
+    local schedules=$(az batch job-schedule list --query "[].id" -o tsv)
+
+    for schedule in $schedules; do
+        echo "Setting job schedule $schedule status to $status"
+        az batch job-schedule $status --job-schedule-id "$schedule"
+    done
+}
+
+function disableJobSchedule {
+    setJobScheduleStatus "disable"
+}
+
+function enableJobSchedule {
+    setJobScheduleStatus "disable"
+}
+
+waitForNodesToGoIdleByNodeType() {
+    local isIdle=false
+    local pool=$1
+    local nodeType=$2
+    local waitTime=1800
+    local nodeTypeContentSelector="[?poolId=='$pool']|[0].$nodeType"
+
+    echo "Waiting for $nodeType nodes under $pool to go idle"
+
+    local endTime=$((SECONDS + waitTime))
+    printf " - Running .."
+    while [ $SECONDS -le $endTime ]; do
+
+        local runningCount=$(az batch pool node-counts list \
+                                --query "$nodeTypeContentSelector.running" \
+                                -o tsv
+                            ) 
+        
+        if [[ $runningCount == 0 ]]; then
+            echo "$nodeType nodes under pool: $pool are idle."
+            isIdle=true
+            break;
+        else
+            printf "."
+            sleep 5
+        fi
+    done
+
+    echo "Currrent Pool Status $pool for $nodeType:"
+    az batch pool node-counts list --query "$nodeTypeContentSelector"
+    
+    if [[ $isIdle == false ]]; then
+        echo "Pool $pool & $nodeType is not in the expected state."
+        exit 1
+    fi
+}
+
+function waitForPoolsToBeIdle() {
+    for pool in $pools; do
+        waitForNodesToGoIdleByNodeType "$pool" "dedicated"
+        waitForNodesToGoIdleByNodeType "$pool" "lowPriority"
+    done
+}
+
+function runCommand() {
+    # Login into Azure Batch account
+    echo "Logging into '$batchAccountName' Azure Batch account"
+    az batch account login --name "$batchAccountName" --resource-group "$resourceGroupName"
+
+    pools=$(az batch pool list --query "[].id" -o tsv)
+
+    disableJobSchedule
+
+    echo "sleeping 10 seconds to wait for any jobs that got kicked off
+     before disabling schedule to start using the nodes"
+    sleep 10
+
+    waitForPoolsToBeIdle
+    
+    echo "Invoking command $commandName"
+    eval "$command"
+
+    enableJobSchedule
+}
+
+runCommand

--- a/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
+++ b/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
@@ -68,7 +68,7 @@ waitForNodesToGoIdleByNodeType() {
     while [ $SECONDS -le $endTime ]; do
 
         local totalCount=$(az batch pool node-counts list \
-                                --query "$nodeTypeContentSelector.running" \
+                                --query "$nodeTypeContentSelector.total" \
                                 -o tsv
                             )
         local idleCount=$(az batch pool node-counts list \
@@ -86,7 +86,6 @@ waitForNodesToGoIdleByNodeType() {
                             )  
 
         local stableCount=$(( $idleCount + $startTaskFailedCount + $unusableCount ))
-
         if [[ $stableCount == $totalCount ]]; then
             echo "$nodeType nodes under pool: $pool are idle."
             isIdle=true

--- a/packages/resource-deployment/scripts/setup-all-pools-for-batch.sh
+++ b/packages/resource-deployment/scripts/setup-all-pools-for-batch.sh
@@ -22,16 +22,7 @@ Usage: $0 -r <resource group>
     exit 1
 }
 
-function waitForProcesses() {
-    local processesToWaitFor=$1
-
-    list="$processesToWaitFor[@]"
-    for pid in "${!list}"; do
-        echo "Waiting for process with pid $pid"
-        wait $pid
-        echo "Process with pid $pid exited"
-    done
-}
+. "${0%/*}/process-utilities.sh"
 
 function setupPools() {
     # Enable managed identity on Batch pools


### PR DESCRIPTION
reset dpkg configuration in pool startup script (If we reboot a node, when installation is happening, it corrupts the dpkg configuration. To solve this, we need to run dpkg configure -a). 
moved common script utitlies like runinparallel & waitForProcess to a new file (process-utilities.sh)

Triggered validation here - https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_releaseProgress?_a=release-environment-logs&releaseId=3247&environmentId=4746

#### Description of changes

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist


- [x]  Addresses an existing issue: Fixes #585 
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
