### PR TITLE
feat (send-notification): update post scan api to accept reply url

### DIFF
--- a/packages/service-library/src/web-api/api-contracts/scan-run-request.ts
+++ b/packages/service-library/src/web-api/api-contracts/scan-run-request.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 export interface ScanRunRequest {
     url: string;
-
+    replyUrl?: string;
     /**
      * Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.
      * The default value is 0.

--- a/packages/service-library/src/web-api/web-api-error-codes.ts
+++ b/packages/service-library/src/web-api/web-api-error-codes.ts
@@ -16,7 +16,8 @@ export declare type WebApiErrorCodeName =
     | 'UnsupportedApiVersion'
     | 'OutOfRangePriority'
     | 'MalformedBody'
-    | 'MissingReleaseVersion';
+    | 'MissingReleaseVersion'
+    | 'InvalidReplyURL';
 
 export interface WebApiErrorCode {
     statusCode: number;
@@ -57,6 +58,15 @@ export class WebApiErrorCodes {
             code: 'InvalidURL',
             codeId: 4003,
             message: 'The URL is not valid.',
+        },
+    };
+
+    public static invalidReplyURL: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'InvalidReplyURL',
+            codeId: 4003,
+            message: 'The reply URL is not valid.',
         },
     };
 

--- a/packages/service-library/src/web-api/web-api-error-codes.ts
+++ b/packages/service-library/src/web-api/web-api-error-codes.ts
@@ -61,15 +61,6 @@ export class WebApiErrorCodes {
         },
     };
 
-    public static invalidReplyURL: WebApiErrorCode = {
-        statusCode: 400,
-        error: {
-            code: 'InvalidReplyURL',
-            codeId: 4003,
-            message: 'The reply URL is not valid.',
-        },
-    };
-
     public static invalidJsonDocument: WebApiErrorCode = {
         statusCode: 400,
         error: {
@@ -139,6 +130,15 @@ export class WebApiErrorCodes {
             code: 'MalformedBody',
             codeId: 4011,
             message: 'The request body does not match the API schema for the given API version.',
+        },
+    };
+
+    public static invalidReplyURL: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'InvalidReplyURL',
+            codeId: 4012,
+            message: 'The reply URL is not valid.',
         },
     };
 

--- a/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
@@ -14,4 +14,5 @@ export interface ScanRunBatchRequest {
     scanId: string;
     priority: number;
     url: string;
+    replyUrl?: string;
 }

--- a/packages/storage-documents/src/on-demand-page-scan-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-request.ts
@@ -8,4 +8,5 @@ export interface OnDemandPageScanRequest extends StorageDocument {
     url: string;
     priority: number;
     itemType: ItemType.onDemandPageScanRequest;
+    replyUrl?: string;
 }

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -74,14 +74,14 @@ describe(ScanRequestController, () => {
     }
 
     describe(ScanRequestController, () => {
-        // it('rejects request with large payload', async () => {
-        //     context.req.rawBody = JSON.stringify([{ url: '' }, { url: '' }, { url: '' }, { url: '' }]);
-        //     scanRequestController = createScanRequestController(context);
+        it('rejects request with large payload', async () => {
+            context.req.rawBody = JSON.stringify([{ url: '' }, { url: '' }, { url: '' }, { url: '' }]);
+            scanRequestController = createScanRequestController(context);
 
-        //     await scanRequestController.handleRequest();
+            await scanRequestController.handleRequest();
 
-        //     expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.requestBodyTooLarge));
-        // });
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.requestBodyTooLarge));
+        });
 
         it('rejects request invalid reply url', async () => {
             context.req.rawBody = JSON.stringify([{ url: 'https://abs/path/', replyUrl: 'invalid-url' }]);

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -74,13 +74,22 @@ describe(ScanRequestController, () => {
     }
 
     describe(ScanRequestController, () => {
-        it('rejects request with large payload', async () => {
-            context.req.rawBody = JSON.stringify([{ url: '' }, { url: '' }, { url: '' }, { url: '' }]);
+        // it('rejects request with large payload', async () => {
+        //     context.req.rawBody = JSON.stringify([{ url: '' }, { url: '' }, { url: '' }, { url: '' }]);
+        //     scanRequestController = createScanRequestController(context);
+
+        //     await scanRequestController.handleRequest();
+
+        //     expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.requestBodyTooLarge));
+        // });
+
+        it('rejects request invalid reply url', async () => {
+            context.req.rawBody = JSON.stringify([{ url: 'https://abs/path/', replyUrl: 'invalid-url' }]);
             scanRequestController = createScanRequestController(context);
 
             await scanRequestController.handleRequest();
 
-            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.requestBodyTooLarge));
+            expect(context.res.body[0].error).toEqual(WebApiErrorCodes.invalidReplyURL.error);
         });
 
         it('accepts valid request only', async () => {

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { GuidGenerator, RestApiConfig, ServiceConfiguration, Url } from 'common';
 import { inject, injectable } from 'inversify';
-import { isNil } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { BatchScanRequestMeasurements, Logger } from 'logger';
 import {
     ApiController,
@@ -14,9 +14,6 @@ import {
     WebApiErrorCodes,
 } from 'service-library';
 import { ScanRunBatchRequest } from 'storage-documents';
-
-// tslint:disable: no-any
-type DictionaryStringToNumber = { [name: string]: number };
 
 interface ProcessedBatchRequestData {
     scanRequestsToBeStoredInDb: ScanRunBatchRequest[];
@@ -88,6 +85,7 @@ export class ScanRequestController extends ApiController {
         this.logger.trackEvent('BatchScanRequestSubmitted', null, measurements);
     }
 
+    // tslint:disable-next-line: no-any
     private getResponse(processedData: ProcessedBatchRequestData): any {
         const isV2 = this.context.req.query['api-version'] === '2.0' ? true : false;
         let response;
@@ -129,6 +127,7 @@ export class ScanRequestController extends ApiController {
                     scanId: scanId,
                     priority: isNil(scanRunRequest.priority) ? 0 : scanRunRequest.priority,
                     url: scanRunRequest.url,
+                    ...(isEmpty(scanRunRequest.replyUrl) ? {} : { replyUrl: scanRunRequest.replyUrl }),
                 });
 
                 scanResponses.push({
@@ -152,6 +151,10 @@ export class ScanRequestController extends ApiController {
     private validateRunRequest(scanRunRequest: ScanRunRequest): RunRequestValidationResult {
         if (Url.tryParseUrlString(scanRunRequest.url) === undefined) {
             return { valid: false, error: WebApiErrorCodes.invalidURL.error };
+        }
+
+        if (!isEmpty(scanRunRequest.replyUrl) && Url.tryParseUrlString(scanRunRequest.replyUrl) === undefined) {
+            return { valid: false, error: WebApiErrorCodes.invalidReplyURL.error };
         }
 
         if (scanRunRequest.priority < this.config.minScanPriorityValue || scanRunRequest.priority > this.config.maxScanPriorityValue) {

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -85,8 +85,7 @@ export class ScanRequestController extends ApiController {
         this.logger.trackEvent('BatchScanRequestSubmitted', null, measurements);
     }
 
-    // tslint:disable-next-line: no-any
-    private getResponse(processedData: ProcessedBatchRequestData): any {
+    private getResponse(processedData: ProcessedBatchRequestData): ScanRunResponse | ScanRunResponse[] {
         const isV2 = this.context.req.query['api-version'] === '2.0' ? true : false;
         let response;
         if (isV2) {


### PR DESCRIPTION
Accept reply url sending with the request and save it into the database. 

Will check if the reply url is valid if the user does provide it. If not, will return an error response.

Api version management refactor will be a separate PR. We might need to put that in the service config.
