### PR TITLE
feat (send-notification): adding initial setup code for send notification job manager

### DIFF
--- a/packages/web-api-send-notification-job-manager/src/index.ts
+++ b/packages/web-api-send-notification-job-manager/src/index.ts
@@ -8,3 +8,19 @@ import 'reflect-metadata';
     console.log('Exception thrown in send notification job manager: ', error);
     process.exit(1);
 });
+
+import { WhyNodeRunningLogger } from 'common';
+
+import { SendNotificationJobManagerEntryPoint } from './send-notification-job-manager-entry-point';
+import { setupSendNotificationJobManagerContainer } from './setup-send-notification-job-manager-container';
+
+const whyNodeRunLogger = new WhyNodeRunningLogger();
+
+(async () => {
+    const sendNotificationJobManagerEntryPoint = new SendNotificationJobManagerEntryPoint(setupSendNotificationJobManagerContainer());
+    await sendNotificationJobManagerEntryPoint.start();
+    await whyNodeRunLogger.logAfterSeconds(10);
+})().catch(error => {
+    console.log('Exception thrown in send notification job manager: ', error);
+    process.exit(1);
+});

--- a/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.spec.ts
+++ b/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.spec.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { BaseTelemetryProperties } from 'logger';
+import { IMock, Mock } from 'typemoq';
+import { SendNotificationJobManagerEntryPoint } from './send-notification-job-manager-entry-point';
+
+// tslint:disable: no-object-literal-type-assertion
+
+class TestableSendNotificationJobManagerEntryPoint extends SendNotificationJobManagerEntryPoint {
+    public invokeGetTelemetryBaseProperties(): BaseTelemetryProperties {
+        return this.getTelemetryBaseProperties();
+    }
+}
+
+describe(SendNotificationJobManagerEntryPoint, () => {
+    let testSubject: TestableSendNotificationJobManagerEntryPoint;
+    let containerMock: IMock<Container>;
+
+    beforeEach(() => {
+        containerMock = Mock.ofType(Container);
+
+        testSubject = new TestableSendNotificationJobManagerEntryPoint(containerMock.object);
+    });
+
+    describe('getTelemetryBaseProperties', () => {
+        it('returns data with source property', () => {
+            expect(testSubject.invokeGetTelemetryBaseProperties()).toEqual({
+                source: 'webApiSendNotificationJobManager',
+            } as BaseTelemetryProperties);
+        });
+    });
+});

--- a/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.ts
+++ b/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Container } from 'inversify';
+import { BaseTelemetryProperties } from 'logger';
+import { ProcessEntryPointBase } from 'service-library';
+import { SendNotificationTaskCreator } from './task/send-notification-task-creator';
+
+export class SendNotificationJobManagerEntryPoint extends ProcessEntryPointBase {
+    protected getTelemetryBaseProperties(): BaseTelemetryProperties {
+        return { source: 'webApiSendNotificationJobManager' };
+    }
+
+    protected async runCustomAction(container: Container): Promise<void> {
+        const taskCreator = container.get<SendNotificationTaskCreator>(SendNotificationTaskCreator);
+        await taskCreator.run();
+    }
+}

--- a/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.spec.ts
+++ b/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.spec.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Batch, Queue } from 'azure-services';
+import { ServiceConfiguration } from 'common';
+import { Container } from 'inversify';
+import { setupSendNotificationJobManagerContainer } from './setup-send-notification-job-manager-container';
+
+// tslint:disable: no-any no-unsafe-any no-object-literal-type-assertion
+
+describe(setupSendNotificationJobManagerContainer, () => {
+    const batchAccountUrl = 'test-batch-account-url';
+    const batchAccountName = 'test-batch-account-name';
+
+    beforeEach(() => {
+        process.env.AZURE_STORAGE_SCAN_QUEUE = 'test-scan-queue';
+        process.env.AZ_BATCH_ACCOUNT_NAME = batchAccountName;
+        process.env.AZ_BATCH_ACCOUNT_URL = batchAccountUrl;
+        process.env.AZ_BATCH_POOL_ID = 'test-batch-pool-id';
+    });
+
+    it('resolves service config to singleton value', () => {
+        const container = setupSendNotificationJobManagerContainer();
+        const serviceConfig = container.get(ServiceConfiguration);
+
+        expect(serviceConfig).toBeInstanceOf(ServiceConfiguration);
+        expect(serviceConfig).toBe(container.get(ServiceConfiguration));
+    });
+
+    it('verify JobManager dependencies resolution', () => {
+        const container = setupSendNotificationJobManagerContainer();
+
+        verifyNonSingletonDependencyResolution(container, Queue);
+        verifySingletonDependencyResolution(container, Batch);
+    });
+
+    function verifySingletonDependencyResolution(container: Container, key: any): void {
+        expect(container.get(key)).toBeDefined();
+        expect(container.get(key)).toBe(container.get(key));
+    }
+
+    function verifyNonSingletonDependencyResolution(container: Container, key: any): void {
+        expect(container.get(key)).toBeDefined();
+        expect(container.get(key)).not.toBe(container.get(key));
+    }
+});

--- a/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.ts
+++ b/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AzureServicesIocTypes, BatchTaskParameterProvider, registerAzureServicesToContainer } from 'azure-services';
+import { setupRuntimeConfigContainer } from 'common';
+import { Container } from 'inversify';
+import { registerGlobalLoggerToContainer } from 'logger';
+
+export function setupSendNotificationJobManagerContainer(): Container {
+    const container = new Container({ autoBindInjectable: true });
+    setupRuntimeConfigContainer(container);
+    registerGlobalLoggerToContainer(container);
+    registerAzureServicesToContainer(container);
+
+    return container;
+}

--- a/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.ts
+++ b/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AzureServicesIocTypes, BatchTaskParameterProvider, registerAzureServicesToContainer } from 'azure-services';
+import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import { Container } from 'inversify';
 import { registerGlobalLoggerToContainer } from 'logger';

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Batch, BatchConfig, BatchTask, JobTask, JobTaskState, Message, PoolLoadGenerator, Queue } from 'azure-services';
+import { IMock, Mock } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { SendNotificationTaskCreator } from './send-notification-task-creator';
+
+// tslint:disable: no-unsafe-any no-object-literal-type-assertion no-any mocha-no-side-effect-code no-null-keyword
+describe(SendNotificationTaskCreator, () => {
+    let taskCreator: SendNotificationTaskCreator;
+    let batchMock: IMock<Batch>;
+    let queueMock: IMock<Queue>;
+    let loggerMock: IMock<MockableLogger>;
+    const batchConfig: BatchConfig = {
+        accountName: 'batch-account-name',
+        accountUrl: '',
+        poolId: 'pool-Id',
+        jobId: 'batch-job-id',
+    };
+
+    beforeEach(() => {
+        batchMock = Mock.ofType(Batch);
+        queueMock = Mock.ofType(Queue);
+        loggerMock = Mock.ofType(MockableLogger);
+
+        queueMock.setup(o => o.scanQueue).returns(() => 'scan-queue');
+
+        taskCreator = new SendNotificationTaskCreator(batchMock.object, queueMock.object, batchConfig, loggerMock.object);
+    });
+
+    it('not implemented', async () => {
+        await taskCreator.run();
+    });
+
+    afterEach(() => {
+        batchMock.verifyAll();
+        queueMock.verifyAll();
+    });
+});

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { Batch, BatchConfig, BatchTask, JobTask, JobTaskState, Message, PoolLoadGenerator, Queue } from 'azure-services';
+import { Batch, BatchConfig, Queue } from 'azure-services';
 import { IMock, Mock } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 import { SendNotificationTaskCreator } from './send-notification-task-creator';

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Batch, BatchConfig, Queue } from 'azure-services';
+import { inject, injectable } from 'inversify';
+import { Logger } from 'logger';
+
+@injectable()
+export class SendNotificationTaskCreator {
+    public constructor(
+        @inject(Batch) private readonly batch: Batch,
+        @inject(Queue) private readonly queue: Queue,
+        @inject(BatchConfig) private readonly batchConfig: BatchConfig,
+        @inject(Logger) private readonly logger: Logger,
+    ) {}
+
+    public async run(): Promise<void> {
+        this.logger.logWarn('not implemented');
+    }
+}

--- a/packages/web-api-send-notification-job-manager/src/test-utilities/mockable-logger.ts
+++ b/packages/web-api-send-notification-job-manager/src/test-utilities/mockable-logger.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Logger } from 'logger';
+
+export class MockableLogger extends Logger {}


### PR DESCRIPTION
#### Description of changes
This PR doesnt have changes required to create the notification runner tasks. It just adds the setup code for dependency injection & execution.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
