### PR TITLE
fix: return InvalidResourceId on invalid guid

### DIFF
--- a/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
@@ -34,7 +34,7 @@ export class ScanReportTestGroup extends FunctionalTestGroup {
 
     @test(TestEnvironment.all)
     public async testGetScanReportWithInvalidGuid(): Promise<void> {
-        const invalidGuid = '00000000-0000-0000-0000-000000000000';
+        const invalidGuid = 'invalid guid';
         const response = await this.a11yServiceClient.getScanReport(this.testContextData.scanId, invalidGuid);
 
         this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, response);

--- a/packages/functional-tests/src/test-groups/scan-status-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-status-test-group.ts
@@ -21,7 +21,7 @@ export class ScanStatusTestGroup extends FunctionalTestGroup {
 
     @test(TestEnvironment.all)
     public async testGetScanStatusWithInvalidGuid(): Promise<void> {
-        const invalidGuid = '00000000-0000-0000-0000-000000000000';
+        const invalidGuid = 'invalid guid';
         const response = await this.a11yServiceClient.getScanStatus(invalidGuid);
 
         this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, response);

--- a/packages/web-api/get-report-func/function.json
+++ b/packages/web-api/get-report-func/function.json
@@ -5,7 +5,7 @@
             "name": "request",
             "type": "httpTrigger",
             "direction": "in",
-            "route": "scans/{scanId:guid}/reports/{reportId:guid}",
+            "route": "scans/{scanId}/reports/{reportId}",
             "methods": ["get"]
         },
         {

--- a/packages/web-api/get-scan-func/function.json
+++ b/packages/web-api/get-scan-func/function.json
@@ -5,7 +5,7 @@
             "name": "request",
             "type": "httpTrigger",
             "direction": "in",
-            "route": "scans/{scanId:guid}",
+            "route": "scans/{scanId}",
             "methods": ["get"]
         },
         {


### PR DESCRIPTION
#### Description of changes

Previously we were throwing 404 if the user asked for scan status or report with anything not formatted as a guid. This will allow us to return an error message instead, as was intended.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #458
- [x] Added relevant ~~unit test~~ functional test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
