### PR TITLE
fix: add retry to MsiCredentialProvider

### DIFF
--- a/packages/azure-services/src/credentials/msi-credential-provider.spec.ts
+++ b/packages/azure-services/src/credentials/msi-credential-provider.spec.ts
@@ -3,17 +3,42 @@
 import 'reflect-metadata';
 
 import * as msRestNodeAuth from '@azure/ms-rest-nodeauth';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { AuthenticationMethod, CredentialType, MSICredentialsProvider } from './msi-credential-provider';
+import { RetryHelper } from 'common';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { AuthenticationMethod, Credentials, CredentialType, MSICredentialsProvider } from './msi-credential-provider';
 
-// tslint:disable: no-any
+// tslint:disable: no-any no-unsafe-any
 
 describe(MSICredentialsProvider, () => {
     let testSubject: MSICredentialsProvider;
     let mockMsRestNodeAuth: IMock<typeof msRestNodeAuth>;
+    let retryHelperMock: IMock<RetryHelper<Credentials>>;
+    const maxAttempts = 3;
+    const millisBetweenRetries = 0;
+    const expectedCreds: any = 'test creds';
+
+    async function retryHelperStub(
+        action: () => Promise<Credentials>,
+        onRetry: (err: Error) => Promise<void>,
+        numMaxAttempts: number,
+        numMillisBetweenRetries: number,
+    ): Promise<Credentials> {
+        return action();
+    }
 
     beforeEach(() => {
         mockMsRestNodeAuth = Mock.ofInstance(msRestNodeAuth, MockBehavior.Strict);
+        retryHelperMock = Mock.ofType<RetryHelper<Credentials>>();
+
+        retryHelperMock
+            .setup(r => r.executeWithRetries(It.isAny(), It.isAny(), maxAttempts, millisBetweenRetries))
+            .returns(retryHelperStub)
+            .verifiable();
+    });
+
+    afterEach(() => {
+        retryHelperMock.verifyAll();
+        mockMsRestNodeAuth.verifyAll();
     });
 
     it('creates credential for app service', async () => {
@@ -21,9 +46,10 @@ describe(MSICredentialsProvider, () => {
             mockMsRestNodeAuth.object,
             AuthenticationMethod.managedIdentity,
             CredentialType.AppService,
+            retryHelperMock.object,
+            maxAttempts,
+            millisBetweenRetries,
         );
-
-        const expectedCreds = 'test creds' as any;
 
         mockMsRestNodeAuth
             .setup(async m => m.loginWithAppServiceMSI({ resource: 'r1' }))
@@ -33,14 +59,17 @@ describe(MSICredentialsProvider, () => {
         const creds = await testSubject.getCredentials('r1');
 
         expect(creds).toBe(expectedCreds);
-
-        mockMsRestNodeAuth.verifyAll();
     });
 
     it('creates credential for vm', async () => {
-        testSubject = new MSICredentialsProvider(mockMsRestNodeAuth.object, AuthenticationMethod.managedIdentity, CredentialType.VM);
-
-        const expectedCreds = 'test creds' as any;
+        testSubject = new MSICredentialsProvider(
+            mockMsRestNodeAuth.object,
+            AuthenticationMethod.managedIdentity,
+            CredentialType.VM,
+            retryHelperMock.object,
+            maxAttempts,
+            millisBetweenRetries,
+        );
 
         mockMsRestNodeAuth
             .setup(async m => m.loginWithVmMSI({ resource: 'r1' }))
@@ -50,8 +79,6 @@ describe(MSICredentialsProvider, () => {
         const creds = await testSubject.getCredentials('r1');
 
         expect(creds).toBe(expectedCreds);
-
-        mockMsRestNodeAuth.verifyAll();
     });
 
     it('creates credentials with service principal', async () => {
@@ -63,9 +90,10 @@ describe(MSICredentialsProvider, () => {
             mockMsRestNodeAuth.object,
             AuthenticationMethod.servicePrincipal,
             CredentialType.AppService,
+            retryHelperMock.object,
+            maxAttempts,
+            millisBetweenRetries,
         );
-
-        const expectedCreds = 'test creds' as any;
 
         mockMsRestNodeAuth
             .setup(async m =>
@@ -79,7 +107,33 @@ describe(MSICredentialsProvider, () => {
         const creds = await testSubject.getCredentials('r1');
 
         expect(creds).toBe(expectedCreds);
+    });
 
-        mockMsRestNodeAuth.verifyAll();
+    it('Throws error on failure', async () => {
+        testSubject = new MSICredentialsProvider(
+            mockMsRestNodeAuth.object,
+            AuthenticationMethod.managedIdentity,
+            CredentialType.AppService,
+            retryHelperMock.object,
+            maxAttempts,
+            millisBetweenRetries,
+        );
+
+        const error = new Error('test error');
+
+        retryHelperMock.reset();
+        retryHelperMock
+            .setup(r => r.executeWithRetries(It.isAny(), It.isAny(), It.isAny(), It.isAny()))
+            .throws(error)
+            .verifiable();
+
+        let caughtError: Error;
+
+        await testSubject.getCredentials('r1').catch(err => {
+            caughtError = err as Error;
+        });
+
+        expect(caughtError).not.toBeUndefined();
+        expect(caughtError.message).toEqual(`MSI getToken failed ${maxAttempts} times with error: ${JSON.stringify(error)}`);
     });
 });

--- a/packages/common/src/system/retry-helper.ts
+++ b/packages/common/src/system/retry-helper.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { injectable } from 'inversify';
+
 export type ErrorHandler = (err: Error) => Promise<void>;
 
 async function defaultSleepFunction(milliseconds: number): Promise<void> {
@@ -8,6 +10,7 @@ async function defaultSleepFunction(milliseconds: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, milliseconds));
 }
 
+@injectable()
 export class RetryHelper<T> {
     public constructor(private readonly sleepFunction: (millis: number) => Promise<void> = defaultSleepFunction) {}
 


### PR DESCRIPTION
#### Description of changes

Retry on errors when fetching token in MSICredentialsProvider

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #563
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
