### PR TITLE
fix: long-running tests

### DIFF
--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -41,7 +41,8 @@
         "typemoq": "^2.1.0",
         "typescript": "^3.8.3",
         "webpack": "^4.42.0",
-        "webpack-cli": "^3.2.3"
+        "webpack-cli": "^3.2.3",
+        "mockdate": "^2.0.5"
     },
     "dependencies": {
         "@azure/batch": "^7.0.0",

--- a/packages/azure-services/src/azure-batch/batch.spec.ts
+++ b/packages/azure-services/src/azure-batch/batch.spec.ts
@@ -66,6 +66,7 @@ describe(Batch, () => {
     let batchTaskParameterProvider: IMock<BatchTaskParameterProvider>;
     let maxTaskDurationInMinutes: number;
     let taskParameter: BatchServiceModels.TaskAddParameter;
+    const maxTasks = 10;
 
     beforeEach(() => {
         maxTaskDurationInMinutes = 5;
@@ -113,6 +114,7 @@ describe(Batch, () => {
             storageContainerSASUrlProviderMock.object,
             config,
             loggerMock.object,
+            maxTasks,
         );
     });
 
@@ -341,8 +343,8 @@ describe(Batch, () => {
             expect(tasksActual.length).toBe(0);
         });
 
-        it('should add no more than 100 tasks in a single Batch API call', async () => {
-            const messagesCount = 103;
+        it('should add no more than maxTasks tasks in a single Batch API call', async () => {
+            const messagesCount = maxTasks + 3;
             const messages = [];
             const tasksAddedBatchCount: number[] = [];
             const taskAddParameters: BatchServiceModels.TaskAddParameter[] = [];
@@ -391,7 +393,7 @@ describe(Batch, () => {
 
             expect(tasksActual.length).toEqual(messagesCount);
             expect(tasksAddedBatchCount.length).toEqual(2);
-            expect(tasksAddedBatchCount[0]).toEqual(100);
+            expect(tasksAddedBatchCount[0]).toEqual(maxTasks);
             expect(tasksAddedBatchCount[1]).toEqual(3);
             taskMock.verifyAll();
             batchTaskParameterProvider.verifyAll();

--- a/packages/azure-services/src/storage/cosmos-container-client.spec.ts
+++ b/packages/azure-services/src/storage/cosmos-container-client.spec.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
     );
     MockDate.set(startTime);
     systemUtilsMock
-        .setup(s => s.wait(It.isAny()))
+        .setup(s => s.wait(retryOptions.intervalMilliseconds))
         .callback((millis: number) => {
             MockDate.set(Date.now() + millis);
         });

--- a/packages/azure-services/src/storage/cosmos-container-client.spec.ts
+++ b/packages/azure-services/src/storage/cosmos-container-client.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
+import * as MockDate from 'mockdate';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { CosmosClientWrapper } from '../azure-cosmos/cosmos-client-wrapper';
 import { CosmosDocument } from '../azure-cosmos/cosmos-document';
@@ -16,11 +17,16 @@ type OperationCallback = (...args: any[]) => Promise<CosmosOperationResponse<any
 const dbName = 'dbName';
 const collectionName = 'collectionName';
 const partitionKey = 'default-partitionKey';
+const startTime = new Date();
 
 let cosmosClientWrapperMock: IMock<CosmosClientWrapper>;
 let cosmosContainerClient: CosmosContainerClient;
 let operationCallbackMock: IMock<OperationCallback>;
 let loggerMock: IMock<MockableLogger>;
+
+const sleepFunctionStub = async (millis: number) => {
+    MockDate.set(Date.now() + millis);
+};
 
 const retryOptions = {
     timeoutMilliseconds: 1000,
@@ -32,7 +38,14 @@ beforeEach(() => {
     cosmosClientWrapperMock = Mock.ofType<CosmosClientWrapper>();
     operationCallbackMock = Mock.ofType<OperationCallback>();
     loggerMock = Mock.ofType(MockableLogger);
-    cosmosContainerClient = new CosmosContainerClient(cosmosClientWrapperMock.object, dbName, collectionName, loggerMock.object);
+    cosmosContainerClient = new CosmosContainerClient(
+        cosmosClientWrapperMock.object,
+        dbName,
+        collectionName,
+        loggerMock.object,
+        sleepFunctionStub
+    );
+    MockDate.set(startTime);
 });
 
 describe('mergeOrWriteDocument()', () => {

--- a/packages/azure-services/src/storage/cosmos-container-client.spec.ts
+++ b/packages/azure-services/src/storage/cosmos-container-client.spec.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
         dbName,
         collectionName,
         loggerMock.object,
-        sleepFunctionStub
+        sleepFunctionStub,
     );
     MockDate.set(startTime);
 });

--- a/packages/azure-services/src/storage/cosmos-container-client.ts
+++ b/packages/azure-services/src/storage/cosmos-container-client.ts
@@ -14,17 +14,13 @@ import { RetryOptions } from './retry-options';
 
 // tslint:disable: no-any no-unsafe-any
 
-async function defaultSleepFunction(millis: number): Promise<void> {
-    await System.wait(millis);
-}
-
 export class CosmosContainerClient {
     constructor(
         private readonly cosmosClientWrapper: CosmosClientWrapper,
         private readonly dbName: string,
         private readonly collectionName: string,
         private readonly logger: Logger,
-        private readonly sleepFunction: (millis: number) => Promise<void> = defaultSleepFunction,
+        private readonly systemUtils: typeof System = System,
     ) {}
 
     public async readDocument<T>(documentId: string, partitionKey?: string): Promise<CosmosOperationResponse<T>> {
@@ -175,7 +171,7 @@ export class CosmosContainerClient {
                     break;
                 }
 
-                await this.sleepFunction(retryOptions.intervalMilliseconds);
+                await this.systemUtils.wait(retryOptions.intervalMilliseconds);
             }
         });
     }

--- a/packages/azure-services/src/storage/cosmos-container-client.ts
+++ b/packages/azure-services/src/storage/cosmos-container-client.ts
@@ -14,13 +14,18 @@ import { RetryOptions } from './retry-options';
 
 // tslint:disable: no-any no-unsafe-any
 
+async function defaultSleepFunction(millis: number): Promise<void> {
+    await System.wait(millis);
+}
+
 export class CosmosContainerClient {
     constructor(
         private readonly cosmosClientWrapper: CosmosClientWrapper,
         private readonly dbName: string,
         private readonly collectionName: string,
         private readonly logger: Logger,
-    ) {}
+        private readonly sleepFunction: (millis: number) => Promise<void> = defaultSleepFunction,
+    ) { }
 
     public async readDocument<T>(documentId: string, partitionKey?: string): Promise<CosmosOperationResponse<T>> {
         return this.cosmosClientWrapper.readItem<T>(documentId, this.dbName, this.collectionName, partitionKey);
@@ -170,7 +175,7 @@ export class CosmosContainerClient {
                     break;
                 }
 
-                await System.wait(retryOptions.intervalMilliseconds);
+                await this.sleepFunction(retryOptions.intervalMilliseconds);
             }
         });
     }

--- a/packages/azure-services/src/storage/cosmos-container-client.ts
+++ b/packages/azure-services/src/storage/cosmos-container-client.ts
@@ -25,7 +25,7 @@ export class CosmosContainerClient {
         private readonly collectionName: string,
         private readonly logger: Logger,
         private readonly sleepFunction: (millis: number) => Promise<void> = defaultSleepFunction,
-    ) { }
+    ) {}
 
     public async readDocument<T>(documentId: string, partitionKey?: string): Promise<CosmosOperationResponse<T>> {
         return this.cosmosClientWrapper.readItem<T>(documentId, this.dbName, this.collectionName, partitionKey);


### PR DESCRIPTION
#### Description of changes

Shorten some long-running tests (partial fix for #601)
- Use mocks/stubs to simulate waiting in CosmosContainerClient instead of actually sleeping during tests
- Stub time-consuming CosmosClient constructor for registerAzureServicesToContainer tests
- Make the max number of batch tasks configurable instead of hardcoding it to 100

#### Pull request checklist

- [x] Addresses an existing issue
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
