### PR TITLE
fix: update scan run without reading first

### DIFF
--- a/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.spec.ts
+++ b/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
-import { ItemType, OnDemandPageScanResult } from 'storage-documents';
+import { ItemType, OnDemandPageScanResult, PartialOnDemandPageScanResult } from 'storage-documents';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { OnDemandPageScanRunResultProvider } from './on-demand-page-scan-run-result-provider';
@@ -56,7 +56,7 @@ describe(OnDemandPageScanRunResultProvider, () => {
     it('updates scan run document', async () => {
         const partition1Result1 = {
             id: 'partition1id1',
-        } as OnDemandPageScanResult;
+        } as PartialOnDemandPageScanResult;
         const partition1Result1ToBeSaved = getDocumentWithSysProps('partition1id1', 'bucket1');
         const partition1Result1Saved = getDocumentWithSysProps('partition1id1', 'bucket1');
         partition1Result1Saved._etag = 'etag-1';

--- a/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.spec.ts
+++ b/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
-import { ItemType, OnDemandPageScanResult, PartialOnDemandPageScanResult } from 'storage-documents';
+import { ItemType, OnDemandPageScanResult } from 'storage-documents';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { OnDemandPageScanRunResultProvider } from './on-demand-page-scan-run-result-provider';
@@ -56,7 +56,7 @@ describe(OnDemandPageScanRunResultProvider, () => {
     it('updates scan run document', async () => {
         const partition1Result1 = {
             id: 'partition1id1',
-        } as PartialOnDemandPageScanResult;
+        } as Partial<OnDemandPageScanResult>;
         const partition1Result1ToBeSaved = getDocumentWithSysProps('partition1id1', 'bucket1');
         const partition1Result1Saved = getDocumentWithSysProps('partition1id1', 'bucket1');
         partition1Result1Saved._etag = 'etag-1';
@@ -70,6 +70,21 @@ describe(OnDemandPageScanRunResultProvider, () => {
         const savedDocument = await testSubject.updateScanRun(partition1Result1);
         expect(savedDocument).toEqual(partition1Result1Saved);
         verifyAll();
+    });
+
+    it('update throws error if document has no id', async () => {
+        const partialDocument = {
+            url: 'url',
+        } as Partial<OnDemandPageScanResult>;
+        const expectedErrorMessage = `Cannot update scan run using partial scan run without id: ${JSON.stringify(partialDocument)}`;
+
+        let caughtError: Error;
+        await testSubject.updateScanRun(partialDocument).catch(err => {
+            caughtError = err as Error;
+        });
+
+        expect(caughtError).not.toBeUndefined();
+        expect(caughtError.message).toEqual(expectedErrorMessage);
     });
 
     describe('readScanRuns', () => {

--- a/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
+++ b/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
@@ -13,7 +13,7 @@ export class OnDemandPageScanRunResultProvider {
         @inject(cosmosContainerClientTypes.OnDemandScanRunsCosmosContainerClient)
         private readonly cosmosContainerClient: CosmosContainerClient,
         @inject(PartitionKeyFactory) private readonly partitionKeyFactory: PartitionKeyFactory,
-    ) { }
+    ) {}
 
     public async readScanRun(scanId: string): Promise<OnDemandPageScanResult> {
         return (await this.cosmosContainerClient.readDocument<OnDemandPageScanResult>(scanId, this.getPartitionKey(scanId))).item;

--- a/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
+++ b/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from 'inversify';
 
 import { CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { flatMap, groupBy } from 'lodash';
-import { ItemType, OnDemandPageScanResult } from 'storage-documents';
+import { ItemType, OnDemandPageScanResult, PartialOnDemandPageScanResult } from 'storage-documents';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 
 @injectable()
@@ -45,10 +45,11 @@ export class OnDemandPageScanRunResultProvider {
         return flatMap(response);
     }
 
-    public async updateScanRun(pageScanResult: OnDemandPageScanResult): Promise<OnDemandPageScanResult> {
-        this.setSystemProperties(pageScanResult);
+    public async updateScanRun(pageScanResult: PartialOnDemandPageScanResult): Promise<OnDemandPageScanResult> {
+        const storableResult = pageScanResult as OnDemandPageScanResult;
+        this.setSystemProperties(storableResult);
 
-        return (await this.cosmosContainerClient.mergeOrWriteDocument(pageScanResult)).item;
+        return (await this.cosmosContainerClient.mergeOrWriteDocument(storableResult)).item;
     }
 
     public async writeScanRuns(scanRuns: OnDemandPageScanResult[]): Promise<void> {

--- a/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
+++ b/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
@@ -46,10 +46,10 @@ export class OnDemandPageScanRunResultProvider {
     }
 
     public async updateScanRun(pageScanResult: PartialOnDemandPageScanResult): Promise<OnDemandPageScanResult> {
-        const storableResult = pageScanResult as OnDemandPageScanResult;
-        this.setSystemProperties(storableResult);
+        const persistedResult = pageScanResult as OnDemandPageScanResult;
+        this.setSystemProperties(persistedResult);
 
-        return (await this.cosmosContainerClient.mergeOrWriteDocument(storableResult)).item;
+        return (await this.cosmosContainerClient.mergeOrWriteDocument(persistedResult)).item;
     }
 
     public async writeScanRuns(scanRuns: OnDemandPageScanResult[]): Promise<void> {

--- a/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
+++ b/packages/service-library/src/data-providers/on-demand-page-scan-run-result-provider.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from 'inversify';
 
 import { CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { flatMap, groupBy } from 'lodash';
-import { ItemType, OnDemandPageScanResult, PartialOnDemandPageScanResult } from 'storage-documents';
+import { ItemType, OnDemandPageScanResult } from 'storage-documents';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 
 @injectable()
@@ -13,7 +13,7 @@ export class OnDemandPageScanRunResultProvider {
         @inject(cosmosContainerClientTypes.OnDemandScanRunsCosmosContainerClient)
         private readonly cosmosContainerClient: CosmosContainerClient,
         @inject(PartitionKeyFactory) private readonly partitionKeyFactory: PartitionKeyFactory,
-    ) {}
+    ) { }
 
     public async readScanRun(scanId: string): Promise<OnDemandPageScanResult> {
         return (await this.cosmosContainerClient.readDocument<OnDemandPageScanResult>(scanId, this.getPartitionKey(scanId))).item;
@@ -45,7 +45,10 @@ export class OnDemandPageScanRunResultProvider {
         return flatMap(response);
     }
 
-    public async updateScanRun(pageScanResult: PartialOnDemandPageScanResult): Promise<OnDemandPageScanResult> {
+    public async updateScanRun(pageScanResult: Partial<OnDemandPageScanResult>): Promise<OnDemandPageScanResult> {
+        if (pageScanResult.id === undefined) {
+            throw new Error(`Cannot update scan run using partial scan run without id: ${JSON.stringify(pageScanResult)}`);
+        }
         const persistedResult = pageScanResult as OnDemandPageScanResult;
         this.setSystemProperties(persistedResult);
 

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -72,3 +72,7 @@ export interface OnDemandPageScanRunResult {
     pageTitle?: string;
     pageResponseCode?: number;
 }
+
+export interface PartialOnDemandPageScanResult extends Partial<OnDemandPageScanResult> {
+    id: string;
+}

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -38,7 +38,7 @@ export interface OnDemandPageScanResult extends StorageDocument {
     run: OnDemandPageScanRunResult;
     priority: number;
     itemType: ItemType.onDemandPageScanRunResult;
-    batchRequestId: string;
+    batchRequestId?: string;
     notification?: ScanCompletedNotification;
 }
 
@@ -71,8 +71,4 @@ export interface OnDemandPageScanRunResult {
     error?: string | ScanError;
     pageTitle?: string;
     pageResponseCode?: number;
-}
-
-export interface PartialOnDemandPageScanResult extends Partial<OnDemandPageScanResult> {
-    id: string;
 }

--- a/packages/storage-documents/src/on-demand-scan-request-message.ts
+++ b/packages/storage-documents/src/on-demand-scan-request-message.ts
@@ -3,4 +3,6 @@
 
 export interface OnDemandScanRequestMessage {
     id: string;
+    batchRequestId: string;
+    url: string;
 }

--- a/packages/storage-documents/src/on-demand-scan-request-message.ts
+++ b/packages/storage-documents/src/on-demand-scan-request-message.ts
@@ -3,6 +3,5 @@
 
 export interface OnDemandScanRequestMessage {
     id: string;
-    batchRequestId: string;
     url: string;
 }

--- a/packages/storage-documents/src/on-demand-scan-request-message.ts
+++ b/packages/storage-documents/src/on-demand-scan-request-message.ts
@@ -3,6 +3,4 @@
 
 export interface OnDemandScanRequestMessage {
     id: string;
-    url: string;
-    priority: number;
 }

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
@@ -22,6 +22,7 @@ describe('Scan request sender', () => {
     let pageScanRequestProvider: IMock<PageScanRequestProvider>;
     let onDemandPageScanRunResultProvider: IMock<OnDemandPageScanRunResultProvider>;
     let dateNow: Date;
+    const batchRequestId: string = 'batch request id';
 
     beforeEach(() => {
         dateNow = new Date();
@@ -143,11 +144,15 @@ describe('Scan request sender', () => {
                 timestamp: dateNow.toJSON(),
             },
             itemType: ItemType.onDemandPageScanRunResult,
-            batchRequestId: scanRequest.id,
+            batchRequestId: batchRequestId,
         };
     }
 
     function createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest): OnDemandScanRequestMessage {
-        return { id: scanRequest.id };
+        return {
+            id: scanRequest.id,
+            url: scanRequest.url,
+            batchRequestId: batchRequestId,
+        };
     }
 });

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
@@ -152,7 +152,6 @@ describe('Scan request sender', () => {
         return {
             id: scanRequest.id,
             url: scanRequest.url,
-            batchRequestId: batchRequestId,
         };
     }
 });

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
@@ -148,10 +148,6 @@ describe('Scan request sender', () => {
     }
 
     function createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest): OnDemandScanRequestMessage {
-        return {
-            id: scanRequest.id,
-            url: scanRequest.url,
-            priority: scanRequest.priority,
-        };
+        return { id: scanRequest.id };
     }
 });

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
@@ -12,7 +12,7 @@ export class OnDemandScanRequestSender {
         @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
         @inject(Queue) private readonly queue: Queue,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
-    ) { }
+    ) {}
 
     public async sendRequestToScan(onDemandPageScanRequests: OnDemandPageScanRequest[]): Promise<void> {
         await Promise.all(
@@ -20,7 +20,7 @@ export class OnDemandScanRequestSender {
                 const resultDocs = await this.onDemandPageScanRunResultProvider.readScanRuns([page.id]);
                 const resultDoc = resultDocs.pop();
                 if (resultDoc !== undefined && resultDoc.run !== undefined && resultDoc.run.state === 'accepted') {
-                    const message = this.createOnDemandScanRequestMessage(page);
+                    const message = this.createOnDemandScanRequestMessage(page, resultDoc.batchRequestId);
                     await this.queue.createMessage(this.storageConfig.scanQueue, message);
                     await this.updateOnDemandPageResultDoc(resultDoc);
                 }
@@ -41,7 +41,11 @@ export class OnDemandScanRequestSender {
         await this.onDemandPageScanRunResultProvider.writeScanRuns([resultDoc]);
     }
 
-    private createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest): OnDemandScanRequestMessage {
-        return { id: scanRequest.id };
+    private createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest, batchRequestId: string): OnDemandScanRequestMessage {
+        return {
+            id: scanRequest.id,
+            url: scanRequest.url,
+            batchRequestId: batchRequestId,
+        };
     }
 }

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
@@ -20,7 +20,7 @@ export class OnDemandScanRequestSender {
                 const resultDocs = await this.onDemandPageScanRunResultProvider.readScanRuns([page.id]);
                 const resultDoc = resultDocs.pop();
                 if (resultDoc !== undefined && resultDoc.run !== undefined && resultDoc.run.state === 'accepted') {
-                    const message = this.createOnDemandScanRequestMessage(page, resultDoc.batchRequestId);
+                    const message = this.createOnDemandScanRequestMessage(page);
                     await this.queue.createMessage(this.storageConfig.scanQueue, message);
                     await this.updateOnDemandPageResultDoc(resultDoc);
                 }
@@ -41,11 +41,10 @@ export class OnDemandScanRequestSender {
         await this.onDemandPageScanRunResultProvider.writeScanRuns([resultDoc]);
     }
 
-    private createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest, batchRequestId: string): OnDemandScanRequestMessage {
+    private createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest): OnDemandScanRequestMessage {
         return {
             id: scanRequest.id,
             url: scanRequest.url,
-            batchRequestId: batchRequestId,
         };
     }
 }

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
@@ -12,7 +12,7 @@ export class OnDemandScanRequestSender {
         @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
         @inject(Queue) private readonly queue: Queue,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
-    ) {}
+    ) { }
 
     public async sendRequestToScan(onDemandPageScanRequests: OnDemandPageScanRequest[]): Promise<void> {
         await Promise.all(
@@ -42,10 +42,6 @@ export class OnDemandScanRequestSender {
     }
 
     private createOnDemandScanRequestMessage(scanRequest: OnDemandPageScanRequest): OnDemandScanRequestMessage {
-        return {
-            id: scanRequest.id,
-            url: scanRequest.url,
-            priority: scanRequest.priority,
-        };
+        return { id: scanRequest.id };
     }
 }

--- a/packages/web-api-scan-runner/run-script/start-web-api-scan-runner.sh
+++ b/packages/web-api-scan-runner/run-script/start-web-api-scan-runner.sh
@@ -4,4 +4,4 @@
 export NODE_PATH=$AZ_BATCH_NODE_SHARED_DIR/batch-web-api-scan-runner/node_modules
 
 echo "Starting runner"
-nodejs web-api-scan-runner.js --id=$1 --url=$2 --batchRequestId=$3
+nodejs web-api-scan-runner.js --id=$1 --url=$2

--- a/packages/web-api-scan-runner/run-script/start-web-api-scan-runner.sh
+++ b/packages/web-api-scan-runner/run-script/start-web-api-scan-runner.sh
@@ -4,4 +4,4 @@
 export NODE_PATH=$AZ_BATCH_NODE_SHARED_DIR/batch-web-api-scan-runner/node_modules
 
 echo "Starting runner"
-nodejs web-api-scan-runner.js --id=$1 --url=$2 --priority=$3
+nodejs web-api-scan-runner.js --id=$1 --url=$2 --batchRequestId=$3

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -352,6 +352,8 @@ describe(Runner, () => {
                 timestamp: dateNow.toJSON(),
                 error: null,
             },
+            scanResult: null,
+            reports: null,
         };
     }
 
@@ -375,6 +377,8 @@ describe(Runner, () => {
                 timestamp: dateNow.toJSON(),
                 error,
             },
+            scanResult: null,
+            reports: null,
         };
 
         if (withPageInfo) {

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -15,7 +15,6 @@ import {
     OnDemandPageScanReport,
     OnDemandPageScanResult,
     OnDemandPageScanRunState,
-    PartialOnDemandPageScanResult,
 } from 'storage-documents';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
@@ -27,7 +26,7 @@ import { Runner } from './runner';
 
 // tslint:disable: no-any mocha-no-side-effect-code no-object-literal-type-assertion no-unsafe-any no-null-keyword
 
-class MockableLogger extends Logger {}
+class MockableLogger extends Logger { }
 
 describe(Runner, () => {
     let runner: Runner;
@@ -350,7 +349,7 @@ describe(Runner, () => {
         reportGeneratorMock.setup(r => r.generateReports(scanResults)).returns(() => [generatedReport1, generatedReport2]);
     }
 
-    function getRunningJobStateScanResult(): PartialOnDemandPageScanResult {
+    function getRunningJobStateScanResult(): Partial<OnDemandPageScanResult> {
         return {
             id: onDemandPageScanResult.id,
             run: {
@@ -373,8 +372,8 @@ describe(Runner, () => {
             .verifiable();
     }
 
-    function getFailingJobStateScanResult(error: any, withPageInfo: boolean = true): PartialOnDemandPageScanResult {
-        const result: PartialOnDemandPageScanResult = {
+    function getFailingJobStateScanResult(error: any, withPageInfo: boolean = true): Partial<OnDemandPageScanResult> {
+        const result: Partial<OnDemandPageScanResult> = {
             id: onDemandPageScanResult.id,
             run: {
                 state: 'failed',
@@ -391,7 +390,7 @@ describe(Runner, () => {
         return result;
     }
 
-    function setupUpdateScanRunResultCall(result: PartialOnDemandPageScanResult): void {
+    function setupUpdateScanRunResultCall(result: Partial<OnDemandPageScanResult>): void {
         const clonedResult = cloneDeep(result);
 
         onDemandPageScanRunResultProviderMock
@@ -400,7 +399,7 @@ describe(Runner, () => {
             .verifiable();
     }
 
-    function getScanResultWithNoViolations(): PartialOnDemandPageScanResult {
+    function getScanResultWithNoViolations(): Partial<OnDemandPageScanResult> {
         return {
             id: onDemandPageScanResult.id,
             run: {
@@ -417,7 +416,7 @@ describe(Runner, () => {
         };
     }
 
-    function getScanResultWithViolations(): PartialOnDemandPageScanResult {
+    function getScanResultWithViolations(): Partial<OnDemandPageScanResult> {
         return {
             id: onDemandPageScanResult.id,
             run: {

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -10,12 +10,7 @@ import * as MockDate from 'mockdate';
 import { Browser } from 'puppeteer';
 import { AxeScanResults } from 'scanner';
 import { OnDemandPageScanRunResultProvider, PageScanRunReportService } from 'service-library';
-import {
-    ItemType,
-    OnDemandPageScanReport,
-    OnDemandPageScanResult,
-    OnDemandPageScanRunState,
-} from 'storage-documents';
+import { ItemType, OnDemandPageScanReport, OnDemandPageScanResult, OnDemandPageScanRunState } from 'storage-documents';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
 import { ScanMetadataConfig } from '../scan-metadata-config';
@@ -26,7 +21,7 @@ import { Runner } from './runner';
 
 // tslint:disable: no-any mocha-no-side-effect-code no-object-literal-type-assertion no-unsafe-any no-null-keyword
 
-class MockableLogger extends Logger { }
+class MockableLogger extends Logger {}
 
 describe(Runner, () => {
     let runner: Runner;

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -43,7 +43,6 @@ describe(Runner, () => {
     const scanMetadata: ScanMetadata = {
         id: 'id',
         url: 'url',
-        batchRequestId: 'batch request id',
     };
 
     const onDemandPageScanResult: OnDemandPageScanResult = {

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -33,7 +33,7 @@ export class Runner {
         @inject(Logger) private readonly logger: Logger,
         @inject(PageScanRunReportService) private readonly pageScanRunReportService: PageScanRunReportService,
         @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
-    ) { }
+    ) {}
 
     public async run(): Promise<void> {
         let browser: Browser;

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -43,7 +43,7 @@ export class Runner {
         const scanSubmittedTimestamp: number = this.guidGenerator.getGuidTimestamp(scanMetadata.id).getTime();
 
         this.logger.logInfo(`Reading page scan run result.`);
-        this.logger.setCustomProperties({ scanId: scanMetadata.id, batchRequestId: scanMetadata.batchRequestId });
+        this.logger.setCustomProperties({ scanId: scanMetadata.id });
 
         this.logger.trackEvent('ScanTaskStarted', undefined, { scanWaitTime: (scanStartedTimestamp - scanSubmittedTimestamp) / 1000 });
 

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -9,10 +9,10 @@ import { AxeScanResults } from 'scanner';
 import { OnDemandPageScanRunResultProvider, PageScanRunReportService } from 'service-library';
 import {
     OnDemandPageScanReport,
-    OnDemandPageScanResult,
     OnDemandPageScanRunResult,
     OnDemandPageScanRunState,
     OnDemandScanResult,
+    PartialOnDemandPageScanResult,
     ScanError,
 } from 'storage-documents';
 import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
@@ -37,25 +37,31 @@ export class Runner {
 
     public async run(): Promise<void> {
         let browser: Browser;
-        let pageScanResult: OnDemandPageScanResult;
         const scanMetadata = this.scanMetadataConfig.getConfig();
 
         const scanStartedTimestamp: number = Date.now();
         const scanSubmittedTimestamp: number = this.guidGenerator.getGuidTimestamp(scanMetadata.id).getTime();
 
         this.logger.logInfo(`Reading page scan run result.`);
-        pageScanResult = await this.onDemandPageScanRunResultProvider.readScanRun(scanMetadata.id);
-        this.logger.setCustomProperties({ scanId: scanMetadata.id, batchRequestId: pageScanResult.batchRequestId });
+        this.logger.setCustomProperties({ scanId: scanMetadata.id, batchRequestId: scanMetadata.batchRequestId });
 
         this.logger.trackEvent('ScanTaskStarted', undefined, { scanWaitTime: (scanStartedTimestamp - scanSubmittedTimestamp) / 1000 });
 
         this.logger.logInfo(`Updating page scan run result state to running.`);
-        pageScanResult = this.resetPageScanResultState(pageScanResult);
-        pageScanResult = await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
+        const pageScanResult: PartialOnDemandPageScanResult = {
+            id: scanMetadata.id,
+            run: {
+                state: 'running',
+                timestamp: new Date().toJSON(),
+                error: null,
+            },
+        };
+
+        await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
 
         try {
             browser = await this.webDriverTask.launch();
-            await this.scan(pageScanResult);
+            await this.scan(pageScanResult, scanMetadata.url);
         } catch (error) {
             const errorMessage = this.getErrorMessage(error);
             pageScanResult.run = this.createRunResult('failed', errorMessage);
@@ -79,10 +85,10 @@ export class Runner {
         await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
     }
 
-    private async scan(pageScanResult: OnDemandPageScanResult): Promise<void> {
+    private async scan(pageScanResult: PartialOnDemandPageScanResult, url: string): Promise<void> {
         this.logger.logInfo(`Running page scan.`);
 
-        const axeScanResults = await this.scannerTask.scan(pageScanResult.url);
+        const axeScanResults = await this.scannerTask.scan(url);
 
         if (!isNil(axeScanResults.error)) {
             this.logger.logInfo(`Updating page scan run result state to failed`);
@@ -101,18 +107,6 @@ export class Runner {
 
         pageScanResult.run.pageTitle = axeScanResults.pageTitle;
         pageScanResult.run.pageResponseCode = axeScanResults.pageResponseCode;
-    }
-
-    private resetPageScanResultState(originPageScanResult: OnDemandPageScanResult): OnDemandPageScanResult {
-        originPageScanResult.scanResult = null;
-        originPageScanResult.reports = null;
-        originPageScanResult.run = {
-            state: 'running',
-            timestamp: new Date().toJSON(),
-            error: null,
-        };
-
-        return originPageScanResult;
     }
 
     private createRunResult(state: OnDemandPageScanRunState, error?: string | ScanError): OnDemandPageScanRunResult {

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -55,6 +55,8 @@ export class Runner {
                 timestamp: new Date().toJSON(),
                 error: null,
             },
+            scanResult: null,
+            reports: null,
         };
 
         await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -9,10 +9,10 @@ import { AxeScanResults } from 'scanner';
 import { OnDemandPageScanRunResultProvider, PageScanRunReportService } from 'service-library';
 import {
     OnDemandPageScanReport,
+    OnDemandPageScanResult,
     OnDemandPageScanRunResult,
     OnDemandPageScanRunState,
     OnDemandScanResult,
-    PartialOnDemandPageScanResult,
     ScanError,
 } from 'storage-documents';
 import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
@@ -33,7 +33,7 @@ export class Runner {
         @inject(Logger) private readonly logger: Logger,
         @inject(PageScanRunReportService) private readonly pageScanRunReportService: PageScanRunReportService,
         @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
-    ) {}
+    ) { }
 
     public async run(): Promise<void> {
         let browser: Browser;
@@ -48,7 +48,7 @@ export class Runner {
         this.logger.trackEvent('ScanTaskStarted', undefined, { scanWaitTime: (scanStartedTimestamp - scanSubmittedTimestamp) / 1000 });
 
         this.logger.logInfo(`Updating page scan run result state to running.`);
-        const pageScanResult: PartialOnDemandPageScanResult = {
+        const pageScanResult: Partial<OnDemandPageScanResult> = {
             id: scanMetadata.id,
             run: {
                 state: 'running',
@@ -85,7 +85,7 @@ export class Runner {
         await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
     }
 
-    private async scan(pageScanResult: PartialOnDemandPageScanResult, url: string): Promise<void> {
+    private async scan(pageScanResult: Partial<OnDemandPageScanResult>, url: string): Promise<void> {
         this.logger.logInfo(`Running page scan.`);
 
         const axeScanResults = await this.scannerTask.scan(url);

--- a/packages/web-api-scan-runner/src/scan-metadata-config.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-metadata-config.spec.ts
@@ -22,6 +22,6 @@ describe(ScanMetadataConfig, () => {
     it('getConfig', () => {
         expect(testSubject.getConfig()).toBe(argvVal);
 
-        argvMock.verify(a => a.demandOption(['id', 'url', 'priority']), Times.once());
+        argvMock.verify(a => a.demandOption(['id', 'url', 'batchRequestId']), Times.once());
     });
 });

--- a/packages/web-api-scan-runner/src/scan-metadata-config.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-metadata-config.spec.ts
@@ -22,6 +22,6 @@ describe(ScanMetadataConfig, () => {
     it('getConfig', () => {
         expect(testSubject.getConfig()).toBe(argvVal);
 
-        argvMock.verify(a => a.demandOption(['id', 'url', 'batchRequestId']), Times.once());
+        argvMock.verify(a => a.demandOption(['id', 'url']), Times.once());
     });
 });

--- a/packages/web-api-scan-runner/src/scan-metadata-config.ts
+++ b/packages/web-api-scan-runner/src/scan-metadata-config.ts
@@ -10,7 +10,7 @@ export class ScanMetadataConfig {
     constructor(@inject(loggerTypes.Argv) private readonly argvObj: Argv) {}
 
     public getConfig(): ScanMetadata {
-        this.argvObj.demandOption(['id', 'url', 'batchRequestId']);
+        this.argvObj.demandOption(['id', 'url']);
 
         return this.argvObj.argv as Arguments<ScanMetadata>;
     }

--- a/packages/web-api-scan-runner/src/scan-metadata-config.ts
+++ b/packages/web-api-scan-runner/src/scan-metadata-config.ts
@@ -10,7 +10,7 @@ export class ScanMetadataConfig {
     constructor(@inject(loggerTypes.Argv) private readonly argvObj: Argv) {}
 
     public getConfig(): ScanMetadata {
-        this.argvObj.demandOption(['id', 'url', 'priority']);
+        this.argvObj.demandOption(['id', 'url', 'batchRequestId']);
 
         return this.argvObj.argv as Arguments<ScanMetadata>;
     }

--- a/packages/web-api-scan-runner/src/types/scan-metadata.ts
+++ b/packages/web-api-scan-runner/src/types/scan-metadata.ts
@@ -3,5 +3,5 @@
 export interface ScanMetadata {
     id: string;
     url: string;
-    priority: number;
+    batchRequestId: string;
 }

--- a/packages/web-api-scan-runner/src/types/scan-metadata.ts
+++ b/packages/web-api-scan-runner/src/types/scan-metadata.ts
@@ -3,5 +3,4 @@
 export interface ScanMetadata {
     id: string;
     url: string;
-    batchRequestId: string;
 }

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.spec.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.spec.ts
@@ -23,7 +23,7 @@ import { NotificationSender } from './notification-sender';
 
 // tslint:disable: no-any mocha-no-side-effect-code no-object-literal-type-assertion no-unsafe-any no-null-keyword
 
-class MockableLogger extends Logger {}
+class MockableLogger extends Logger { }
 
 describe(NotificationSender, () => {
     let sender: NotificationSender;
@@ -95,8 +95,6 @@ describe(NotificationSender, () => {
     });
 
     it('Send Notification Succeeded', async () => {
-        setupReadScanResultCall(onDemandPageScanResult);
-
         const notification = generateNotification(notificationSenderMetadata.scanNotifyUrl, 'sent', null, 200);
         setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
 
@@ -116,8 +114,6 @@ describe(NotificationSender, () => {
     });
 
     it('Send Notification Failed', async () => {
-        setupReadScanResultCall(onDemandPageScanResult);
-
         const notification = generateNotification(
             notificationSenderMetadata.scanNotifyUrl,
             'sendFailed',
@@ -145,8 +141,6 @@ describe(NotificationSender, () => {
     });
 
     it('Send Notification Failed Error', async () => {
-        setupReadScanResultCall(onDemandPageScanResult);
-
         const notification = generateNotification(
             notificationSenderMetadata.scanNotifyUrl,
             'sendFailed',
@@ -179,24 +173,17 @@ describe(NotificationSender, () => {
         systemMock.verifyAll();
     });
 
-    function setupReadScanResultCall(scanResult: any): void {
-        onDemandPageScanRunResultProviderMock
-            .setup(async d => d.readScanRun(notificationSenderMetadata.scanId))
-            .returns(async () => Promise.resolve(cloneDeep(scanResult)))
-            .verifiable(Times.once());
+    function getRunningJobStateScanResult(notification: ScanCompletedNotification): Partial<OnDemandPageScanResult> {
+        return {
+            id: onDemandPageScanResult.id,
+            notification: notification,
+        };
     }
 
-    function getRunningJobStateScanResult(notification: ScanCompletedNotification): OnDemandPageScanResult {
-        const result = cloneDeep(onDemandPageScanResult);
-        result.notification = notification;
-
-        return result;
-    }
-
-    function setupUpdateScanRunResultCall(result: OnDemandPageScanResult): void {
+    function setupUpdateScanRunResultCall(result: Partial<OnDemandPageScanResult>): void {
         onDemandPageScanRunResultProviderMock
             .setup(async d => d.updateScanRun(result))
-            .returns(async () => Promise.resolve(result))
+            .returns(async () => Promise.resolve(result as OnDemandPageScanResult))
             .verifiable(Times.once());
     }
 

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.spec.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.spec.ts
@@ -23,7 +23,7 @@ import { NotificationSender } from './notification-sender';
 
 // tslint:disable: no-any mocha-no-side-effect-code no-object-literal-type-assertion no-unsafe-any no-null-keyword
 
-class MockableLogger extends Logger { }
+class MockableLogger extends Logger {}
 
 describe(NotificationSender, () => {
     let sender: NotificationSender;

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
@@ -21,7 +21,7 @@ export class NotificationSender {
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
         private readonly system: typeof System = System,
-    ) { }
+    ) {}
 
     public async sendNotification(): Promise<void> {
         const notificationSenderConfigData = this.notificationSenderConfig.getConfig();
@@ -86,12 +86,7 @@ export class NotificationSender {
 
         return {
             id: scanId,
-            notification: this.generateNotification(
-                notificationSenderConfigData.scanNotifyUrl,
-                notificationState,
-                error,
-                statusCode,
-            ),
+            notification: this.generateNotification(notificationSenderConfigData.scanNotifyUrl, notificationState, error, statusCode),
         };
     }
 


### PR DESCRIPTION
#### Description of changes

- Remove unused priority field from OnDemandScanRequestMessage
- Add batchRequestId to OnDemandScanRequestMessage
- Refactor updateScanRuns to accept a partial document (with only id required)
- Refactor runner to update the scan run document without first reading it

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #620 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
