### PR TITLE
feat(send-notification): adding scan notification task creator

### DIFF
--- a/packages/azure-services/src/azure-batch/pool-load-generator.spec.ts
+++ b/packages/azure-services/src/azure-batch/pool-load-generator.spec.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { ServiceConfiguration } from 'common';
+import { JobManagerConfig, ServiceConfiguration } from 'common';
 import * as moment from 'moment';
 import { IMock, Mock } from 'typemoq';
 import { PoolLoadGenerator, PoolMetricsInfo } from './pool-load-generator';
 
-// tslint:disable: no-unsafe-any
+// tslint:disable: no-unsafe-any no-object-literal-type-assertion
 
 let poolMetricsInfo: PoolMetricsInfo;
 let poolLoadGenerator: PoolLoadGenerator;
@@ -26,7 +26,7 @@ describe(PoolLoadGenerator, () => {
                     activeToRunningTasksRatio: activeToRunningTasksRatio,
                     addTasksIntervalInSeconds: 15,
                     maxWallClockTimeInHours: 1,
-                };
+                } as JobManagerConfig;
             });
 
         jest.spyOn(process, 'hrtime').mockImplementation((time?: [number, number]) => [5, 0]);

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -45,6 +45,11 @@ Object {
       "doc": "The amount of time the job manager instance will run.",
       "format": "int",
     },
+    "sendNotificationTasksCount": Object {
+      "default": 100,
+      "doc": "Number of scan notification tasks that can be in active/running state",
+      "format": "int",
+    },
   },
   "logConfig": Object {
     "logInConsole": Object {
@@ -217,6 +222,11 @@ Object {
     "maxWallClockTimeInHours": Object {
       "default": 2,
       "doc": "The amount of time the job manager instance will run.",
+      "format": "int",
+    },
+    "sendNotificationTasksCount": Object {
+      "default": 100,
+      "doc": "Number of scan notification tasks that can be in active/running state",
       "format": "int",
     },
   },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -4,6 +4,7 @@ import * as convict from 'convict';
 import * as fs from 'fs';
 import { injectable } from 'inversify';
 import { isNil } from 'lodash';
+import { format } from 'url';
 
 export interface TaskRuntimeConfig {
     taskTimeoutInMinutes: number;
@@ -23,6 +24,7 @@ export interface JobManagerConfig {
     activeToRunningTasksRatio: number;
     addTasksIntervalInSeconds: number;
     maxWallClockTimeInHours: number;
+    sendNotificationTasksCount: number;
 }
 
 export interface ScanRunTimeConfig {
@@ -149,6 +151,11 @@ export class ServiceConfiguration {
                     format: 'int',
                     default: 2,
                     doc: 'The amount of time the job manager instance will run.',
+                },
+                sendNotificationTasksCount: {
+                    format: 'int',
+                    default: 100,
+                    doc: 'Number of scan notification tasks that can be in active/running state',
                 },
             },
             scanConfig: {

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -4,7 +4,6 @@ import * as convict from 'convict';
 import * as fs from 'fs';
 import { injectable } from 'inversify';
 import { isNil } from 'lodash';
-import { format } from 'url';
 
 export interface TaskRuntimeConfig {
     taskTimeoutInMinutes: number;

--- a/packages/job-manager/src/batch/pool-load-generator.spec.ts
+++ b/packages/job-manager/src/batch/pool-load-generator.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { ServiceConfiguration } from 'common';
+import { JobManagerConfig, ServiceConfiguration } from 'common';
 import { IMock, Mock } from 'typemoq';
 import { PoolLoadGenerator, PoolMetricsInfo } from './pool-load-generator';
 
@@ -10,6 +10,8 @@ let poolMetricsInfo: PoolMetricsInfo;
 let poolLoadGenerator: PoolLoadGenerator;
 let serviceConfigMock: IMock<ServiceConfiguration>;
 let activeToRunningTasksRatio: number;
+
+// tslint:disable: no-object-literal-type-assertion
 
 describe(PoolLoadGenerator, () => {
     beforeEach(() => {
@@ -22,7 +24,7 @@ describe(PoolLoadGenerator, () => {
                     activeToRunningTasksRatio: activeToRunningTasksRatio,
                     addTasksIntervalInSeconds: 15,
                     maxWallClockTimeInHours: 1,
-                };
+                } as JobManagerConfig;
             });
 
         poolLoadGenerator = new PoolLoadGenerator(serviceConfigMock.object);

--- a/packages/job-manager/src/worker/worker.spec.ts
+++ b/packages/job-manager/src/worker/worker.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { Message, Queue } from 'azure-services';
-import { ServiceConfiguration, System } from 'common';
+import { JobManagerConfig, ServiceConfiguration, System } from 'common';
 import * as _ from 'lodash';
 import * as moment from 'moment';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
@@ -63,7 +63,7 @@ describe(Worker, () => {
                     activeToRunningTasksRatio: activeToRunningTasksRatioDefault,
                     addTasksIntervalInSeconds: addTasksIntervalInSecondsDefault,
                     maxWallClockTimeInHours: maxWallClockTimeInHours,
-                };
+                } as JobManagerConfig;
             })
             .verifiable(Times.atLeastOnce());
 

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -85,7 +85,13 @@ export abstract class BatchTaskCreator {
 
     protected hasChildTasksRunning(poolMetricsInfo: PoolMetricsInfo): boolean {
         // The Batch service API may set activeTasks value instead of runningTasks value hence handle this case
-        return poolMetricsInfo.load.activeTasks + poolMetricsInfo.load.runningTasks > 1;
+        return this.getChildTasksCount(poolMetricsInfo) > 0;
+    }
+
+    protected getChildTasksCount(poolMetricsInfo: PoolMetricsInfo): number {
+        const taskCount = poolMetricsInfo.load.activeTasks + poolMetricsInfo.load.runningTasks - 1;
+
+        return taskCount < 0 ? 0 : taskCount;
     }
 
     protected async addTasksToJob(messages: Message[]): Promise<JobTask[]> {

--- a/packages/web-api-scan-job-manager/src/web-api-scan-job-manager-entry-point.spec.ts
+++ b/packages/web-api-scan-job-manager/src/web-api-scan-job-manager-entry-point.spec.ts
@@ -4,23 +4,30 @@ import 'reflect-metadata';
 
 import { Container } from 'inversify';
 import { BaseTelemetryProperties } from 'logger';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 import { WebApiScanJobManagerEntryPoint } from './web-api-scan-job-manager-entry-point';
-
+import { Worker } from './worker/worker';
 // tslint:disable: no-object-literal-type-assertion
 
 class TestableWebApiScanJobManagerEntryPoint extends WebApiScanJobManagerEntryPoint {
     public invokeGetTelemetryBaseProperties(): BaseTelemetryProperties {
         return this.getTelemetryBaseProperties();
     }
+
+    // tslint:disable-next-line: no-unnecessary-override
+    public async runCustomAction(container: Container): Promise<void> {
+        return super.runCustomAction(container);
+    }
 }
 
 describe(WebApiScanJobManagerEntryPoint, () => {
     let testSubject: TestableWebApiScanJobManagerEntryPoint;
     let containerMock: IMock<Container>;
+    let workerMock: IMock<Worker>;
 
     beforeEach(() => {
         containerMock = Mock.ofType(Container);
+        workerMock = Mock.ofType(Worker);
 
         testSubject = new TestableWebApiScanJobManagerEntryPoint(containerMock.object);
     });
@@ -31,5 +38,30 @@ describe(WebApiScanJobManagerEntryPoint, () => {
                 source: 'webApiScanJobManager',
             } as BaseTelemetryProperties);
         });
+    });
+
+    describe('runCustomAction', () => {
+        beforeEach(() => {
+            containerMock.setup(c => c.get(Worker)).returns(() => workerMock.object);
+        });
+
+        it('invokes worker', async () => {
+            workerMock
+                .setup(async w => w.init())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            workerMock
+                .setup(async w => w.run())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            await testSubject.runCustomAction(containerMock.object);
+        });
+    });
+
+    afterEach(() => {
+        containerMock.verifyAll();
+        workerMock.verifyAll();
     });
 });

--- a/packages/web-api-scan-job-manager/src/web-api-scan-job-manager-entry-point.ts
+++ b/packages/web-api-scan-job-manager/src/web-api-scan-job-manager-entry-point.ts
@@ -13,6 +13,7 @@ export class WebApiScanJobManagerEntryPoint extends ProcessEntryPointBase {
 
     protected async runCustomAction(container: Container): Promise<void> {
         const worker = container.get<Worker>(Worker);
+        await worker.init();
         await worker.run();
     }
 }

--- a/packages/web-api-scan-job-manager/src/worker/__snapshots__/worker.spec.ts.snap
+++ b/packages/web-api-scan-job-manager/src/worker/__snapshots__/worker.spec.ts.snap
@@ -1,12 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Worker onExit complete failed tasks - {
-  failureInfo: {
-    category: 'serverError',
-    code: '3456',
-    message: 'some server error occurred'
-  }
-} 1`] = `
+exports[`Worker onExit complete failed tasks - {"failureInfo":{"category":"serverError","code":"3456","message":"some server error occurred"}} 1`] = `
 Object {
   "id": "task id1",
   "run": Object {
@@ -17,7 +11,7 @@ Object {
 }
 `;
 
-exports[`Worker onExit complete failed tasks - { failureInfo: undefined } 1`] = `
+exports[`Worker onExit complete failed tasks - {} 1`] = `
 Object {
   "id": "task id1",
   "run": Object {

--- a/packages/web-api-scan-job-manager/src/worker/__snapshots__/worker.spec.ts.snap
+++ b/packages/web-api-scan-job-manager/src/worker/__snapshots__/worker.spec.ts.snap
@@ -12,7 +12,7 @@ Object {
   "run": Object {
     "error": "Task was terminated unexpectedly. Exit code: 123, Error category: serverError, Error details: some server error occurred",
     "state": "failed",
-    "timestamp": "2020-02-01T08:00:00.000Z",
+    "timestamp": "2020-01-01T12:00:00.000Z",
   },
 }
 `;
@@ -23,7 +23,7 @@ Object {
   "run": Object {
     "error": "Task was terminated unexpectedly. Exit code: 123",
     "state": "failed",
-    "timestamp": "2020-02-01T08:00:00.000Z",
+    "timestamp": "2020-01-01T12:00:00.000Z",
   },
 }
 `;
@@ -34,7 +34,7 @@ Object {
   "run": Object {
     "error": "Task was terminated unexpectedly. Exit code: 123",
     "state": "failed",
-    "timestamp": "2020-02-01T08:00:00.000Z",
+    "timestamp": "2020-01-01T12:00:00.000Z",
   },
 }
 `;
@@ -45,7 +45,7 @@ Object {
   "run": Object {
     "error": "Task was terminated unexpectedly. Exit code: 456",
     "state": "failed",
-    "timestamp": "2020-02-02T08:00:00.000Z",
+    "timestamp": "2020-01-02T12:00:00.000Z",
   },
 }
 `;

--- a/packages/web-api-scan-job-manager/src/worker/__snapshots__/worker.spec.ts.snap
+++ b/packages/web-api-scan-job-manager/src/worker/__snapshots__/worker.spec.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Worker onExit complete failed tasks - {
+  failureInfo: {
+    category: 'serverError',
+    code: '3456',
+    message: 'some server error occurred'
+  }
+} 1`] = `
+Object {
+  "id": "task id1",
+  "run": Object {
+    "error": "Task was terminated unexpectedly. Exit code: 123, Error category: serverError, Error details: some server error occurred",
+    "state": "failed",
+    "timestamp": "2020-02-01T08:00:00.000Z",
+  },
+}
+`;
+
+exports[`Worker onExit complete failed tasks - { failureInfo: undefined } 1`] = `
+Object {
+  "id": "task id1",
+  "run": Object {
+    "error": "Task was terminated unexpectedly. Exit code: 123",
+    "state": "failed",
+    "timestamp": "2020-02-01T08:00:00.000Z",
+  },
+}
+`;
+
+exports[`Worker onExit handles multiple failed tasks 1`] = `
+Object {
+  "id": "task id1",
+  "run": Object {
+    "error": "Task was terminated unexpectedly. Exit code: 123",
+    "state": "failed",
+    "timestamp": "2020-02-01T08:00:00.000Z",
+  },
+}
+`;
+
+exports[`Worker onExit handles multiple failed tasks 2`] = `
+Object {
+  "id": "task id2",
+  "run": Object {
+    "error": "Task was terminated unexpectedly. Exit code: 456",
+    "state": "failed",
+    "timestamp": "2020-02-02T08:00:00.000Z",
+  },
+}
+`;

--- a/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
@@ -177,7 +177,7 @@ describe(Worker, () => {
                     id: undefined,
                 },
             },
-        ])('logs error if unable to get required task arguments - %o', async testCase => {
+        ])('logs error if unable to get required task arguments - %j', async testCase => {
             const failedTasks = [
                 {
                     taskArguments: JSON.stringify(testCase.taskArguments),
@@ -257,7 +257,7 @@ describe(Worker, () => {
                     message: 'some server error occurred',
                 } as BatchTaskFailureInfo,
             },
-        ])('complete failed tasks - %o', async testCase => {
+        ])('complete failed tasks - %j', async testCase => {
             const taskArgs: TaskArguments = {
                 id: 'task id1',
             };

--- a/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
@@ -2,16 +2,26 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { Batch, BatchConfig, BatchTask, JobTask, JobTaskState, Message, PoolLoadGenerator, Queue } from 'azure-services';
+import {
+    Batch,
+    BatchConfig,
+    BatchTask,
+    BatchTaskFailureInfo,
+    JobTask,
+    Message,
+    PoolLoadGenerator,
+    PoolLoadSnapshot,
+    PoolMetricsInfo,
+    Queue,
+} from 'azure-services';
 import { ServiceConfiguration, System } from 'common';
-import * as _ from 'lodash';
-import { BatchPoolMeasurements } from 'logger';
+import { isEqual, isNil } from 'lodash';
 import * as moment from 'moment';
 import { BatchPoolLoadSnapshotProvider, OnDemandPageScanRunResultProvider } from 'service-library';
-import { OnDemandPageScanRunState, StorageDocument } from 'storage-documents';
+import { OnDemandPageScanResult, StorageDocument } from 'storage-documents';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
-import { Worker } from './worker';
+import { TaskArguments, Worker } from './worker';
 
 // tslint:disable: no-unsafe-any no-object-literal-type-assertion no-any mocha-no-side-effect-code no-null-keyword
 
@@ -30,8 +40,26 @@ jest.mock('moment', () => {
     };
 });
 
+class TestableWorker extends Worker {
+    // tslint:disable-next-line: no-unnecessary-override
+    public async onTasksAdded(tasks: JobTask[]): Promise<void> {
+        return super.onTasksAdded(tasks);
+    }
+
+    // tslint:disable-next-line: no-unnecessary-override
+    public async onExit(): Promise<void> {
+        return super.onExit();
+    }
+
+    // tslint:disable-next-line: no-unnecessary-override
+    public async getMessagesForTaskCreation(): Promise<Message[]> {
+        return super.getMessagesForTaskCreation();
+    }
+}
+
 describe(Worker, () => {
-    let worker: Worker;
+    let worker: TestableWorker;
+
     let batchMock: IMock<Batch>;
     let queueMock: IMock<Queue>;
     let poolLoadGeneratorMock: IMock<PoolLoadGenerator>;
@@ -40,6 +68,7 @@ describe(Worker, () => {
     let batchPoolLoadSnapshotProviderMock: IMock<BatchPoolLoadSnapshotProvider>;
     let onDemandPageScanRunResultProviderMock: IMock<OnDemandPageScanRunResultProvider>;
     let systemMock: IMock<typeof System>;
+
     let maxWallClockTimeInHours: number;
     const batchConfig: BatchConfig = {
         accountName: 'batch-account-name',
@@ -47,65 +76,21 @@ describe(Worker, () => {
         poolId: 'pool-Id',
         jobId: 'batch-job-id',
     };
-    const activeToRunningTasksRatioDefault = 2;
-    const addTasksIntervalInSecondsDefault = 1;
     const dateNow = new Date('2019-12-12T12:00:00.000Z');
-    let poolMetricsInfo = {
-        id: 'pool-id',
-        maxTasksPerPool: 4,
-        load: {
-            activeTasks: 4,
-            runningTasks: 4,
-        },
-    };
-    const poolLoadSnapshot = {
-        tasksIncrementCountPerInterval: 60,
-        targetActiveToRunningTasksRatio: 2,
-        configuredMaxTasksPerPool: poolMetricsInfo.maxTasksPerPool,
-        poolId: poolMetricsInfo.id,
-        samplingIntervalInSeconds: 5,
-        tasksProcessingSpeedPerInterval: 7,
-        tasksProcessingSpeedPerMinute: 13,
-        timestamp: dateNow,
-        ...poolMetricsInfo.load,
-    };
 
     beforeEach(() => {
         currentTime = '2019-01-01';
-        batchMock = Mock.ofType(Batch);
-        queueMock = Mock.ofType(Queue);
-        poolLoadGeneratorMock = Mock.ofType(PoolLoadGenerator);
-        serviceConfigMock = Mock.ofType(ServiceConfiguration);
+        batchMock = Mock.ofType(Batch, MockBehavior.Strict);
+        queueMock = Mock.ofType(Queue, MockBehavior.Strict);
+        poolLoadGeneratorMock = Mock.ofType(PoolLoadGenerator, MockBehavior.Strict);
+        serviceConfigMock = Mock.ofType(ServiceConfiguration, MockBehavior.Strict);
         loggerMock = Mock.ofType(MockableLogger);
-        batchPoolLoadSnapshotProviderMock = Mock.ofType(BatchPoolLoadSnapshotProvider);
-        onDemandPageScanRunResultProviderMock = Mock.ofType(OnDemandPageScanRunResultProvider);
+        batchPoolLoadSnapshotProviderMock = Mock.ofType(BatchPoolLoadSnapshotProvider, MockBehavior.Strict);
+        onDemandPageScanRunResultProviderMock = Mock.ofType(OnDemandPageScanRunResultProvider, MockBehavior.Strict);
         systemMock = Mock.ofInstance(System, MockBehavior.Strict);
         maxWallClockTimeInHours = 1;
 
-        queueMock.setup(o => o.scanQueue).returns(() => 'scan-queue');
-
-        serviceConfigMock
-            .setup(async s => s.getConfigValue('jobManagerConfig'))
-            .returns(async () => {
-                return {
-                    activeToRunningTasksRatio: activeToRunningTasksRatioDefault,
-                    addTasksIntervalInSeconds: addTasksIntervalInSecondsDefault,
-                    maxWallClockTimeInHours: maxWallClockTimeInHours,
-                };
-            })
-            .verifiable(Times.atLeastOnce());
-
-        poolLoadGeneratorMock
-            .setup(async o => o.getPoolLoadSnapshot(poolMetricsInfo))
-            .returns(async () => Promise.resolve(poolLoadSnapshot))
-            .verifiable(Times.once());
-
-        batchMock
-            .setup(async o => o.createJobIfNotExists(batchConfig.jobId, true))
-            .returns(async () => Promise.resolve(batchConfig.jobId))
-            .verifiable(Times.once());
-
-        worker = new Worker(
+        worker = new TestableWorker(
             batchMock.object,
             queueMock.object,
             poolLoadGeneratorMock.object,
@@ -116,423 +101,403 @@ describe(Worker, () => {
             loggerMock.object,
             systemMock.object,
         );
-        worker.runOnce = true;
     });
+
+    describe('onTasksAdded', () => {
+        it('sets pool load generator last increment count', async () => {
+            const tasks: any[] = ['task1', 'task2'];
+
+            poolLoadGeneratorMock.setup(p => p.setLastTasksIncrementCount(2)).verifiable(Times.once());
+
+            await worker.onTasksAdded(tasks);
+        });
+    });
+
+    function setVerifiableFailedTasksCall(tasks: BatchTask[]): void {
+        batchMock
+            .setup(async b => b.getFailedTasks(batchConfig.jobId))
+            .returns(async () => Promise.resolve(tasks))
+            .verifiable(Times.once());
+    }
+
+    function setupVerifiableReadScanRunCall(scanId: string, document: OnDemandPageScanResult): void {
+        onDemandPageScanRunResultProviderMock
+            .setup(async s => s.readScanRun(scanId))
+            .returns(async () => Promise.resolve(document))
+            .verifiable(Times.once());
+    }
+
+    function setupVerifiableReadScanRunsCall(scanIds: string[], documents: OnDemandPageScanResult[]): void {
+        onDemandPageScanRunResultProviderMock
+            .setup(async s => s.readScanRuns(scanIds))
+            .returns(async () => Promise.resolve(documents))
+            .verifiable(Times.once());
+    }
+
+    function setupVerifiableUpdateScanRunCall(
+        document: OnDemandPageScanResult,
+        callback?: (toUpdateDoc: OnDemandPageScanResult) => void,
+    ): void {
+        onDemandPageScanRunResultProviderMock
+            .setup(async s => s.updateScanRun(It.is(doc => doc.id === document.id)))
+            .callback(toUpdateDoc => {
+                if (!isNil(callback)) {
+                    callback(toUpdateDoc);
+                }
+            })
+            .returns(async () => Promise.resolve(document))
+            .verifiable(Times.once());
+    }
+
+    describe('onExit', () => {
+        test.each([
+            {
+                jobTasks: undefined,
+            },
+            {
+                jobTasks: [],
+            },
+        ])('does nothing if there are no failed tasks', async testCase => {
+            setVerifiableFailedTasksCall(testCase.jobTasks);
+
+            await worker.onExit();
+        });
+
+        test.each([
+            {
+                taskArguments: null,
+            },
+            {
+                taskArguments: {
+                    id: null,
+                },
+            },
+            {
+                taskArguments: {
+                    id: undefined,
+                },
+            },
+        ])('logs error if unable to get required task arguments - %o', async testCase => {
+            const failedTasks = [
+                {
+                    taskArguments: JSON.stringify(testCase.taskArguments),
+                } as BatchTask,
+            ];
+
+            setVerifiableFailedTasksCall(failedTasks);
+
+            loggerMock
+                .setup(l =>
+                    l.logError(
+                        'Task has no run arguments defined',
+                        It.isValue({
+                            taskProperties: JSON.stringify(failedTasks[0]),
+                        }),
+                    ),
+                )
+                .verifiable(Times.once());
+
+            await worker.onExit();
+        });
+
+        it('logs error if page scan result document not found', async () => {
+            const taskArgs: TaskArguments = {
+                id: 'task id1',
+            };
+            const failedTasks = [
+                {
+                    taskArguments: JSON.stringify(taskArgs),
+                } as BatchTask,
+            ];
+
+            setupVerifiableReadScanRunCall(taskArgs.id, undefined);
+            setVerifiableFailedTasksCall(failedTasks);
+
+            loggerMock
+                .setup(l =>
+                    l.logError('Task has no corresponding state in a service storage', {
+                        taskProperties: JSON.stringify(failedTasks[0]),
+                    }),
+                )
+                .verifiable(Times.once());
+
+            await worker.onExit();
+        });
+
+        it('does nothing if scan document is already set to failed', async () => {
+            const taskArgs: TaskArguments = {
+                id: 'task id1',
+            };
+            const failedTasks = [
+                {
+                    taskArguments: JSON.stringify(taskArgs),
+                } as BatchTask,
+            ];
+            const document = {
+                id: taskArgs.id,
+                run: {
+                    state: 'failed',
+                },
+            } as OnDemandPageScanResult;
+
+            setupVerifiableReadScanRunCall(taskArgs.id, document);
+            setVerifiableFailedTasksCall(failedTasks);
+
+            await worker.onExit();
+        });
+
+        test.each([
+            {
+                failureInfo: undefined,
+            },
+            {
+                failureInfo: {
+                    category: 'serverError',
+                    code: '3456',
+                    message: 'some server error occurred',
+                } as BatchTaskFailureInfo,
+            },
+        ])('complete failed tasks - %o', async testCase => {
+            const taskArgs: TaskArguments = {
+                id: 'task id1',
+            };
+            const failedTasks = [
+                {
+                    taskArguments: JSON.stringify(taskArgs),
+                    exitCode: 123,
+                    timestamp: new Date(2020, 1, 1),
+                    failureInfo: testCase.failureInfo,
+                } as BatchTask,
+            ];
+            const document = {
+                id: taskArgs.id,
+                run: {
+                    state: 'running',
+                },
+            } as OnDemandPageScanResult;
+
+            let expectedUpdatedDocument: OnDemandPageScanResult;
+
+            setupVerifiableReadScanRunCall(taskArgs.id, document);
+            setupVerifiableUpdateScanRunCall(document, actualDocument => {
+                expectedUpdatedDocument = actualDocument;
+            });
+
+            setVerifiableFailedTasksCall(failedTasks);
+
+            await worker.onExit();
+
+            expect(expectedUpdatedDocument).toMatchSnapshot();
+        });
+
+        it('handles multiple failed tasks', async () => {
+            const taskArgs1: TaskArguments = {
+                id: 'task id1',
+            };
+            const taskArgs2: TaskArguments = {
+                id: 'task id2',
+            };
+            const failedTasks = [
+                {
+                    taskArguments: JSON.stringify(taskArgs1),
+                    exitCode: 123,
+                    timestamp: new Date(2020, 1, 1),
+                } as BatchTask,
+                {
+                    taskArguments: JSON.stringify(taskArgs2),
+                    exitCode: 456,
+                    timestamp: new Date(2020, 1, 2),
+                } as BatchTask,
+            ];
+            const pageDocument1 = {
+                id: taskArgs1.id,
+                run: {
+                    state: 'running',
+                },
+            } as OnDemandPageScanResult;
+
+            const pageDocument2 = {
+                id: taskArgs2.id,
+                run: {
+                    state: 'queued',
+                },
+            } as OnDemandPageScanResult;
+
+            let expectedUpdatedDocument1: OnDemandPageScanResult;
+            let expectedUpdatedDocument2: OnDemandPageScanResult;
+
+            setupVerifiableReadScanRunCall(taskArgs1.id, pageDocument1);
+            setupVerifiableReadScanRunCall(taskArgs2.id, pageDocument2);
+
+            setupVerifiableUpdateScanRunCall(pageDocument1, actualDocument => {
+                expectedUpdatedDocument1 = actualDocument;
+            });
+            setupVerifiableUpdateScanRunCall(pageDocument2, actualDocument => {
+                expectedUpdatedDocument2 = actualDocument;
+            });
+
+            setVerifiableFailedTasksCall(failedTasks);
+
+            await worker.onExit();
+
+            expect(expectedUpdatedDocument1).toMatchSnapshot();
+            expect(expectedUpdatedDocument2).toMatchSnapshot();
+        });
+    });
+
+    describe('getMessagesForTaskCreation', () => {
+        let poolMetricsInfo: PoolMetricsInfo;
+        let poolLoadSnapshot: PoolLoadSnapshot;
+
+        beforeEach(() => {
+            poolMetricsInfo = {
+                id: 'pool-id',
+                maxTasksPerPool: 4,
+                load: {
+                    activeTasks: 4,
+                    runningTasks: 4,
+                },
+            };
+
+            poolLoadSnapshot = {
+                tasksIncrementCountPerInterval: 60,
+                targetActiveToRunningTasksRatio: 2,
+                configuredMaxTasksPerPool: poolMetricsInfo.maxTasksPerPool,
+                poolId: poolMetricsInfo.id,
+                samplingIntervalInSeconds: 5,
+                tasksProcessingSpeedPerInterval: 7,
+                tasksProcessingSpeedPerMinute: 13,
+                timestamp: dateNow,
+                ...poolMetricsInfo.load,
+            };
+
+            batchMock
+                .setup(async o => o.getPoolMetricsInfo())
+                .returns(async () => Promise.resolve(poolMetricsInfo))
+                .verifiable(Times.once());
+
+            poolLoadGeneratorMock
+                .setup(async p => p.getPoolLoadSnapshot(poolMetricsInfo))
+                .returns(async () => Promise.resolve(poolLoadSnapshot))
+                .verifiable(Times.once());
+
+            setupBatchPoolLoadSnapshotProviderMock();
+        });
+
+        it('does not get messages if already has enough pending tasks', async () => {
+            poolLoadSnapshot.tasksIncrementCountPerInterval = 0;
+
+            const messages = await worker.getMessagesForTaskCreation();
+
+            expect(messages).toHaveLength(0);
+        });
+
+        it('does not return messages if queue is empty', async () => {
+            poolLoadSnapshot.tasksIncrementCountPerInterval = 10;
+
+            setupVerifiableGetQueueMessagesCall([]);
+            const messages = await worker.getMessagesForTaskCreation();
+
+            expect(messages).toHaveLength(0);
+        });
+
+        it('gets only messages that are not scanned', async () => {
+            poolLoadSnapshot.tasksIncrementCountPerInterval = 10;
+            const queueMessages: Message[] = [
+                {
+                    messageId: 'id1',
+                    messageText: JSON.stringify({ id: 'id1' }),
+                },
+                {
+                    messageId: 'id2',
+                    messageText: JSON.stringify({ id: 'id2' }),
+                },
+            ];
+
+            const scanDocuments = [
+                {
+                    id: queueMessages[0].messageId,
+                    run: {
+                        state: 'queued',
+                    },
+                } as OnDemandPageScanResult,
+                {
+                    id: queueMessages[1].messageId,
+                    run: {
+                        state: 'running',
+                    },
+                } as OnDemandPageScanResult,
+            ];
+
+            setupVerifiableGetQueueMessagesCall(queueMessages);
+            systemMock
+                .setup(s =>
+                    s.chunkArray(
+                        It.is(arr => arr.length === 2),
+                        100,
+                    ),
+                )
+                .returns((arr: any[]) => {
+                    const chunks = [];
+                    chunks.push(arr.slice(0, 1));
+                    chunks.push(arr.slice(1, 2));
+
+                    return chunks;
+                })
+                .verifiable(Times.once());
+
+            setupVerifiableReadScanRunsCall([queueMessages[0].messageId], [scanDocuments[0]]);
+            setupVerifiableReadScanRunsCall([queueMessages[1].messageId], [scanDocuments[1]]);
+            setupVerifiableDeleteQueueMessageCall(queueMessages[1]);
+
+            const messages = await worker.getMessagesForTaskCreation();
+
+            expect(messages).toHaveLength(1);
+            expect(messages[0]).toBe(queueMessages[0]);
+        });
+
+        function setupBatchPoolLoadSnapshotProviderMock(times: Times = Times.once()): void {
+            batchPoolLoadSnapshotProviderMock
+                .setup(async o =>
+                    o.writeBatchPoolLoadSnapshot(
+                        It.is(d => {
+                            const document = {
+                                // tslint:disable-next-line: no-object-literal-type-assertion
+                                ...({} as StorageDocument),
+                                batchAccountName: batchConfig.accountName,
+                                ...poolLoadSnapshot,
+                            };
+
+                            return isEqual(document, d);
+                        }),
+                    ),
+                )
+                .verifiable(times);
+        }
+
+        function setupVerifiableGetQueueMessagesCall(messages: Message[]): void {
+            queueMock
+                .setup(q => q.getMessages(poolLoadSnapshot.tasksIncrementCountPerInterval))
+                .returns(async () => Promise.resolve(messages))
+                .verifiable(Times.once());
+        }
+    });
+
+    function setupVerifiableDeleteQueueMessageCall(message: Message): void {
+        queueMock
+            .setup(q => q.deleteMessage(It.isValue(message)))
+            .returns(async () => Promise.resolve())
+            .verifiable(Times.once());
+    }
 
     afterEach(() => {
         batchMock.verifyAll();
         queueMock.verifyAll();
+        poolLoadGeneratorMock.verifyAll();
         serviceConfigMock.verifyAll();
-        batchPoolLoadSnapshotProviderMock.verifyAll();
-        systemMock.verifyAll();
-        onDemandPageScanRunResultProviderMock.verifyAll();
-    });
-
-    it('complete terminated tasks', async () => {
-        const timestamp = new Date();
-        const scanId = '12';
-        const taskArguments = { id: scanId };
-
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .returns(async () => Promise.resolve(poolMetricsInfo))
-            .verifiable(Times.once());
-        queueMock
-            .setup(async o => o.getMessages())
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.once());
-        setupBatchPoolLoadSnapshotProviderMock();
-
-        const expectedFailedTasks: BatchTask[] = [
-            {
-                id: 'id-1',
-                taskArguments: JSON.stringify(taskArguments),
-                exitCode: 1,
-                result: 'failure',
-                failureInfo: { category: 'userError', code: '1', message: 'Task Error Message' },
-                timestamp,
-            },
-        ];
-        batchMock
-            .setup(async o => o.getFailedTasks(batchConfig.jobId))
-            .returns(async () => Promise.resolve(expectedFailedTasks))
-            .verifiable(Times.once());
-
-        const pageScanResultStorageVersion = { run: { state: 'running' } } as any;
-        onDemandPageScanRunResultProviderMock
-            .setup(async o => o.readScanRun(scanId))
-            .returns(async () => Promise.resolve(pageScanResultStorageVersion))
-            .verifiable(Times.once());
-
-        const pageScanResultUpdatedVersion = {
-            run: {
-                state: 'failed',
-                timestamp: timestamp.toJSON(),
-                error: 'Task was terminated unexpectedly. Exit code: 1, Error category: userError, Error details: Task Error Message',
-            },
-        } as any;
-        onDemandPageScanRunResultProviderMock
-            .setup(async o => o.updateScanRun(pageScanResultUpdatedVersion))
-            .returns(async () => Promise.resolve(pageScanResultUpdatedVersion))
-            .verifiable(Times.once());
-
-        await worker.run();
-    });
-
-    it('drop message for a completed scan', async () => {
-        const taskCount = 2;
-        const queueMessages: Message[] = [];
-        const jobTasks: JobTask[] = [];
-        const scanIds: string[] = [];
-        let scanMessagesCount = 0;
-        for (let i = 1; i <= taskCount; i += 1) {
-            const id = `scan-id-${i}`;
-            scanIds.push(id);
-
-            const message = {
-                messageText: JSON.stringify({ id }),
-                messageId: `message-id-${i}`,
-            };
-            queueMessages.push(message);
-
-            const jobTask = new JobTask();
-            jobTask.state = JobTaskState.queued;
-            jobTask.correlationId = message.messageId;
-            jobTasks.push(jobTask);
-        }
-        batchMock
-            .setup(async o => o.createTasks(batchConfig.jobId, queueMessages.slice(0, 1)))
-            .returns(async () => Promise.resolve(jobTasks.slice(0, 1)))
-            .verifiable(Times.once());
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .returns(async () => Promise.resolve(poolMetricsInfo))
-            .verifiable(Times.once());
-        queueMock
-            .setup(async o => o.getMessages())
-            .callback(() => {
-                scanMessagesCount += 1;
-            })
-            .returns(async () => {
-                return queueMessages.length >= scanMessagesCount
-                    ? Promise.resolve([queueMessages[scanMessagesCount - 1]])
-                    : Promise.resolve([]);
-            })
-            .verifiable(Times.exactly(taskCount + 1));
-        queueMock.setup(async o => o.deleteMessage(It.isAny())).verifiable(Times.exactly(taskCount));
-        setupBatchPoolLoadSnapshotProviderMock();
-        setupOnDemandPageScanRunResultProviderMock(scanIds, ['queued', 'failed']);
-
-        await worker.run();
-    });
-
-    it('add tasks to the job', async () => {
-        const taskCount = 2;
-        const queueMessages: Message[] = [];
-        const jobTasks: JobTask[] = [];
-        const scanIds: string[] = [];
-        let scanMessagesCount = 0;
-        for (let i = 1; i <= taskCount; i += 1) {
-            const id = `scan-id-${i}`;
-            scanIds.push(id);
-
-            const message = {
-                messageText: JSON.stringify({ id }),
-                messageId: `message-id-${i}`,
-            };
-            queueMessages.push(message);
-
-            const jobTask = new JobTask();
-            jobTask.state = JobTaskState.queued;
-            jobTask.correlationId = message.messageId;
-            jobTasks.push(jobTask);
-        }
-        batchMock
-            .setup(async o => o.createTasks(batchConfig.jobId, queueMessages))
-            .returns(async () => Promise.resolve(jobTasks))
-            .verifiable(Times.once());
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .returns(async () => Promise.resolve(poolMetricsInfo))
-            .verifiable(Times.once());
-        queueMock
-            .setup(async o => o.getMessages())
-            .callback(() => {
-                scanMessagesCount += 1;
-            })
-            .returns(async () => {
-                return queueMessages.length >= scanMessagesCount
-                    ? Promise.resolve([queueMessages[scanMessagesCount - 1]])
-                    : Promise.resolve([]);
-            })
-            .verifiable(Times.exactly(taskCount + 1));
-        queueMock
-            .setup(async o => o.deleteMessage(It.isAny()))
-            .callback(message => {
-                const i = queueMessages.indexOf(queueMessages.find(m => m.messageId === message.messageId));
-                queueMessages.splice(i, 1);
-            })
-            .verifiable(Times.exactly(taskCount));
-        const expectedMeasurements: BatchPoolMeasurements = {
-            runningTasks: poolMetricsInfo.load.runningTasks,
-            samplingIntervalInSeconds: poolLoadSnapshot.samplingIntervalInSeconds,
-            maxParallelTasks: poolMetricsInfo.maxTasksPerPool,
-        };
-        loggerMock.setup(lm => lm.trackEvent('BatchPoolStats', null, expectedMeasurements)).verifiable(Times.once());
-        setupBatchPoolLoadSnapshotProviderMock();
-        setupOnDemandPageScanRunResultProviderMock(scanIds);
-
-        await worker.run();
-
-        // should delete messages from the queue
-        expect(queueMessages.length).toEqual(0);
         loggerMock.verifyAll();
+        batchPoolLoadSnapshotProviderMock.verifyAll();
+        onDemandPageScanRunResultProviderMock.verifyAll();
+        systemMock.verifyAll();
     });
-
-    it('skip adding tasks when pool is overloaded', async () => {
-        poolLoadSnapshot.tasksIncrementCountPerInterval = 0;
-        poolLoadGeneratorMock
-            .setup(async o => o.getPoolLoadSnapshot(poolMetricsInfo))
-            .returns(async () => Promise.resolve(poolLoadSnapshot))
-            .verifiable(Times.once());
-        batchMock
-            .setup(async o => o.createTasks(batchConfig.jobId, It.isAny()))
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.never());
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .returns(async () => Promise.resolve(poolMetricsInfo))
-            .verifiable(Times.once());
-        queueMock
-            .setup(async o => o.getMessages())
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.never());
-        queueMock.setup(async o => o.deleteMessage(It.isAny())).verifiable(Times.never());
-        setupBatchPoolLoadSnapshotProviderMock();
-
-        await worker.run();
-
-        // reset default setup
-        poolLoadSnapshot.tasksIncrementCountPerInterval = 60;
-    });
-
-    it('skip adding tasks when message queue is empty', async () => {
-        batchMock
-            .setup(async o => o.createTasks(batchConfig.jobId, It.isAny()))
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.never());
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .returns(async () => Promise.resolve(poolMetricsInfo))
-            .verifiable(Times.once());
-        queueMock
-            .setup(async o => o.getMessages())
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.once());
-        queueMock.setup(async o => o.deleteMessage(It.isAny())).verifiable(Times.never());
-        setupBatchPoolLoadSnapshotProviderMock();
-
-        await worker.run();
-    });
-
-    it('Continue waiting until all active tasks are completed', async () => {
-        let poolMetricsInfoCallbackCount = 0;
-        poolMetricsInfo = {
-            id: 'pool-id',
-            maxTasksPerPool: 4,
-            load: {
-                activeTasks: 4,
-                runningTasks: 4,
-            },
-        };
-        poolLoadGeneratorMock
-            .setup(async o =>
-                o.getPoolLoadSnapshot(
-                    It.is(actualMetrics => {
-                        return _.isEqual(poolMetricsInfo, actualMetrics);
-                    }),
-                ),
-            )
-            .returns(async () => Promise.resolve(poolLoadSnapshot))
-            .verifiable(Times.exactly(2));
-        batchMock
-            .setup(async o => o.createTasks(batchConfig.jobId, It.isAny()))
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.never());
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .callback(() => {
-                poolMetricsInfoCallbackCount += 1;
-            })
-            .returns(async () => {
-                if (poolMetricsInfoCallbackCount > 1) {
-                    poolMetricsInfo.load.activeTasks = 0;
-                    poolMetricsInfo.load.runningTasks = 1;
-
-                    return Promise.resolve(poolMetricsInfo);
-                } else {
-                    return Promise.resolve(poolMetricsInfo);
-                }
-            })
-            .verifiable(Times.exactly(2));
-        setupBatchPoolLoadSnapshotProviderMock(Times.exactly(2));
-
-        queueMock
-            .setup(async o => o.getMessages())
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.exactly(2));
-
-        systemMock
-            .setup(async s => s.wait(1000))
-            .returns(async () => Promise.resolve())
-            .verifiable(Times.once());
-
-        // let it exit by itself
-        worker.runOnce = false;
-        await worker.run();
-    });
-
-    it('Continue waiting until all running tasks are completed', async () => {
-        let poolMetricsInfoCallbackCount = 0;
-        poolMetricsInfo = {
-            id: 'pool-id',
-            maxTasksPerPool: 4,
-            load: {
-                activeTasks: 4,
-                runningTasks: 4,
-            },
-        };
-        poolLoadGeneratorMock
-            .setup(async o =>
-                o.getPoolLoadSnapshot(
-                    It.is(actualMetrics => {
-                        return _.isEqual(poolMetricsInfo, actualMetrics);
-                    }),
-                ),
-            )
-            .returns(async () => Promise.resolve(poolLoadSnapshot))
-            .verifiable(Times.exactly(2));
-        batchMock
-            .setup(async o => o.createTasks(batchConfig.jobId, It.isAny()))
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.never());
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .callback(() => {
-                poolMetricsInfoCallbackCount += 1;
-            })
-            .returns(async () => {
-                if (poolMetricsInfoCallbackCount > 1) {
-                    poolMetricsInfo.load.activeTasks = 1;
-                    poolMetricsInfo.load.runningTasks = 0;
-
-                    return Promise.resolve(poolMetricsInfo);
-                } else {
-                    return Promise.resolve(poolMetricsInfo);
-                }
-            })
-            .verifiable(Times.exactly(2));
-        setupBatchPoolLoadSnapshotProviderMock(Times.exactly(2));
-
-        queueMock
-            .setup(async o => o.getMessages())
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.exactly(2));
-        systemMock
-            .setup(async s => s.wait(1000))
-            .returns(async () => Promise.resolve())
-            .verifiable(Times.once());
-
-        // let it exit by itself
-        worker.runOnce = false;
-        await worker.run();
-    });
-
-    it('Terminate if restart timeout has reached', async () => {
-        const startTime = currentTime;
-
-        poolMetricsInfo = {
-            id: 'pool-id',
-            maxTasksPerPool: 4,
-            load: {
-                activeTasks: 5,
-                runningTasks: 6,
-            },
-        };
-        let poolMetricsInfoCallbackCount = 0;
-        poolLoadGeneratorMock
-            .setup(async o =>
-                o.getPoolLoadSnapshot(
-                    It.is(actualMetrics => {
-                        return _.isEqual(poolMetricsInfo, actualMetrics);
-                    }),
-                ),
-            )
-            .returns(async () => Promise.resolve(poolLoadSnapshot));
-
-        batchMock
-            .setup(async o => o.getPoolMetricsInfo())
-            .callback(() => {
-                poolMetricsInfoCallbackCount += 1;
-                currentTime = moment(startTime)
-                    .add(maxWallClockTimeInHours, 'hour')
-                    .toDate()
-                    .toJSON();
-                poolMetricsInfo.load.activeTasks = poolMetricsInfo.load.activeTasks > 0 ? poolMetricsInfo.load.activeTasks - 1 : 0;
-                poolMetricsInfo.load.runningTasks = poolMetricsInfo.load.runningTasks > 1 ? poolMetricsInfo.load.runningTasks - 1 : 1;
-            })
-            .returns(async () => {
-                return Promise.resolve(poolMetricsInfo);
-            });
-
-        queueMock
-            .setup(async o => o.getMessages())
-            .returns(async () => Promise.resolve([]))
-            .verifiable(Times.once());
-
-        systemMock
-            .setup(async s => s.wait(5000))
-            .returns(async () => Promise.resolve())
-            .verifiable(Times.exactly(3));
-
-        // let it exit by itself
-        worker.runOnce = false;
-        await worker.run();
-
-        expect(poolMetricsInfo.load.activeTasks).toBe(0);
-        expect(poolMetricsInfo.load.runningTasks).toBe(1);
-    });
-
-    function setupOnDemandPageScanRunResultProviderMock(scanIds: string[], states: OnDemandPageScanRunState[] = []): void {
-        let i = 0;
-        const scanRuns = scanIds.map(id => {
-            const scanRun = { id, run: { state: states[i] !== undefined ? states[i] : 'queued' } } as any;
-            i = i + 1;
-
-            return scanRun;
-        });
-        onDemandPageScanRunResultProviderMock
-            .setup(async o => o.readScanRuns(scanIds))
-            .returns(async () => Promise.resolve(scanRuns))
-            .verifiable(Times.once());
-    }
-
-    function setupBatchPoolLoadSnapshotProviderMock(times: Times = Times.once()): void {
-        const document = {
-            // tslint:disable-next-line: no-object-literal-type-assertion
-            ...({} as StorageDocument),
-            batchAccountName: batchConfig.accountName,
-            ...poolLoadSnapshot,
-        };
-
-        batchPoolLoadSnapshotProviderMock
-            .setup(async o =>
-                o.writeBatchPoolLoadSnapshot(
-                    It.is(d => {
-                        return _.isEqual(document, d);
-                    }),
-                ),
-            )
-            .verifiable(times);
-    }
 });

--- a/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
@@ -265,7 +265,7 @@ describe(Worker, () => {
                 {
                     taskArguments: JSON.stringify(taskArgs),
                     exitCode: 123,
-                    timestamp: new Date(2020, 1, 1),
+                    timestamp: new Date('2020-01-01T12:00:00.000Z'),
                     failureInfo: testCase.failureInfo,
                 } as BatchTask,
             ];
@@ -301,12 +301,12 @@ describe(Worker, () => {
                 {
                     taskArguments: JSON.stringify(taskArgs1),
                     exitCode: 123,
-                    timestamp: new Date(2020, 1, 1),
+                    timestamp: new Date('2020-01-01T12:00:00.000Z'),
                 } as BatchTask,
                 {
                     taskArguments: JSON.stringify(taskArgs2),
                     exitCode: 456,
-                    timestamp: new Date(2020, 1, 2),
+                    timestamp: new Date('2020-01-02T12:00:00.000Z'),
                 } as BatchTask,
             ];
             const pageDocument1 = {

--- a/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.spec.ts
+++ b/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.spec.ts
@@ -4,8 +4,9 @@ import 'reflect-metadata';
 
 import { Container } from 'inversify';
 import { BaseTelemetryProperties } from 'logger';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 import { SendNotificationJobManagerEntryPoint } from './send-notification-job-manager-entry-point';
+import { SendNotificationTaskCreator } from './task/send-notification-task-creator';
 
 // tslint:disable: no-object-literal-type-assertion
 
@@ -13,14 +14,21 @@ class TestableSendNotificationJobManagerEntryPoint extends SendNotificationJobMa
     public invokeGetTelemetryBaseProperties(): BaseTelemetryProperties {
         return this.getTelemetryBaseProperties();
     }
+
+    // tslint:disable-next-line: no-unnecessary-override
+    public async runCustomAction(container: Container): Promise<void> {
+        return super.runCustomAction(container);
+    }
 }
 
 describe(SendNotificationJobManagerEntryPoint, () => {
     let testSubject: TestableSendNotificationJobManagerEntryPoint;
     let containerMock: IMock<Container>;
+    let sendNotificationTaskCreatorMock: IMock<SendNotificationTaskCreator>;
 
     beforeEach(() => {
         containerMock = Mock.ofType(Container);
+        sendNotificationTaskCreatorMock = Mock.ofType(SendNotificationTaskCreator);
 
         testSubject = new TestableSendNotificationJobManagerEntryPoint(containerMock.object);
     });
@@ -31,5 +39,30 @@ describe(SendNotificationJobManagerEntryPoint, () => {
                 source: 'webApiSendNotificationJobManager',
             } as BaseTelemetryProperties);
         });
+    });
+
+    describe('runCustomAction', () => {
+        beforeEach(() => {
+            containerMock.setup(c => c.get(SendNotificationTaskCreator)).returns(() => sendNotificationTaskCreatorMock.object);
+        });
+
+        it('invokes worker', async () => {
+            sendNotificationTaskCreatorMock
+                .setup(async w => w.init())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            sendNotificationTaskCreatorMock
+                .setup(async w => w.run())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            await testSubject.runCustomAction(containerMock.object);
+        });
+    });
+
+    afterEach(() => {
+        containerMock.verifyAll();
+        sendNotificationTaskCreatorMock.verifyAll();
     });
 });

--- a/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.ts
+++ b/packages/web-api-send-notification-job-manager/src/send-notification-job-manager-entry-point.ts
@@ -13,6 +13,7 @@ export class SendNotificationJobManagerEntryPoint extends ProcessEntryPointBase 
 
     protected async runCustomAction(container: Container): Promise<void> {
         const taskCreator = container.get<SendNotificationTaskCreator>(SendNotificationTaskCreator);
+        await taskCreator.init();
         await taskCreator.run();
     }
 }

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
@@ -2,17 +2,31 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { Batch, BatchConfig, Queue } from 'azure-services';
-import { IMock, Mock } from 'typemoq';
+import { Batch, BatchConfig, Message, PoolMetricsInfo, Queue } from 'azure-services';
+import { JobManagerConfig, ServiceConfiguration, System } from 'common';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 import { SendNotificationTaskCreator } from './send-notification-task-creator';
 
 // tslint:disable: no-unsafe-any no-object-literal-type-assertion no-any mocha-no-side-effect-code no-null-keyword
+
+class TestableSendNotificationTaskCreator extends SendNotificationTaskCreator {
+    public jobManagerConfig: JobManagerConfig;
+
+    // tslint:disable-next-line: no-unnecessary-override
+    public async getMessagesForTaskCreation(): Promise<Message[]> {
+        return super.getMessagesForTaskCreation();
+    }
+}
 describe(SendNotificationTaskCreator, () => {
-    let taskCreator: SendNotificationTaskCreator;
+    let taskCreator: TestableSendNotificationTaskCreator;
+
     let batchMock: IMock<Batch>;
     let queueMock: IMock<Queue>;
     let loggerMock: IMock<MockableLogger>;
+    let serviceConfigMock: IMock<ServiceConfiguration>;
+    let systemMock: IMock<typeof System>;
+
     const batchConfig: BatchConfig = {
         accountName: 'batch-account-name',
         accountUrl: '',
@@ -21,21 +35,110 @@ describe(SendNotificationTaskCreator, () => {
     };
 
     beforeEach(() => {
-        batchMock = Mock.ofType(Batch);
-        queueMock = Mock.ofType(Queue);
+        batchMock = Mock.ofType(Batch, MockBehavior.Strict);
+        queueMock = Mock.ofType(Queue, MockBehavior.Strict);
         loggerMock = Mock.ofType(MockableLogger);
+        systemMock = Mock.ofInstance(System, MockBehavior.Strict);
+        serviceConfigMock = Mock.ofType(ServiceConfiguration, MockBehavior.Strict);
 
-        queueMock.setup(o => o.scanQueue).returns(() => 'scan-queue');
+        taskCreator = new TestableSendNotificationTaskCreator(
+            batchMock.object,
+            queueMock.object,
+            batchConfig,
+            serviceConfigMock.object,
+            loggerMock.object,
+            systemMock.object,
+        );
 
-        taskCreator = new SendNotificationTaskCreator(batchMock.object, queueMock.object, batchConfig, loggerMock.object);
+        taskCreator.jobManagerConfig = {
+            sendNotificationTasksCount: 10,
+        } as JobManagerConfig;
     });
 
-    it('not implemented', async () => {
-        await taskCreator.run();
+    describe('getMessagesForTaskCreation', () => {
+        let poolMetricsInfo: PoolMetricsInfo;
+
+        beforeEach(() => {
+            poolMetricsInfo = {
+                load: {
+                    activeTasks: 1,
+                    runningTasks: 1,
+                },
+            } as PoolMetricsInfo;
+
+            batchMock
+                .setup(b => b.getPoolMetricsInfo())
+                .returns(async () => Promise.resolve(poolMetricsInfo))
+                .verifiable(Times.once());
+        });
+
+        it('returns empty array if no messages in queue', async () => {
+            poolMetricsInfo.load.activeTasks = 1;
+            poolMetricsInfo.load.runningTasks = 1;
+            queueMock
+                .setup(async q => q.getMessages(9))
+                .returns(async () => Promise.resolve([]))
+                .verifiable(Times.once());
+
+            await expect(taskCreator.getMessagesForTaskCreation()).resolves.toEqual([]);
+        });
+
+        test.each([
+            {
+                activeTasks: 1,
+                runningTasks: 10,
+            },
+            {
+                activeTasks: 10,
+                runningTasks: 1,
+            },
+            {
+                activeTasks: 0,
+                runningTasks: 15,
+            },
+        ])('returns empty array if max number of tasks are in active/pending state - %o', async poolLoad => {
+            poolMetricsInfo.load = poolLoad;
+
+            await expect(taskCreator.getMessagesForTaskCreation()).resolves.toEqual([]);
+        });
+
+        test.each([
+            {
+                activeTasks: 1,
+                runningTasks: 9,
+            },
+            {
+                activeTasks: 9,
+                runningTasks: 1,
+            },
+            {
+                activeTasks: 0,
+                runningTasks: 1,
+            },
+            {
+                activeTasks: 1,
+                runningTasks: 0,
+            },
+        ])('returns messages from queue - %o', async poolLoad => {
+            const expectedMessageCount =
+                taskCreator.jobManagerConfig.sendNotificationTasksCount - (poolLoad.activeTasks + poolLoad.runningTasks - 1);
+            const messages: any[] = ['message 1', 'message 2'];
+            poolMetricsInfo.load = poolLoad;
+
+            queueMock
+                .setup(async q => q.getMessages(expectedMessageCount))
+                .returns(async () => Promise.resolve(messages))
+                .verifiable(Times.once());
+
+            await expect(taskCreator.getMessagesForTaskCreation()).resolves.toEqual(messages);
+        });
     });
 
     afterEach(() => {
         batchMock.verifyAll();
         queueMock.verifyAll();
+        serviceConfigMock.verifyAll();
+        systemMock.verifyAll();
+        loggerMock.verifyAll();
     });
 });

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
@@ -1,20 +1,39 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Batch, BatchConfig, Queue } from 'azure-services';
+import { Batch, BatchConfig, JobTask, Message, Queue } from 'azure-services';
+import { ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
 import { Logger } from 'logger';
+import { BatchTaskCreator } from 'service-library';
 
 @injectable()
-export class SendNotificationTaskCreator {
+export class SendNotificationTaskCreator extends BatchTaskCreator {
     public constructor(
-        @inject(Batch) private readonly batch: Batch,
-        @inject(Queue) private readonly queue: Queue,
-        @inject(BatchConfig) private readonly batchConfig: BatchConfig,
-        @inject(Logger) private readonly logger: Logger,
-    ) {}
-
-    public async run(): Promise<void> {
-        this.logger.logWarn('not implemented');
+        @inject(Batch) batch: Batch,
+        @inject(Queue) queue: Queue,
+        @inject(BatchConfig) batchConfig: BatchConfig,
+        @inject(ServiceConfiguration) serviceConfig: ServiceConfiguration,
+        @inject(Logger) logger: Logger,
+        system: typeof System = System,
+    ) {
+        super(batch, queue, batchConfig, serviceConfig, logger, system);
     }
+
+    protected async getMessagesForTaskCreation(): Promise<Message[]> {
+        const poolMetricsInfo = await this.batch.getPoolMetricsInfo();
+
+        const messagesCount = this.jobManagerConfig.sendNotificationTasksCount - this.getChildTasksCount(poolMetricsInfo);
+        if (messagesCount > 0) {
+            return this.queue.getMessages(messagesCount);
+        }
+
+        return [];
+    }
+
+    // tslint:disable-next-line: no-empty
+    protected async onExit(): Promise<void> {}
+
+    // tslint:disable-next-line: no-empty
+    protected async onTasksAdded(tasks: JobTask[]): Promise<void> {}
 }


### PR DESCRIPTION
#### Description of changes
refactored web-api-job-manager's Worker to use the base class BatchTaskCreator.
This pr also fixes not to add more tasks than the maximum allowed running tasks. 

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
