### PR TITLE
feat (send-notification): create notification message on scan completion

### DIFF
--- a/packages/azure-services/src/azure-queue/queue.spec.ts
+++ b/packages/azure-services/src/azure-queue/queue.spec.ts
@@ -195,6 +195,18 @@ describe(Queue, () => {
         });
     });
 
+    describe('getMessageCount', async () => {
+        it('getCountQueue', async () => {
+            const count = 30;
+            setupQueueGetCount(30);
+
+            const actualCount = await testSubject.getMessageCount(queue);
+            expect(actualCount).toBe(count);
+
+            verifyAll();
+        });
+    });
+
     describe('createMessage', () => {
         it('creates message & queue', async () => {
             const messageText = 'some message';
@@ -233,6 +245,12 @@ describe(Queue, () => {
             verifyAll();
         });
     });
+
+    function setupQueueGetCount(count: number): void {
+        const getProperties = { approximateMessagesCount: count } as Models.QueueGetPropertiesResponse;
+        queueURLMock.setup(async q => q.getProperties(Aborter.none)).returns(async () => Promise.resolve(getProperties));
+        deadQueueURLMock.setup(async q => q.getProperties(Aborter.none)).returns(async () => Promise.resolve(getProperties));
+    }
 
     function setupQueueCreationCallWhenQueueExists(): void {
         queueURLMock.setup(async q => q.getProperties(Aborter.none)).returns(async () => Promise.resolve(null));

--- a/packages/azure-services/src/azure-queue/queue.spec.ts
+++ b/packages/azure-services/src/azure-queue/queue.spec.ts
@@ -219,13 +219,26 @@ describe(Queue, () => {
             verifyAll();
         });
 
-        it('creates message when queue exists', async () => {
+        it('creates message succeeded when queue exists', async () => {
             const messageText = 'some message';
 
             setupQueueCreationCallWhenQueueExists();
-            setupVerifyCallToEnqueueMessage(messagesURLMock, messageText);
+            setupVerifyCallToEnqueueMessage(messagesURLMock, messageText, { messageId: 'id' });
 
-            await testSubject.createMessage(queue, messageText);
+            const isCreated = await testSubject.createMessage(queue, messageText);
+            expect(isCreated).toBe(true);
+
+            verifyAll();
+        });
+
+        test.each([null, { messageId: null }])('creates message failed - response = %o', async response => {
+            const messageText = 'some message';
+
+            setupQueueCreationCallWhenQueueExists();
+            setupVerifyCallToEnqueueMessage(messagesURLMock, messageText, response);
+
+            const isCreated = await testSubject.createMessage(queue, messageText);
+            expect(isCreated).toBe(false);
 
             verifyAll();
         });
@@ -269,10 +282,10 @@ describe(Queue, () => {
         setupVerifyCallToDeleteMessage(message);
     }
 
-    function setupVerifyCallToEnqueueMessage(currentMessagesURLMock: IMock<MessagesURL>, messageText: string): void {
+    function setupVerifyCallToEnqueueMessage(currentMessagesURLMock: IMock<MessagesURL>, messageText: string, response: any = null): void {
         currentMessagesURLMock
             .setup(async d => d.enqueue(Aborter.none, JSON.stringify(messageText)))
-            .returns(async () => null)
+            .returns(async () => Promise.resolve(response))
             .verifiable(Times.once());
     }
 

--- a/packages/azure-services/src/azure-queue/queue.spec.ts
+++ b/packages/azure-services/src/azure-queue/queue.spec.ts
@@ -11,7 +11,6 @@ import { MockableLogger } from '../test-utilities/mockable-logger';
 import { getPromisableDynamicMock } from '../test-utilities/promisable-mock';
 import { Message } from './message';
 import { Queue } from './queue';
-import { StorageConfig } from './storage-config';
 
 describe(Queue, () => {
     const messageVisibilityTimeout = 30;

--- a/packages/azure-services/src/azure-queue/queue.spec.ts
+++ b/packages/azure-services/src/azure-queue/queue.spec.ts
@@ -249,7 +249,6 @@ describe(Queue, () => {
     function setupQueueGetCount(count: number): void {
         const getProperties = { approximateMessagesCount: count } as Models.QueueGetPropertiesResponse;
         queueURLMock.setup(async q => q.getProperties(Aborter.none)).returns(async () => Promise.resolve(getProperties));
-        deadQueueURLMock.setup(async q => q.getProperties(Aborter.none)).returns(async () => Promise.resolve(getProperties));
     }
 
     function setupQueueCreationCallWhenQueueExists(): void {

--- a/packages/azure-services/src/azure-queue/queue.ts
+++ b/packages/azure-services/src/azure-queue/queue.ts
@@ -70,11 +70,11 @@ export class Queue {
         return this.deleteQueueMessage(queueURL, message.messageId, message.popReceipt);
     }
 
-    public async createMessage(queue: string, message: unknown): Promise<void> {
+    public async createMessage(queue: string, message: unknown): Promise<boolean> {
         const queueURL = await this.getQueueURL(queue);
         await this.ensureQueueExists(queueURL);
 
-        await this.createQueueMessage(queueURL, message);
+        return this.createQueueMessage(queueURL, message);
     }
 
     public async getMessageCount(queue: string): Promise<number> {
@@ -125,10 +125,15 @@ export class Queue {
         await this.deleteQueueMessage(originQueueURL, queueMessage.messageId, queueMessage.popReceipt);
     }
 
-    private async createQueueMessage(queueURL: QueueURL, message: unknown): Promise<void> {
+    private async createQueueMessage(queueURL: QueueURL, message: unknown): Promise<boolean> {
         const messagesURL = this.getMessagesURL(queueURL);
 
-        await messagesURL.enqueue(Aborter.none, JSON.stringify(message));
+        const response = await messagesURL.enqueue(Aborter.none, JSON.stringify(message));
+        if (_.isNil(response) || _.isNil(response.messageId)) {
+            return false;
+        }
+
+        return true;
     }
 
     private getMessagesURL(queueURL: QueueURL): MessagesURL {

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -156,7 +156,7 @@ Object {
       "format": "int",
     },
     "maxSendNotificationRetryCount": Object {
-      "default": 3,
+      "default": 5,
       "doc": "Maximum number of retries allowed for a scan notification sending",
       "format": "int",
     },
@@ -347,7 +347,7 @@ Object {
       "format": "int",
     },
     "maxSendNotificationRetryCount": Object {
-      "default": 3,
+      "default": 5,
       "doc": "Maximum number of retries allowed for a scan notification sending",
       "format": "int",
     },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -193,7 +193,7 @@ export class ServiceConfiguration {
                 },
                 maxSendNotificationRetryCount: {
                     format: 'int',
-                    default: 3,
+                    default: 5,
                     doc: 'Maximum number of retries allowed for a scan notification sending',
                 },
                 accessibilityRuleExclusionList: {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -17,6 +17,7 @@ export {
     RestApiConfig,
     AvailabilityTestConfig,
     LogRuntimeConfig,
+    FeatureFlags,
 } from './configuration/service-configuration';
 export { setupRuntimeConfigContainer } from './setup-runtime-config-container';
 

--- a/packages/resource-deployment/runtime-config/runtime-config.ci.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ci.json
@@ -16,8 +16,7 @@
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,
         "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3,
-        "maxSendNotificationRetryCount": 3
+        "maxScanRetryCount": 3
     },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300

--- a/packages/resource-deployment/runtime-config/runtime-config.ci.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ci.json
@@ -1,6 +1,6 @@
 {
     "featureFlags": {
-        "sendNotification": false
+        "sendNotification": true
     },
     "logConfig": {
         "logInConsole": true

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -16,8 +16,7 @@
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,
         "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3,
-        "maxSendNotificationRetryCount": 3
+        "maxScanRetryCount": 3
     },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -16,8 +16,7 @@
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,
         "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3,
-        "maxSendNotificationRetryCount": 3
+        "maxScanRetryCount": 3
     },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -1,6 +1,6 @@
 {
     "featureFlags": {
-        "sendNotification": false
+        "sendNotification": true
     },
     "logConfig": {
         "logInConsole": true

--- a/packages/resource-deployment/runtime-config/runtime-config.prod.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.prod.json
@@ -17,8 +17,7 @@
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,
         "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3,
-        "maxSendNotificationRetryCount": 3
+        "maxScanRetryCount": 3
     },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300

--- a/packages/resource-deployment/runtime-config/runtime-config.selftest.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.selftest.json
@@ -15,8 +15,7 @@
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,
         "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3,
-        "maxSendNotificationRetryCount": 3
+        "maxScanRetryCount": 3
     },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300

--- a/packages/resource-deployment/templates/on-demand-send-notification-schedule.template.json
+++ b/packages/resource-deployment/templates/on-demand-send-notification-schedule.template.json
@@ -49,7 +49,7 @@
             },
             {
                 "name": "RUNNER_SCRIPTS_CONTAINER_NAME",
-                "value": "batch-send-notification-runner-script"
+                "value": "batch-web-api-send-notification-runner-script"
             }
         ],
         "poolInfo": {

--- a/packages/scan-request-sender/src/sender/scan-request-sender.spec.ts
+++ b/packages/scan-request-sender/src/sender/scan-request-sender.spec.ts
@@ -39,7 +39,7 @@ describe('Scan request Sender', () => {
             const message: ScanRequestMessage = getScanRequestMessage(page);
             queueMock
                 .setup(async q => q.createMessage(storageConfigStub.scanQueue, message))
-                .returns(async () => Promise.resolve())
+                .returns(async () => Promise.resolve(true))
                 .verifiable(Times.once());
 
             pageDocumentProviderMock
@@ -65,7 +65,7 @@ describe('Scan request Sender', () => {
             const message: ScanRequestMessage = getScanRequestMessage(page);
             queueMock
                 .setup(async q => q.createMessage(storageConfigStub.scanQueue, message))
-                .returns(async () => Promise.resolve())
+                .returns(async () => Promise.resolve(true))
                 .verifiable(Times.once());
 
             pageDocumentProviderMock

--- a/packages/scanner/src/factories/axe-puppeteer-factory.spec.ts
+++ b/packages/scanner/src/factories/axe-puppeteer-factory.spec.ts
@@ -16,7 +16,7 @@ describe('AxePuppeteerFactory', () => {
         scanConfig = {
             failedPageRescanIntervalInHours: 3,
             maxScanRetryCount: 4,
-            maxSendNotificationRetryCount: 3,
+            maxSendNotificationRetryCount: 5,
             minLastReferenceSeenInDays: 5,
             pageRescanIntervalInDays: 6,
             accessibilityRuleExclusionList: [],

--- a/packages/service-library/src/data-providers/page-document-provider.db.spec.ts
+++ b/packages/service-library/src/data-providers/page-document-provider.db.spec.ts
@@ -62,7 +62,7 @@ describe(PageDocumentProvider, () => {
                 pageRescanIntervalInDays: 2,
                 failedPageRescanIntervalInHours: 3,
                 maxScanRetryCount: 4,
-                maxSendNotificationRetryCount: 3,
+                maxSendNotificationRetryCount: 5,
                 minLastReferenceSeenInDays: 5,
                 accessibilityRuleExclusionList: [],
                 scanTimeoutInMin: 1,

--- a/packages/service-library/src/data-providers/page-document-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-document-provider.spec.ts
@@ -34,7 +34,7 @@ describe('PageDocumentProvider', () => {
         scanConfig = {
             failedPageRescanIntervalInHours: 3,
             maxScanRetryCount: 4,
-            maxSendNotificationRetryCount: 3,
+            maxSendNotificationRetryCount: 5,
             minLastReferenceSeenInDays: 5,
             pageRescanIntervalInDays: 6,
             accessibilityRuleExclusionList: [],

--- a/packages/storage-documents/src/index.ts
+++ b/packages/storage-documents/src/index.ts
@@ -14,4 +14,5 @@ export * from './on-demand-page-scan-batch-request';
 export * from './partition-key';
 export * from './on-demand-page-scan-request';
 export * from './on-demand-scan-request-message';
+export * from './on-demand-notification-request-message';
 export * from './batch-pool-load-snapshot';

--- a/packages/storage-documents/src/on-demand-notification-request-message.ts
+++ b/packages/storage-documents/src/on-demand-notification-request-message.ts
@@ -1,7 +1,7 @@
-import { OnDemandPageScanRunState, ScanState } from './on-demand-page-scan-result';
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+import { OnDemandPageScanRunState, ScanState } from './on-demand-page-scan-result';
 
 export interface OnDemandNotificationRequestMessage {
     scanId: string;

--- a/packages/storage-documents/src/on-demand-notification-request-message.ts
+++ b/packages/storage-documents/src/on-demand-notification-request-message.ts
@@ -1,0 +1,11 @@
+import { OnDemandPageScanRunState, ScanState } from './on-demand-page-scan-result';
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export interface OnDemandNotificationRequestMessage {
+    scanId: string;
+    scanNotifyUrl: string;
+    runStatus: OnDemandPageScanRunState;
+    scanStatus: ScanState;
+}

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.spec.ts
@@ -70,7 +70,7 @@ describe('Scan request sender', () => {
 
             queueMock
                 .setup(async q => q.createMessage(storageConfigStub.scanQueue, message))
-                .returns(async () => Promise.resolve())
+                .returns(async () => Promise.resolve(true))
                 .verifiable(Times.once());
 
             pageScanRequestProvider
@@ -101,7 +101,7 @@ describe('Scan request sender', () => {
 
             queueMock
                 .setup(async q => q.createMessage(storageConfigStub.scanQueue, message))
-                .returns(async () => Promise.resolve())
+                .returns(async () => Promise.resolve(true))
                 .verifiable(Times.never());
 
             pageScanRequestProvider

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -275,6 +275,27 @@ describe(Runner, () => {
         await runner.run();
     });
 
+    it('return redirected url', async () => {
+        setupWebDriverCalls();
+
+        setupUpdateScanRunResultCall(getRunningJobStateScanResult());
+
+        const clonedPassedAxeScanResults = cloneDeep(passedAxeScanResults);
+        clonedPassedAxeScanResults.scannedUrl = 'redirect url';
+        scannerTaskMock
+            .setup(async s => s.scan(scanMetadata.url))
+            .returns(async () => Promise.resolve(clonedPassedAxeScanResults))
+            .verifiable();
+
+        setupGenerateReportsCall(clonedPassedAxeScanResults);
+        setupSaveAllReportsCall();
+        const scanResultWithNoViolations = getScanResultWithNoViolations();
+        scanResultWithNoViolations.scannedUrl = clonedPassedAxeScanResults.scannedUrl;
+        setupUpdateScanRunResultCall(scanResultWithNoViolations);
+
+        await runner.run();
+    });
+
     it('sets scan status to fail if violation length > 0', async () => {
         setupWebDriverCalls();
 

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -410,18 +410,21 @@ describe(Runner, () => {
                 .verifiable(Times.once());
         });
 
-        test.each([undefined, { scanNotifyUrl: undefined }])('Notification = %o', async notification => {
-            const fullResult = cloneDeep(onDemandPageScanResult);
-            fullResult.notification = notification;
-            setupUpdateScanRunResultCall(getRunningJobStateScanResult(), fullResult);
-            setupUpdateScanRunResultCall(getScanResultWithNoViolations(), fullResult);
-            notificationQueueMessageSenderMock
-                .setup(ndm => ndm.sendNotificationMessage(notificationMessage))
-                .returns(async () => Promise.resolve())
-                .verifiable(Times.never());
+        test.each([undefined, { scanNotifyUrl: undefined }])(
+            'Do not send notification when url not present, notification = %o',
+            async notification => {
+                const fullResult = cloneDeep(onDemandPageScanResult);
+                fullResult.notification = notification;
+                setupUpdateScanRunResultCall(getRunningJobStateScanResult(), fullResult);
+                setupUpdateScanRunResultCall(getScanResultWithNoViolations(), fullResult);
+                notificationQueueMessageSenderMock
+                    .setup(ndm => ndm.sendNotificationMessage(notificationMessage))
+                    .returns(async () => Promise.resolve())
+                    .verifiable(Times.never());
 
-            await runner.run();
-        });
+                await runner.run();
+            },
+        );
 
         it('Notification URL is not null', async () => {
             const fullResult = cloneDeep(onDemandPageScanResult);

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -92,7 +92,9 @@ export class Runner {
         const fullPageScanResult = await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
 
         const featureFlags = await this.getDefaultFeatureFlags();
+        this.logger.logInfo(`sendNotification feature flag ${featureFlags.sendNotification}`);
         if (featureFlags.sendNotification && !this.scanNotifyUrlEmpty(fullPageScanResult.notification)) {
+            this.logger.logInfo(`Sending notification to ${fullPageScanResult.notification.scanNotifyUrl}`);
             await this.notificationDispatcher.dispatchOnDemandScanRequests(
                 this.createOnDemandNotificationRequestMessage(fullPageScanResult),
             );

--- a/packages/web-api-scan-runner/src/tasks/notification-dispatcher.spec.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-dispatcher.spec.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Queue, StorageConfig } from 'azure-services';
+import { ScanRunTimeConfig, ServiceConfiguration, System } from 'common';
+import { cloneDeep } from 'lodash';
+import { Logger } from 'logger';
+import { OnDemandPageScanRunResultProvider } from 'service-library';
+import {
+    ItemType,
+    NotificationError,
+    NotificationState,
+    OnDemandNotificationRequestMessage,
+    OnDemandPageScanResult,
+    OnDemandPageScanRunState,
+    ScanCompletedNotification,
+} from 'storage-documents';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { NotificationDispatcher } from './notification-dispatcher';
+
+// tslint:disable: no-any mocha-no-side-effect-code no-object-literal-type-assertion no-unsafe-any no-null-keyword
+
+class MockableLogger extends Logger {}
+
+describe(NotificationDispatcher, () => {
+    let dispatcher: NotificationDispatcher;
+    let onDemandPageScanRunResultProviderMock: IMock<OnDemandPageScanRunResultProvider>;
+    let queueMock: IMock<Queue>;
+    let loggerMock: IMock<MockableLogger>;
+    let serviceConfigMock: IMock<ServiceConfiguration>;
+    let systemMock: IMock<typeof System>;
+    let processStub: typeof process;
+    let scanConfig: ScanRunTimeConfig;
+    let storageConfigStub: StorageConfig;
+
+    const notificationSenderMetadata: OnDemandNotificationRequestMessage = {
+        scanId: 'id',
+        scanNotifyUrl: 'scanNotifyUrl',
+        runStatus: 'completed',
+        scanStatus: 'pass',
+    };
+
+    const onDemandPageScanResult: OnDemandPageScanResult = {
+        url: 'url',
+        scanResult: null,
+        reports: null,
+        run: {
+            state: 'queued' as OnDemandPageScanRunState,
+            timestamp: 'timestamp',
+        },
+        priority: 1,
+        itemType: ItemType.onDemandPageScanRunResult,
+        id: 'id',
+        partitionKey: 'item-partitionKey',
+        batchRequestId: 'batch-id',
+    };
+
+    beforeEach(() => {
+        scanConfig = {
+            failedPageRescanIntervalInHours: 3,
+            maxScanRetryCount: 4,
+            maxSendNotificationRetryCount: 3,
+            minLastReferenceSeenInDays: 5,
+            pageRescanIntervalInDays: 6,
+            accessibilityRuleExclusionList: [],
+            scanTimeoutInMin: 1,
+        };
+
+        storageConfigStub = {
+            notificationQueue: 'test-notification-queue',
+        } as StorageConfig;
+
+        onDemandPageScanRunResultProviderMock = Mock.ofType(OnDemandPageScanRunResultProvider, MockBehavior.Strict);
+        queueMock = Mock.ofType(Queue);
+        loggerMock = Mock.ofType(MockableLogger);
+        serviceConfigMock = Mock.ofType(ServiceConfiguration);
+        serviceConfigMock
+            .setup(async s => s.getConfigValue('scanConfig'))
+            .returns(async () => scanConfig)
+            .verifiable(Times.once());
+        systemMock = Mock.ofInstance(System, MockBehavior.Strict);
+
+        processStub = {} as typeof process;
+        processStub.env = { batchJobId: 'job 1' };
+
+        dispatcher = new NotificationDispatcher(
+            onDemandPageScanRunResultProviderMock.object,
+            serviceConfigMock.object,
+            storageConfigStub,
+            queueMock.object,
+            loggerMock.object,
+            processStub,
+            systemMock.object,
+        );
+    });
+
+    it('Enqueue Notification Succeeded', async () => {
+        const notification = generateNotification(notificationSenderMetadata.scanNotifyUrl, 'queued', null, 200);
+        setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
+
+        systemMock
+            .setup(sm => sm.wait(5000))
+            .returns(async () => Promise.resolve())
+            .verifiable(Times.never());
+
+        queueMock
+            .setup(qm => qm.createMessage(storageConfigStub.notificationQueue, notificationSenderMetadata))
+            .returns(async () => Promise.resolve(true))
+            .verifiable(Times.once());
+
+        await dispatcher.dispatchOnDemandScanRequests(notificationSenderMetadata);
+    });
+
+    it('Send Notification Failed', async () => {
+        const notification = generateNotification(
+            notificationSenderMetadata.scanNotifyUrl,
+            'queueFailed',
+            {
+                errorType: 'InternalError',
+                message: 'Failed to enqueue the notification!',
+            },
+            500,
+        );
+        setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
+
+        systemMock
+            .setup(sm => sm.wait(5000))
+            .returns(async () => Promise.resolve())
+            .verifiable(Times.exactly(2));
+
+        queueMock
+            .setup(qm => qm.createMessage(storageConfigStub.notificationQueue, notificationSenderMetadata))
+            .returns(async () => Promise.resolve(false))
+            .verifiable(Times.exactly(3));
+
+        await dispatcher.dispatchOnDemandScanRequests(notificationSenderMetadata);
+    });
+
+    it('Send Notification Failed Error', async () => {
+        const notification = generateNotification(
+            notificationSenderMetadata.scanNotifyUrl,
+            'queueFailed',
+            {
+                errorType: 'InternalError',
+                message: 'Unexpected Error',
+            },
+            500,
+        );
+        setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
+
+        systemMock
+            .setup(sm => sm.wait(5000))
+            .returns(async () => Promise.resolve())
+            .verifiable(Times.exactly(2));
+
+        queueMock
+            .setup(qm => qm.createMessage(storageConfigStub.notificationQueue, notificationSenderMetadata))
+            .throws(new Error('Unexpected Error'))
+            .verifiable(Times.exactly(3));
+
+        await dispatcher.dispatchOnDemandScanRequests(notificationSenderMetadata);
+    });
+
+    afterEach(() => {
+        onDemandPageScanRunResultProviderMock.verifyAll();
+        queueMock.verifyAll();
+        loggerMock.verifyAll();
+        serviceConfigMock.verifyAll();
+        systemMock.verifyAll();
+    });
+
+    function getRunningJobStateScanResult(notification: ScanCompletedNotification): Partial<OnDemandPageScanResult> {
+        return {
+            id: onDemandPageScanResult.id,
+            notification: notification,
+        };
+    }
+
+    function setupUpdateScanRunResultCall(result: Partial<OnDemandPageScanResult>): void {
+        const clonedResult = cloneDeep(result);
+        onDemandPageScanRunResultProviderMock
+            .setup(async d => d.updateScanRun(clonedResult))
+            .returns(async () => Promise.resolve(clonedResult as OnDemandPageScanResult))
+            .verifiable(Times.once());
+    }
+
+    function generateNotification(
+        notificationUrl: string,
+        state: NotificationState,
+        error: NotificationError,
+        statusCode: number,
+    ): ScanCompletedNotification {
+        return {
+            scanNotifyUrl: notificationUrl,
+            state: state,
+            error: error,
+            responseCode: statusCode,
+        };
+    }
+});

--- a/packages/web-api-scan-runner/src/tasks/notification-dispatcher.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-dispatcher.ts
@@ -13,6 +13,8 @@ import {
     ScanCompletedNotification,
 } from 'storage-documents';
 
+// tslint:disable: no-null-keyword no-any
+
 @injectable()
 export class NotificationDispatcher {
     constructor(

--- a/packages/web-api-scan-runner/src/tasks/notification-dispatcher.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-dispatcher.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Queue, StorageConfig } from 'azure-services';
+import { ScanRunTimeConfig, ServiceConfiguration, System } from 'common';
+import { inject, injectable } from 'inversify';
+import { Logger, loggerTypes } from 'logger';
+import { OnDemandPageScanRunResultProvider } from 'service-library';
+import {
+    NotificationError,
+    NotificationState,
+    OnDemandNotificationRequestMessage,
+    OnDemandPageScanResult,
+    ScanCompletedNotification,
+} from 'storage-documents';
+
+@injectable()
+export class NotificationDispatcher {
+    constructor(
+        @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
+        @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
+        @inject(StorageConfig) private readonly storageConfig: StorageConfig,
+        @inject(Queue) private readonly queue: Queue,
+        @inject(Logger) private readonly logger: Logger,
+        @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
+        private readonly system: typeof System = System,
+    ) {}
+
+    public async dispatchOnDemandScanRequests(onDemandNotificationRequestMessage: OnDemandNotificationRequestMessage): Promise<void> {
+        this.logger.logInfo(`Reading page scan run result ${onDemandNotificationRequestMessage.scanId}`);
+        this.logger.setCustomProperties({
+            scanId: onDemandNotificationRequestMessage.scanId,
+            batchJobId: this.currentProcess.env.AZ_BATCH_JOB_ID,
+        });
+
+        const pageScanResult = await this.enqueueNotificationWithRetry(onDemandNotificationRequestMessage);
+
+        this.logger.logInfo(`Writing page notification status to a storage.`);
+        await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
+    }
+
+    private async enqueueNotificationWithRetry(
+        notificationSenderConfigData: OnDemandNotificationRequestMessage,
+    ): Promise<Partial<OnDemandPageScanResult>> {
+        let numberOfTries = 1;
+        let notificationState: NotificationState = 'queueFailed';
+        let error: NotificationError = null;
+        let statusCode = 500;
+        const scanConfig = await this.getScanConfig();
+
+        while (numberOfTries <= scanConfig.maxSendNotificationRetryCount) {
+            this.logger.logInfo(`Enqueuing the scan notification, try #${numberOfTries}`);
+            let response;
+            try {
+                response = await this.queue.createMessage(this.storageConfig.notificationQueue, notificationSenderConfigData);
+
+                if (response) {
+                    this.logger.logInfo(`Notification enqueued successfully!, try #${numberOfTries}`);
+                    notificationState = 'queued';
+                    error = null;
+                    statusCode = 200;
+                    break;
+                } else {
+                    this.logger.logInfo(`Failed to enqueue the notification!, try #${numberOfTries}`);
+                    error = { errorType: 'InternalError', message: `Failed to enqueue the notification!` };
+                }
+            } catch (e) {
+                this.logger.logError(`Failed to enqueue the notification!, error message: ${(e as Error).message}`);
+                error = { errorType: 'InternalError', message: (e as Error).message };
+            }
+            numberOfTries = numberOfTries + 1;
+            if (numberOfTries <= scanConfig.maxSendNotificationRetryCount) {
+                await this.system.wait(5000);
+            }
+        }
+
+        return {
+            id: notificationSenderConfigData.scanId,
+            notification: this.generateNotification(notificationSenderConfigData.scanNotifyUrl, notificationState, error, statusCode),
+        };
+    }
+
+    private async getScanConfig(): Promise<ScanRunTimeConfig> {
+        return this.serviceConfig.getConfigValue('scanConfig');
+    }
+
+    private generateNotification(
+        scanNotifyUrl: string,
+        state: NotificationState,
+        error: NotificationError,
+        statusCode: number,
+    ): ScanCompletedNotification {
+        return {
+            scanNotifyUrl: scanNotifyUrl,
+            state: state,
+            error: error,
+            responseCode: statusCode,
+        };
+    }
+}

--- a/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.spec.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.spec.ts
@@ -60,7 +60,7 @@ describe(NotificationQueueMessageSender, () => {
         scanConfig = {
             failedPageRescanIntervalInHours: 3,
             maxScanRetryCount: 4,
-            maxSendNotificationRetryCount: 3,
+            maxSendNotificationRetryCount: 2,
             minLastReferenceSeenInDays: 5,
             pageRescanIntervalInDays: 6,
             accessibilityRuleExclusionList: [],
@@ -125,14 +125,14 @@ describe(NotificationQueueMessageSender, () => {
         setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
 
         systemMock
-            .setup(sm => sm.wait(5000))
+            .setup(sm => sm.wait(1000))
             .returns(async () => Promise.resolve())
-            .verifiable(Times.exactly(2));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount - 1));
 
         queueMock
             .setup(qm => qm.createMessage(storageConfigStub.notificationQueue, notificationSenderMetadata))
             .returns(async () => Promise.resolve(false))
-            .verifiable(Times.exactly(3));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount));
 
         await dispatcher.sendNotificationMessage(notificationSenderMetadata);
     });
@@ -150,14 +150,14 @@ describe(NotificationQueueMessageSender, () => {
         setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
 
         systemMock
-            .setup(sm => sm.wait(5000))
+            .setup(sm => sm.wait(1000))
             .returns(async () => Promise.resolve())
-            .verifiable(Times.exactly(2));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount - 1));
 
         queueMock
             .setup(qm => qm.createMessage(storageConfigStub.notificationQueue, notificationSenderMetadata))
             .throws(new Error('Unexpected Error'))
-            .verifiable(Times.exactly(3));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount));
 
         await dispatcher.sendNotificationMessage(notificationSenderMetadata);
     });

--- a/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.spec.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.spec.ts
@@ -17,14 +17,14 @@ import {
     ScanCompletedNotification,
 } from 'storage-documents';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { NotificationDispatcher } from './notification-dispatcher';
+import { NotificationQueueMessageSender } from './notification-queue-message-sender';
 
 // tslint:disable: no-any mocha-no-side-effect-code no-object-literal-type-assertion no-unsafe-any no-null-keyword
 
 class MockableLogger extends Logger {}
 
-describe(NotificationDispatcher, () => {
-    let dispatcher: NotificationDispatcher;
+describe(NotificationQueueMessageSender, () => {
+    let dispatcher: NotificationQueueMessageSender;
     let onDemandPageScanRunResultProviderMock: IMock<OnDemandPageScanRunResultProvider>;
     let queueMock: IMock<Queue>;
     let loggerMock: IMock<MockableLogger>;
@@ -84,7 +84,7 @@ describe(NotificationDispatcher, () => {
         processStub = {} as typeof process;
         processStub.env = { batchJobId: 'job 1' };
 
-        dispatcher = new NotificationDispatcher(
+        dispatcher = new NotificationQueueMessageSender(
             onDemandPageScanRunResultProviderMock.object,
             serviceConfigMock.object,
             storageConfigStub,
@@ -109,7 +109,7 @@ describe(NotificationDispatcher, () => {
             .returns(async () => Promise.resolve(true))
             .verifiable(Times.once());
 
-        await dispatcher.dispatchOnDemandScanRequests(notificationSenderMetadata);
+        await dispatcher.sendNotificationMessage(notificationSenderMetadata);
     });
 
     it('Send Notification Failed', async () => {
@@ -134,7 +134,7 @@ describe(NotificationDispatcher, () => {
             .returns(async () => Promise.resolve(false))
             .verifiable(Times.exactly(3));
 
-        await dispatcher.dispatchOnDemandScanRequests(notificationSenderMetadata);
+        await dispatcher.sendNotificationMessage(notificationSenderMetadata);
     });
 
     it('Send Notification Failed Error', async () => {
@@ -159,7 +159,7 @@ describe(NotificationDispatcher, () => {
             .throws(new Error('Unexpected Error'))
             .verifiable(Times.exactly(3));
 
-        await dispatcher.dispatchOnDemandScanRequests(notificationSenderMetadata);
+        await dispatcher.sendNotificationMessage(notificationSenderMetadata);
     });
 
     afterEach(() => {

--- a/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.spec.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.spec.ts
@@ -60,7 +60,7 @@ describe(NotificationQueueMessageSender, () => {
         scanConfig = {
             failedPageRescanIntervalInHours: 3,
             maxScanRetryCount: 4,
-            maxSendNotificationRetryCount: 2,
+            maxSendNotificationRetryCount: 4,
             minLastReferenceSeenInDays: 5,
             pageRescanIntervalInDays: 6,
             accessibilityRuleExclusionList: [],
@@ -124,10 +124,12 @@ describe(NotificationQueueMessageSender, () => {
         );
         setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
 
-        systemMock
-            .setup(sm => sm.wait(1000))
-            .returns(async () => Promise.resolve())
-            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount - 1));
+        for (let tryNumber = 1; tryNumber < scanConfig.maxSendNotificationRetryCount; tryNumber = tryNumber + 1) {
+            systemMock
+                .setup(sm => sm.wait(tryNumber * 1000))
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+        }
 
         queueMock
             .setup(qm => qm.createMessage(storageConfigStub.notificationQueue, notificationSenderMetadata))
@@ -149,10 +151,12 @@ describe(NotificationQueueMessageSender, () => {
         );
         setupUpdateScanRunResultCall(getRunningJobStateScanResult(notification));
 
-        systemMock
-            .setup(sm => sm.wait(1000))
-            .returns(async () => Promise.resolve())
-            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount - 1));
+        for (let tryNumber = 1; tryNumber < scanConfig.maxSendNotificationRetryCount; tryNumber = tryNumber + 1) {
+            systemMock
+                .setup(sm => sm.wait(tryNumber * 1000))
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+        }
 
         queueMock
             .setup(qm => qm.createMessage(storageConfigStub.notificationQueue, notificationSenderMetadata))

--- a/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.ts
@@ -78,7 +78,8 @@ export class NotificationQueueMessageSender {
             }
             numberOfTries = numberOfTries + 1;
             if (numberOfTries <= scanConfig.maxSendNotificationRetryCount) {
-                await this.system.wait(5000);
+                // tslint:disable-next-line:binary-expression-operand-order
+                await this.system.wait(1000 * (numberOfTries - 1));
             }
         }
 

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.spec.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.spec.ts
@@ -62,7 +62,7 @@ describe(NotificationSender, () => {
         scanConfig = {
             failedPageRescanIntervalInHours: 3,
             maxScanRetryCount: 4,
-            maxSendNotificationRetryCount: 3,
+            maxSendNotificationRetryCount: 5,
             minLastReferenceSeenInDays: 5,
             pageRescanIntervalInDays: 6,
             accessibilityRuleExclusionList: [],
@@ -128,14 +128,14 @@ describe(NotificationSender, () => {
         systemMock
             .setup(sm => sm.wait(5000))
             .returns(async () => Promise.resolve())
-            .verifiable(Times.exactly(2));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount - 1));
 
         const response = { statusCode: 400, body: 'Bad Request' } as ResponseAsJSON;
 
         webAPIMock
             .setup(wam => wam.sendNotification(notificationSenderMetadata))
             .returns(async () => Promise.resolve(response))
-            .verifiable(Times.exactly(3));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount));
 
         await sender.sendNotification();
     });
@@ -155,12 +155,12 @@ describe(NotificationSender, () => {
         systemMock
             .setup(sm => sm.wait(5000))
             .returns(async () => Promise.resolve())
-            .verifiable(Times.exactly(2));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount - 1));
 
         webAPIMock
             .setup(wam => wam.sendNotification(notificationSenderMetadata))
             .throws(new Error('Unexpected Error'))
-            .verifiable(Times.exactly(3));
+            .verifiable(Times.exactly(scanConfig.maxSendNotificationRetryCount));
 
         await sender.sendNotification();
     });

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
@@ -25,15 +25,14 @@ export class NotificationSender {
 
     public async sendNotification(): Promise<void> {
         const notificationSenderConfigData = this.notificationSenderConfig.getConfig();
-        const scanId = notificationSenderConfigData.scanId;
 
-        this.logger.logInfo(`Reading page scan run result ${scanId}`);
+        this.logger.logInfo(`Reading page scan run result ${notificationSenderConfigData.scanId}`);
         this.logger.setCustomProperties({
-            scanId: scanId,
+            scanId: notificationSenderConfigData.scanId,
             batchJobId: this.currentProcess.env.AZ_BATCH_JOB_ID,
         });
 
-        const pageScanResult = await this.sendNotificationWithRetry(notificationSenderConfigData, scanId);
+        const pageScanResult = await this.sendNotificationWithRetry(notificationSenderConfigData);
 
         this.logger.logInfo(`Writing page notification status to a storage.`);
         await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
@@ -43,7 +42,6 @@ export class NotificationSender {
 
     private async sendNotificationWithRetry(
         notificationSenderConfigData: NotificationSenderMetadata,
-        scanId: string,
     ): Promise<Partial<OnDemandPageScanResult>> {
         let numberOfTries = 1;
         let notificationState: NotificationState = 'sendFailed';
@@ -85,7 +83,7 @@ export class NotificationSender {
         }
 
         return {
-            id: scanId,
+            id: notificationSenderConfigData.scanId,
             notification: this.generateNotification(notificationSenderConfigData.scanNotifyUrl, notificationState, error, statusCode),
         };
     }


### PR DESCRIPTION
#### Description of changes

- Create notification message on scan completion at the end of web-api-scan-runner if the send-notification feature flag is on and the scan-notify-url isn't empty! 

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
