### PR TITLE
fix: resize batch pools

### DIFF
--- a/packages/resource-deployment/scripts/recreate-vmss-for-pools.sh
+++ b/packages/resource-deployment/scripts/recreate-vmss-for-pools.sh
@@ -14,9 +14,6 @@ export pools
 areVmssOld=false
 recycleVmssIntervalDays=15
 
-# Set default ARM Batch account template files
-batchTemplateFile="${0%/*}/../templates/batch-account.template.json"
-
 exitWithUsageInfo() {
     echo "
 Usage: $0 -r <resource group>

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -2,12 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "scanRequestPoolNodes": {
-            "value": "1"
-        },
-        "urlScanPoolNodes": {
-            "value": "1"
-        },
         "onDemandScanRequestPoolNodes": {
             "value": "1"
         },

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "scanRequestPoolVmSize": {
+            "value": "standard_d1_v2"
+        },
+        "scanRequestPoolNodes": {
+            "value": "1"
+        },
+        "urlScanPoolVmSize": {
+            "value": "standard_d11_v2"
+        },
+        "urlScanPoolNodes": {
+            "value": "1"
+        },
+        "onDemandScanRequestPoolVmSize": {
+            "value": "standard_d1_v2"
+        },
+        "onDemandScanRequestPoolNodes": {
+            "value": "1"
+        },
+        "onDemandUrlScanPoolVmSize": {
+            "value": "standard_d11_v2"
+        },
+        "onDemandUrlScanPoolNodes": {
+            "value": "1"
+        }
+    }
+}

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -2,26 +2,14 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "scanRequestPoolVmSize": {
-            "value": "standard_d1_v2"
-        },
         "scanRequestPoolNodes": {
             "value": "1"
-        },
-        "urlScanPoolVmSize": {
-            "value": "standard_d11_v2"
         },
         "urlScanPoolNodes": {
             "value": "1"
         },
-        "onDemandScanRequestPoolVmSize": {
-            "value": "standard_d1_v2"
-        },
         "onDemandScanRequestPoolNodes": {
             "value": "1"
-        },
-        "onDemandUrlScanPoolVmSize": {
-            "value": "standard_d11_v2"
         },
         "onDemandUrlScanPoolNodes": {
             "value": "1"

--- a/packages/resource-deployment/templates/batch-account-prod.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-prod.parameters.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "scanRequestPoolVmSize": {
+            "value": "standard_d1_v2"
+        },
+        "scanRequestPoolNodes": {
+            "value": "2"
+        },
+        "urlScanPoolVmSize": {
+            "value": "standard_d11_v2"
+        },
+        "urlScanPoolNodes": {
+            "value": "3"
+        },
+        "onDemandScanRequestPoolVmSize": {
+            "value": "standard_d1_v2"
+        },
+        "onDemandScanRequestPoolNodes": {
+            "value": "2"
+        },
+        "onDemandUrlScanPoolVmSize": {
+            "value": "standard_d11_v2"
+        },
+        "onDemandUrlScanPoolNodes": {
+            "value": "6"
+        }
+    }
+}

--- a/packages/resource-deployment/templates/batch-account-prod.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-prod.parameters.json
@@ -2,12 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "scanRequestPoolNodes": {
-            "value": "2"
-        },
-        "urlScanPoolNodes": {
-            "value": "3"
-        },
         "onDemandScanRequestPoolNodes": {
             "value": "2"
         },

--- a/packages/resource-deployment/templates/batch-account-prod.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-prod.parameters.json
@@ -2,26 +2,14 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "scanRequestPoolVmSize": {
-            "value": "standard_d1_v2"
-        },
         "scanRequestPoolNodes": {
             "value": "2"
-        },
-        "urlScanPoolVmSize": {
-            "value": "standard_d11_v2"
         },
         "urlScanPoolNodes": {
             "value": "3"
         },
-        "onDemandScanRequestPoolVmSize": {
-            "value": "standard_d1_v2"
-        },
         "onDemandScanRequestPoolNodes": {
             "value": "2"
-        },
-        "onDemandUrlScanPoolVmSize": {
-            "value": "standard_d11_v2"
         },
         "onDemandUrlScanPoolNodes": {
             "value": "6"

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -37,20 +37,6 @@
                 "description": "Name of the virtual network to be used for the batch pool nodes"
             }
         },
-        "scanRequestPoolNodes": {
-            "defaultValue": "2",
-            "type": "string",
-            "metadata": {
-                "description": "Number of dedicated nodes for scan-request-pool"
-            }
-        },
-        "urlScanPoolNodes": {
-            "defaultValue": "3",
-            "type": "string",
-            "metadata": {
-                "description": "Number of dedicated nodes for url-scan-pool"
-            }
-        },
         "onDemandScanRequestPoolNodes": {
             "defaultValue": "2",
             "type": "string",
@@ -115,7 +101,7 @@
                 },
                 "scaleSettings": {
                     "fixedScale": {
-                        "targetDedicatedNodes": "[parameters('scanRequestPoolNodes')]",
+                        "targetDedicatedNodes": 1,
                         "targetLowPriorityNodes": 0,
                         "resizeTimeout": "PT15M"
                     }
@@ -172,7 +158,7 @@
                 },
                 "scaleSettings": {
                     "fixedScale": {
-                        "targetDedicatedNodes": "[parameters('urlScanPoolNodes')]",
+                        "targetDedicatedNodes": 1,
                         "targetLowPriorityNodes": 0,
                         "resizeTimeout": "PT15M"
                     }

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -37,13 +37,6 @@
                 "description": "Name of the virtual network to be used for the batch pool nodes"
             }
         },
-        "scanRequestPoolVmSize": {
-            "defaultValue": "standard_d1_v2",
-            "type": "string",
-            "metadata": {
-                "description": "Value for the vmSize setting of scan-request-pool"
-            }
-        },
         "scanRequestPoolNodes": {
             "defaultValue": "2",
             "type": "string",
@@ -51,46 +44,25 @@
                 "description": "Number of dedicated nodes for scan-request-pool"
             }
         },
-        "urlScanPoolVmSize": {
-            "defaultValue": "standard_d11_v2",
-            "type": "string",
-            "metadata": {
-                "description": "Value for the vmSize setting of scan-request-pool"
-            }
-        },
         "urlScanPoolNodes": {
             "defaultValue": "3",
             "type": "string",
             "metadata": {
-                "description": "Number of dedicated nodes for scan-request-pool"
-            }
-        },
-        "onDemandScanRequestPoolVmSize": {
-            "defaultValue": "standard_d1_v2",
-            "type": "string",
-            "metadata": {
-                "description": "Value for the vmSize setting of scan-request-pool"
+                "description": "Number of dedicated nodes for url-scan-pool"
             }
         },
         "onDemandScanRequestPoolNodes": {
             "defaultValue": "2",
             "type": "string",
             "metadata": {
-                "description": "Number of dedicated nodes for scan-request-pool"
-            }
-        },
-        "onDemandUrlScanPoolVmSize": {
-            "defaultValue": "standard_d11_v2",
-            "type": "string",
-            "metadata": {
-                "description": "Value for the vmSize setting of scan-request-pool"
+                "description": "Number of dedicated nodes for on-demand-scan-request-pool"
             }
         },
         "onDemandUrlScanPoolNodes": {
             "defaultValue": "3",
             "type": "string",
             "metadata": {
-                "description": "Number of dedicated nodes for scan-request-pool"
+                "description": "Number of dedicated nodes for on-demand-url-scan-pool"
             }
         }
     },
@@ -119,9 +91,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/scan-request-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "[parameters('scanRequestPoolVmSize')]",
+                "vmSize": "standard_d1_v2",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 1,
                 "taskSchedulingPolicy": {
@@ -176,9 +150,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/url-scan-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "[parameters('urlScanPoolVmSize')]",
+                "vmSize": "standard_d11_v2",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 2,
                 "taskSchedulingPolicy": {
@@ -233,9 +209,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-url-scan-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "[parameters('onDemandUrlScanPoolVmSize')]",
+                "vmSize": "standard_d11_v2",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 2,
                 "taskSchedulingPolicy": {
@@ -290,9 +268,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-scan-request-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "[parameters('onDemandScanRequestPoolVmSize')]",
+                "vmSize": "standard_d1_v2",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 1,
                 "taskSchedulingPolicy": {

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -36,6 +36,62 @@
             "metadata": {
                 "description": "Name of the virtual network to be used for the batch pool nodes"
             }
+        },
+        "scanRequestPoolVmSize": {
+            "defaultValue": "standard_d1_v2",
+            "type": "string",
+            "metadata": {
+                "description": "Value for the vmSize setting of scan-request-pool"
+            }
+        },
+        "scanRequestPoolNodes": {
+            "defaultValue": "2",
+            "type": "string",
+            "metadata": {
+                "description": "Number of dedicated nodes for scan-request-pool"
+            }
+        },
+        "urlScanPoolVmSize": {
+            "defaultValue": "standard_d11_v2",
+            "type": "string",
+            "metadata": {
+                "description": "Value for the vmSize setting of scan-request-pool"
+            }
+        },
+        "urlScanPoolNodes": {
+            "defaultValue": "3",
+            "type": "string",
+            "metadata": {
+                "description": "Number of dedicated nodes for scan-request-pool"
+            }
+        },
+        "onDemandScanRequestPoolVmSize": {
+            "defaultValue": "standard_d1_v2",
+            "type": "string",
+            "metadata": {
+                "description": "Value for the vmSize setting of scan-request-pool"
+            }
+        },
+        "onDemandScanRequestPoolNodes": {
+            "defaultValue": "2",
+            "type": "string",
+            "metadata": {
+                "description": "Number of dedicated nodes for scan-request-pool"
+            }
+        },
+        "onDemandUrlScanPoolVmSize": {
+            "defaultValue": "standard_d11_v2",
+            "type": "string",
+            "metadata": {
+                "description": "Value for the vmSize setting of scan-request-pool"
+            }
+        },
+        "onDemandUrlScanPoolNodes": {
+            "defaultValue": "3",
+            "type": "string",
+            "metadata": {
+                "description": "Number of dedicated nodes for scan-request-pool"
+            }
         }
     },
     "variables": {
@@ -63,9 +119,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/scan-request-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "standard_d1_v2",
+                "vmSize": "[parameters('scanRequestPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 1,
                 "taskSchedulingPolicy": {
@@ -87,7 +145,7 @@
                 },
                 "scaleSettings": {
                     "fixedScale": {
-                        "targetDedicatedNodes": 2,
+                        "targetDedicatedNodes": "[parameters('scanRequestPoolNodes')]",
                         "targetLowPriorityNodes": 0,
                         "resizeTimeout": "PT15M"
                     }
@@ -120,9 +178,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/url-scan-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "standard_d11_v2",
+                "vmSize": "[parameters('urlScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 2,
                 "taskSchedulingPolicy": {
@@ -144,7 +204,7 @@
                 },
                 "scaleSettings": {
                     "fixedScale": {
-                        "targetDedicatedNodes": 3,
+                        "targetDedicatedNodes": "[parameters('urlScanPoolNodes')]",
                         "targetLowPriorityNodes": 0,
                         "resizeTimeout": "PT15M"
                     }
@@ -177,9 +237,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-url-scan-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "standard_d11_v2",
+                "vmSize": "[parameters('onDemandUrlScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 2,
                 "taskSchedulingPolicy": {
@@ -201,7 +263,7 @@
                 },
                 "scaleSettings": {
                     "fixedScale": {
-                        "targetDedicatedNodes": 3,
+                        "targetDedicatedNodes": "[parameters('onDemandUrlScanPoolNodes')]",
                         "targetLowPriorityNodes": 0,
                         "resizeTimeout": "PT15M"
                     }
@@ -234,9 +296,11 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-scan-request-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
-                "vmSize": "standard_d1_v2",
+                "vmSize": "[parameters('onDemandScanRequestPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
                 "maxTasksPerNode": 1,
                 "taskSchedulingPolicy": {
@@ -258,7 +322,7 @@
                 },
                 "scaleSettings": {
                     "fixedScale": {
-                        "targetDedicatedNodes": 2,
+                        "targetDedicatedNodes": "[parameters('onDemandScanRequestPoolNodes')]",
                         "targetLowPriorityNodes": 0,
                         "resizeTimeout": "PT15M"
                     }

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -91,9 +91,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/scan-request-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "standard_d1_v2",
                 "interNodeCommunication": "Disabled",
@@ -150,9 +148,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/url-scan-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "standard_d11_v2",
                 "interNodeCommunication": "Disabled",
@@ -209,9 +205,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-url-scan-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "standard_d11_v2",
                 "interNodeCommunication": "Disabled",
@@ -268,9 +262,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-scan-request-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "standard_d1_v2",
                 "interNodeCommunication": "Disabled",

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -119,9 +119,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/scan-request-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "[parameters('scanRequestPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -178,9 +176,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/url-scan-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "[parameters('urlScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -237,9 +233,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-url-scan-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "[parameters('onDemandUrlScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -296,9 +290,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2018-12-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-scan-request-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "[parameters('onDemandScanRequestPoolVmSize')]",
                 "interNodeCommunication": "Disabled",


### PR DESCRIPTION
#### Description of changes

- Resize all batch pools to 1 node for dev and ci environments
- Scale up url-scan-pool from 3 to 6 nodes in prod and ppe

This should bring batch costs down by more than half in dev resource groups (from ~$17 to ~$8 per day)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #628
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
