### PR TITLE
fix: use deployment group instead of group deployment

### DIFF
--- a/packages/resource-deployment/scripts/app-insights-create.sh
+++ b/packages/resource-deployment/scripts/app-insights-create.sh
@@ -36,7 +36,7 @@ az extension add -n application-insights
 
 echo "Creating Application Insights resource using ARM template"
 export resourceName
-resources=$(az group deployment create \
+resources=$(az deployment group create \
     --subscription "$subscription" \
     --resource-group "$resourceGroupName" \
     --template-file "${0%/*}/../templates/app-insights.template.json" \

--- a/packages/resource-deployment/scripts/batch-account-create.sh
+++ b/packages/resource-deployment/scripts/batch-account-create.sh
@@ -33,7 +33,7 @@ function deployBatch() {
     # Deploy Azure Batch account using resource manager template
     echo "Deploying Azure Batch account in resource group $resourceGroupName with template $batchTemplateFile"
     resources=$(
-        az group deployment create \
+        az deployment group create \
             --resource-group "$resourceGroupName" \
             --template-file "$batchTemplateFile" \
             --query "properties.outputResources[].id" \

--- a/packages/resource-deployment/scripts/create-api-management.sh
+++ b/packages/resource-deployment/scripts/create-api-management.sh
@@ -47,7 +47,7 @@ fi
 # Start deployment
 echo "[create-api-management] Deploying API management instance. This might take up to 45 mins"
 
-resources=$(az group deployment create \
+resources=$(az deployment group create \
     --resource-group "$resourceGroupName" \
     --template-file "$templateFilePath" \
     --parameters adminEmail="$publisherEmail" orgName="$orgName" tier="$tier" \

--- a/packages/resource-deployment/scripts/create-dashboard.sh
+++ b/packages/resource-deployment/scripts/create-dashboard.sh
@@ -33,7 +33,7 @@ fi
 # Deploy Azure dashboard using resource manager template
 echo "Deploying dashboard in resource group $resourceGroupName with template $dashboardTemplateFile"
 resources=$(
-    az group deployment create \
+    az deployment group create \
         --resource-group "$resourceGroupName" \
         --template-file "$dashboardTemplateFile" \
         --query "properties.outputResources[].id" \

--- a/packages/resource-deployment/scripts/create-datalake-storage-account.sh
+++ b/packages/resource-deployment/scripts/create-datalake-storage-account.sh
@@ -29,7 +29,7 @@ templateFile="${0%/*}/../templates/datalake-storage.template.json"
 parameters="${0%/*}/../templates/datalake-storage.parameters.json"
 
 echo "[create-datalake-storage-account] Creating Data Lake enabled storage account under resource group '$resourceGroupName' using ARM template $templateFile"
-resources=$(az group deployment create --resource-group "$resourceGroupName" --template-file "$templateFile" --parameters "$parameters" --query "properties.outputResources[].id" -o tsv)
+resources=$(az deployment group create --resource-group "$resourceGroupName" --template-file "$templateFile" --parameters "$parameters" --query "properties.outputResources[].id" -o tsv)
 
 export resourceName
 . "${0%/*}/get-resource-name-from-resource-paths.sh" -p "Microsoft.Storage/storageAccounts" -r "$resources"

--- a/packages/resource-deployment/scripts/create-storage-account.sh
+++ b/packages/resource-deployment/scripts/create-storage-account.sh
@@ -29,7 +29,7 @@ templateFile="${0%/*}/../templates/blob-storage.template.json"
 parameters="${0%/*}/../templates/blob-storage.parameters.json"
 
 echo "Creating storage account under resource group '$resourceGroupName' using ARM template $templateFile"
-resources=$(az group deployment create --resource-group "$resourceGroupName" --template-file "$templateFile" --parameters "$parameters" --query "properties.outputResources[].id" -o tsv)
+resources=$(az deployment group create --resource-group "$resourceGroupName" --template-file "$templateFile" --parameters "$parameters" --query "properties.outputResources[].id" -o tsv)
 
 export resourceName
 . "${0%/*}/get-resource-name-from-resource-paths.sh" -p "Microsoft.Storage/storageAccounts" -r "$resources"

--- a/packages/resource-deployment/scripts/create-vnet.sh
+++ b/packages/resource-deployment/scripts/create-vnet.sh
@@ -34,7 +34,7 @@ subnetAddressPrefix=${subnetAddressPrefix:-"10.2.0.0/24"}
 
 echo "[create-vnet] Starting Virtual Network creation"
 
-vnetResource=$(az group deployment create \
+vnetResource=$(az deployment group create \
     --resource-group "$resourceGroupName" \
     --template-file "$templateFilePath" \
     --parameters addressPrefix="$addressPrefix" subnetAddressPrefix="$subnetAddressPrefix" \

--- a/packages/resource-deployment/scripts/deploy-rest-api.sh
+++ b/packages/resource-deployment/scripts/deploy-rest-api.sh
@@ -9,14 +9,14 @@ set -eo pipefail
 deployResource() {
     local templateName=$1
     echo "Deploying with resource parameters: Resource = $resourceGroupName, Template = $templateName, API Instance = $apiManagementName"
-    az group deployment create --resource-group "$resourceGroupName" --template-file "$templateName" --parameters apimServiceName="$apiManagementName" 1>/dev/null
+    az deployment group create --resource-group "$resourceGroupName" --template-file "$templateName" --parameters apimServiceName="$apiManagementName" 1>/dev/null
     echo "  Completed"
 }
 
 deployResourceWithFunctionName() {
     local templateName=$1
     echo "Deploying with resource parameters: Resource = $resourceGroupName, Template = $templateName, API Instance = $apiManagementName"
-    az group deployment create --resource-group "$resourceGroupName" --template-file "$templateName" --parameters functionName="$webApiFuncAppName" apimServiceName="$apiManagementName" 1>/dev/null
+    az deployment group create --resource-group "$resourceGroupName" --template-file "$templateName" --parameters functionName="$webApiFuncAppName" apimServiceName="$apiManagementName" 1>/dev/null
     echo "  Completed"
 }
 

--- a/packages/resource-deployment/scripts/function-app-create.sh
+++ b/packages/resource-deployment/scripts/function-app-create.sh
@@ -129,7 +129,7 @@ deployFunctionApp() {
     local extraParameters=$4
 
     echo "Deploying Azure Function App $functionAppName using ARM template..."
-    resources=$(az group deployment create \
+    resources=$(az deployment group create \
         --resource-group "$resourceGroupName" \
         --template-file "$templateFilePath" \
         --parameters namePrefix="$functionAppNamePrefix" releaseVersion="$releaseVersion" $extraParameters \

--- a/packages/resource-deployment/scripts/setup-cosmos-db.sh
+++ b/packages/resource-deployment/scripts/setup-cosmos-db.sh
@@ -12,7 +12,7 @@ export resourceGroupName
 
 createCosmosAccount() {
     echo "[setup-cosmos-db] Creating Cosmos DB account..."
-    resources=$(az group deployment create --resource-group "$resourceGroupName" --template-file "${0%/*}/../templates/cosmos-db.template.json" --parameters "${0%/*}/../templates/cosmos-db.parameters.json" --query "properties.outputResources[].id" -o tsv)
+    resources=$(az deployment group create --resource-group "$resourceGroupName" --template-file "${0%/*}/../templates/cosmos-db.template.json" --parameters "${0%/*}/../templates/cosmos-db.parameters.json" --query "properties.outputResources[].id" -o tsv)
 
     export resourceName
     . "${0%/*}/get-resource-name-from-resource-paths.sh" -p "Microsoft.DocumentDB/databaseAccounts" -r "$resources"


### PR DESCRIPTION
#### Description of changes

The `group deployment` command is deprecated in the most recent version of the azure cli. This will replace it with the new `deployment group` command.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #589
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
