### PR TITLE
fix: scale up scan request pool to 2 nodes

### DIFF
--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "onDemandScanRequestPoolNodes": {
-            "value": "1"
+            "value": "2"
         },
         "onDemandUrlScanPoolNodes": {
             "value": "1"

--- a/packages/web-api-send-notification-job-manager/src/index.ts
+++ b/packages/web-api-send-notification-job-manager/src/index.ts
@@ -2,13 +2,6 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-(async () => {
-    console.log('not implemented');
-})().catch(error => {
-    console.log('Exception thrown in send notification job manager: ', error);
-    process.exit(1);
-});
-
 import { WhyNodeRunningLogger } from 'common';
 
 import { SendNotificationJobManagerEntryPoint } from './send-notification-job-manager-entry-point';


### PR DESCRIPTION
#### Description of changes

- change OnDemandScanRequestPool from 1 to 2 nodes because the notification sender will have 2 tasks
- Remove "not implemented" error from send notification job manager

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
