### PR TITLE
chore: Set Scan Request Sender Job Priority to Maximum

### DIFF
--- a/packages/resource-deployment/templates/on-demand-scan-req-schedule.template.json
+++ b/packages/resource-deployment/templates/on-demand-scan-req-schedule.template.json
@@ -4,7 +4,7 @@
         "recurrenceInterval": "PT2M"
     },
     "jobSpecification": {
-        "priority": 0,
+        "priority": 1000,
         "constraints": {
             "maxWallClockTime": "PT1H",
             "maxTaskRetryCount": 0


### PR DESCRIPTION
#### Description of changes

- Set scan request sender job priority to 1000, while notification job is still 0, so scan request sender won't starve if too many notifications are being sent.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
