### PR TITLE
fix: only add error prop in get scan response if there is error in db document

### DIFF
--- a/packages/web-api/src/converters/scan-error-converter.ts
+++ b/packages/web-api/src/converters/scan-error-converter.ts
@@ -25,6 +25,10 @@ export class ScanErrorConverter {
     }
 
     public getScanNotificationErrorCode(scanNotificationError: string | NotificationError): ScanNotificationErrorCode {
+        if (isNil(scanNotificationError)) {
+            return undefined;
+        }
+
         if (isString(scanNotificationError)) {
             return ScanNotificationErrorCodes.InternalError;
         }

--- a/packages/web-api/src/converters/scan-error-converter.ts
+++ b/packages/web-api/src/converters/scan-error-converter.ts
@@ -25,10 +25,6 @@ export class ScanErrorConverter {
     }
 
     public getScanNotificationErrorCode(scanNotificationError: string | NotificationError): ScanNotificationErrorCode {
-        if (isNil(scanNotificationError)) {
-            return undefined;
-        }
-
         if (isString(scanNotificationError)) {
             return ScanNotificationErrorCodes.InternalError;
         }

--- a/packages/web-api/src/converters/scan-response-converter.spec.ts
+++ b/packages/web-api/src/converters/scan-response-converter.spec.ts
@@ -163,14 +163,17 @@ describe(ScanResponseConverter, () => {
         expect(response).toEqual(responseExpected);
     });
 
-    it('notification response object does not have error field if there is error in the db document', () => {
-        // verify that the response should have error object when db document has error
+    it('adds error to notification if db has error info', () => {
         const pageScanDbResult = getPageScanResult('completed', true);
         const responseExpected: ScanRunResultResponse = getScanResultClientResponseFull('completed', true) as ScanRunResultResponse;
 
         expect(scanResponseConverter.getScanResultResponse(baseUrl, apiVersion, pageScanDbResult)).toEqual(responseExpected);
+    });
 
-        // the response should not have error object when db document does not have error
+    it('does not add error to notification is db doc has no error', () => {
+        const pageScanDbResult = getPageScanResult('completed', true);
+        const responseExpected: ScanRunResultResponse = getScanResultClientResponseFull('completed', true) as ScanRunResultResponse;
+
         // tslint:disable-next-line: no-null-keyword
         pageScanDbResult.notification.error = null;
         const expectedNotificationResponse = responseExpected.notification;

--- a/packages/web-api/src/converters/scan-response-converter.spec.ts
+++ b/packages/web-api/src/converters/scan-response-converter.spec.ts
@@ -30,7 +30,7 @@ let scanResponseConverter: ScanResponseConverter;
 let scanErrorConverterMock: IMock<ScanErrorConverter>;
 const pageTitle = 'sample page title';
 const pageResponseCode = 101;
-let notification: Notification;
+let notificationDb: Notification;
 let notificationResponse: ScanCompletedNotification;
 
 beforeEach(() => {
@@ -52,7 +52,7 @@ beforeEach(() => {
         error: ScanNotificationErrorCodes.InternalError,
         responseCode: 200,
     };
-    notification = {
+    notificationDb = {
         scanNotifyUrl: 'reply-url',
         state: 'queued',
         error: {
@@ -88,7 +88,7 @@ function getPageScanResult(state: RunStateDb, isNotificationEnabled = false): On
             pageResponseCode: pageResponseCode,
         },
         batchRequestId: 'batch-id',
-        ...(isNotificationEnabled ? { notification } : {}),
+        ...(isNotificationEnabled ? { notification: notificationDb } : {}),
     };
 }
 
@@ -161,6 +161,21 @@ describe(ScanResponseConverter, () => {
         const responseExpected = getScanResultClientResponseFull('completed', notificationEnabled);
         const response = scanResponseConverter.getScanResultResponse(baseUrl, apiVersion, pageScanDbResult);
         expect(response).toEqual(responseExpected);
+    });
+
+    it('notification response object does not have error field if there is error in the db document', () => {
+        // verify that the response should have error object when db document has error
+        const pageScanDbResult = getPageScanResult('completed', true);
+        const responseExpected: ScanRunResultResponse = getScanResultClientResponseFull('completed', true) as ScanRunResultResponse;
+
+        expect(scanResponseConverter.getScanResultResponse(baseUrl, apiVersion, pageScanDbResult)).toEqual(responseExpected);
+
+        // the response should not have error object when db document does not have error
+        // tslint:disable-next-line: no-null-keyword
+        pageScanDbResult.notification.error = null;
+        const expectedNotificationResponse = responseExpected.notification;
+        delete expectedNotificationResponse.error;
+        expect(scanResponseConverter.getScanResultResponse(baseUrl, apiVersion, pageScanDbResult)).toEqual(responseExpected);
     });
 
     it('create full canonical REST Get Report URL', () => {

--- a/packages/web-api/src/converters/scan-response-converter.ts
+++ b/packages/web-api/src/converters/scan-response-converter.ts
@@ -2,8 +2,13 @@
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
 import { isEmpty, isNil } from 'lodash';
-import { notificationErrorNameToErrorMap, ScanReport, ScanResultResponse } from 'service-library';
-import { OnDemandPageScanResult, OnDemandPageScanRunState, ScanCompletedNotification } from 'storage-documents';
+import {
+    notificationErrorNameToErrorMap,
+    ScanCompletedNotification as NotificationResponse,
+    ScanReport,
+    ScanResultResponse,
+} from 'service-library';
+import { OnDemandPageScanResult, OnDemandPageScanRunState, ScanCompletedNotification as NotificationDb } from 'storage-documents';
 
 import { ScanErrorConverter } from './scan-error-converter';
 
@@ -84,20 +89,20 @@ export class ScanResponseConverter {
         });
     }
 
-    private getRunCompleteNotificationResponse(
-        notification: ScanCompletedNotification,
-    ): { [notification: string]: ScanCompletedNotification } | {} {
+    private getRunCompleteNotificationResponse(notification: NotificationDb): { [notification: string]: NotificationResponse } | {} {
         if (isNil(notification)) {
             return {};
         }
-
-        return {
-            notification: {
-                scanNotifyUrl: notification.scanNotifyUrl,
-                state: notification.state,
-                error: this.scanErrorConverter.getScanNotificationErrorCode(notification.error),
-                responseCode: notification.responseCode,
-            },
+        const notificationResponse: NotificationResponse = {
+            scanNotifyUrl: notification.scanNotifyUrl,
+            state: notification.state,
+            responseCode: notification.responseCode,
         };
+
+        if (!isNil(notification.error)) {
+            notificationResponse.error = this.scanErrorConverter.getScanNotificationErrorCode(notification.error);
+        }
+
+        return { notification: notificationResponse };
     }
 }


### PR DESCRIPTION
#### Description of changes

fix: only add error prop in get scan response if there is error in db document
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
