### PR TITLE
fix: context aware logger should be singleton

### DIFF
--- a/packages/azure-services/src/azure-batch/batch.ts
+++ b/packages/azure-services/src/azure-batch/batch.ts
@@ -7,7 +7,7 @@ import { System } from 'common';
 import * as crypto from 'crypto';
 import { inject, injectable, optional } from 'inversify';
 import * as _ from 'lodash';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { VError } from 'verror';
 import { StorageContainerSASUrlProvider } from '../azure-blob/storage-container-sas-url-provider';
 import { Message } from '../azure-queue/message';
@@ -28,7 +28,7 @@ export class Batch {
         private readonly batchTaskConfigGenerator: BatchTaskConfigGenerator,
         @inject(StorageContainerSASUrlProvider) private readonly containerSASUrlProvider: StorageContainerSASUrlProvider,
         @inject(BatchConfig) private readonly config: BatchConfig,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         // Azure Batch supports the maximum 100 tasks to be added in a single addTaskCollection() API call
         private readonly maxTasks = 100,
     ) {}

--- a/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.ts
+++ b/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.ts
@@ -4,7 +4,7 @@ import * as cosmos from '@azure/cosmos';
 import { System } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
-import { ContextAwareLogger, Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 
 import { CosmosClientProvider, iocTypeNames } from '../ioc-types';
 import { client } from '../storage/client';

--- a/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.ts
+++ b/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.ts
@@ -4,7 +4,7 @@ import * as cosmos from '@azure/cosmos';
 import { System } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
-import { Logger } from 'logger';
+import { ContextAwareLogger, Logger } from 'logger';
 
 import { CosmosClientProvider, iocTypeNames } from '../ioc-types';
 import { client } from '../storage/client';
@@ -22,7 +22,7 @@ export class CosmosClientWrapper {
 
     constructor(
         @inject(iocTypeNames.CosmosClientProvider) private readonly cosmosClientProvider: CosmosClientProvider,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(ContextAwareLogger) private readonly logger: ContextAwareLogger,
     ) {}
 
     public async upsertItems<T extends CosmosDocument>(

--- a/packages/azure-services/src/azure-queue/queue.ts
+++ b/packages/azure-services/src/azure-queue/queue.ts
@@ -4,7 +4,7 @@ import { Aborter, MessageIdURL, MessagesURL, Models, QueueURL } from '@azure/sto
 import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import * as _ from 'lodash';
-import { Logger } from 'logger';
+import { ContextAwareLogger, Logger } from 'logger';
 import { iocTypeNames, MessageIdURLProvider, MessagesURLProvider, QueueServiceURLProvider, QueueURLProvider } from '../ioc-types';
 import { Message } from './message';
 
@@ -16,7 +16,7 @@ export class Queue {
         @inject(iocTypeNames.MessagesURLProvider) private readonly messagesURLProvider: MessagesURLProvider,
         @inject(iocTypeNames.MessageIdURLProvider) private readonly messageIdURLProvider: MessageIdURLProvider,
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(ContextAwareLogger) private readonly logger: ContextAwareLogger,
     ) {}
 
     /**

--- a/packages/azure-services/src/register-azure-services-to-container.spec.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.spec.ts
@@ -10,7 +10,7 @@ import { BlobServiceClient } from '@azure/storage-blob';
 import { MessageIdURL, MessagesURL, QueueURL } from '@azure/storage-queue';
 import { Container, interfaces } from 'inversify';
 import * as _ from 'lodash';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { ContextAwareLogger, registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { IMock, Mock, Times } from 'typemoq';
 import { CosmosClientWrapper } from './azure-cosmos/cosmos-client-wrapper';
 import { Queue } from './azure-queue/queue';
@@ -84,6 +84,7 @@ describe(registerAzureServicesToContainer, () => {
     beforeEach(() => {
         container = new Container({ autoBindInjectable: true });
         registerGlobalLoggerToContainer(container);
+        registerContextAwareLoggerToContainer(container);
     });
 
     it('verify singleton resolution', async () => {
@@ -343,6 +344,7 @@ function verifyCosmosContainerClient(container: Container, cosmosContainerType: 
     const cosmosContainerClient = container.get<CosmosContainerClient>(cosmosContainerType);
     expect((cosmosContainerClient as any).dbName).toBe(dbName);
     expect((cosmosContainerClient as any).collectionName).toBe(collectionName);
+    expect((cosmosContainerClient as any).logger).toBe(container.get(ContextAwareLogger));
 }
 
 function runCosmosClientTest(container: Container, secretProviderMock: IMock<SecretProvider>): void {

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -8,7 +8,7 @@ import { BlobServiceClient, StorageSharedKeyCredential as SharedKeyCredentialBlo
 import { MessageIdURL, MessagesURL, QueueURL, ServiceURL, SharedKeyCredential, StorageURL } from '@azure/storage-queue';
 import { IoC } from 'common';
 import { Container, interfaces } from 'inversify';
-import { Logger } from 'logger';
+import { Logger, ContextAwareLogger } from 'logger';
 import { Batch } from './azure-batch/batch';
 import { BatchConfig } from './azure-batch/batch-config';
 import { StorageContainerSASUrlProvider } from './azure-blob/storage-container-sas-url-provider';
@@ -136,7 +136,7 @@ function setupBlobServiceClientProvider(container: interfaces.Container): void {
 }
 
 function createCosmosContainerClient(container: interfaces.Container, dbName: string, collectionName: string): CosmosContainerClient {
-    return new CosmosContainerClient(container.get(CosmosClientWrapper), dbName, collectionName, container.get(Logger));
+    return new CosmosContainerClient(container.get(CosmosClientWrapper), dbName, collectionName, container.get(ContextAwareLogger));
 }
 
 function setupAuthenticationMethod(container: interfaces.Container): void {

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -8,7 +8,7 @@ import { BlobServiceClient, StorageSharedKeyCredential as SharedKeyCredentialBlo
 import { MessageIdURL, MessagesURL, QueueURL, ServiceURL, SharedKeyCredential, StorageURL } from '@azure/storage-queue';
 import { IoC } from 'common';
 import { Container, interfaces } from 'inversify';
-import { Logger, ContextAwareLogger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { Batch } from './azure-batch/batch';
 import { BatchConfig } from './azure-batch/batch-config';
 import { StorageContainerSASUrlProvider } from './azure-blob/storage-container-sas-url-provider';

--- a/packages/functional-tests/src/functional-tests.local.spec.ts
+++ b/packages/functional-tests/src/functional-tests.local.spec.ts
@@ -7,7 +7,7 @@ import { GuidGenerator, ServiceConfiguration, setupRuntimeConfigContainer, Syste
 import * as dotenv from 'dotenv';
 import { Container } from 'inversify';
 import { isEmpty } from 'lodash';
-import { ConsoleLoggerClient, GlobalLogger, Logger } from 'logger';
+import { ConsoleLoggerClient, GlobalLogger } from 'logger';
 import { OnDemandPageScanRunResultProvider, RunState, ScanResultResponse, ScanRunResultResponse } from 'service-library';
 import { A11yServiceClient, A11yServiceCredential } from 'web-api-client';
 
@@ -42,7 +42,7 @@ describe('functional tests', () => {
             const container = getContainer();
             onDemandPageScanRunResultProvider = container.get(OnDemandPageScanRunResultProvider);
             guidGenerator = container.get(GuidGenerator);
-            logger = container.get(Logger);
+            logger = container.get(GlobalLogger);
             testRunner = container.get(TestRunner);
             a11yServiceClient = container.get(A11yServiceClient);
             await logger.setup({
@@ -130,7 +130,7 @@ describe('functional tests', () => {
     function getContainer(): Container {
         const container = new Container({ autoBindInjectable: true });
         setupRuntimeConfigContainer(container);
-        container.bind(Logger).toDynamicValue(_ => {
+        container.bind(GlobalLogger).toDynamicValue(_ => {
             return new GlobalLogger([new ConsoleLoggerClient(container.get(ServiceConfiguration), console)], process);
         });
         registerAzureServicesToContainer(container, CredentialType.AppService);
@@ -141,7 +141,7 @@ describe('functional tests', () => {
                 clientSecret,
                 clientId,
                 `https://login.microsoftonline.com/${tenantId}`,
-                container.get(Logger),
+                container.get(GlobalLogger),
             );
 
             return new A11yServiceClient(cred, `https://apim-${apimName}.azure-api.net`);

--- a/packages/functional-tests/src/runner/test-runner.ts
+++ b/packages/functional-tests/src/runner/test-runner.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { inject, injectable, optional } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { TestContainerLogProperties, TestDefinition, TestEnvironment, TestRunLogProperties } from '../common-types';
 import { getDefinedTestsMetadata } from '../test-decorator';
 
@@ -11,9 +11,9 @@ import { getDefinedTestsMetadata } from '../test-decorator';
 
 @injectable()
 export class TestRunner {
-    public constructor(@optional() @inject(Logger) private logger: Logger) {}
+    public constructor(@optional() @inject(GlobalLogger) private logger: GlobalLogger) {}
 
-    public setLogger(logger: Logger): void {
+    public setLogger(logger: GlobalLogger): void {
         this.logger = logger;
     }
 

--- a/packages/job-manager/src/batch/batch.ts
+++ b/packages/job-manager/src/batch/batch.ts
@@ -6,7 +6,7 @@ import { ServiceConfiguration, System, TaskRuntimeConfig } from 'common';
 import * as crypto from 'crypto';
 import { inject, injectable } from 'inversify';
 import * as _ from 'lodash';
-import { Logger } from 'logger';
+import { GlobalLogger, Logger } from 'logger';
 import * as moment from 'moment';
 import { VError } from 'verror';
 import { BatchConfig } from './batch-config';
@@ -21,7 +21,7 @@ export class Batch {
         @inject(BatchConfig) private readonly config: BatchConfig,
         @inject(RunnerTaskConfig) private readonly runnerTaskConfig: RunnerTaskConfig,
         @inject(AzureServicesIocTypes.BatchServiceClientProvider) private readonly batchClientProvider: BatchServiceClientProvider,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
     ) {}
 
     public async getPoolMetricsInfo(): Promise<PoolMetricsInfo> {

--- a/packages/job-manager/src/job-manager-entry-point.ts
+++ b/packages/job-manager/src/job-manager-entry-point.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Container } from 'inversify';
-import { BaseTelemetryProperties } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { Worker } from './worker/worker';
 
 export class JobManagerEntryPoint extends ProcessEntryPointBase {
     protected async runCustomAction(container: Container): Promise<void> {
+        await container.get(ContextAwareLogger).setup();
+
         const worker = container.get<Worker>(Worker);
         await worker.run();
     }

--- a/packages/job-manager/src/setup-job-manager-container.ts
+++ b/packages/job-manager/src/setup-job-manager-container.ts
@@ -3,7 +3,7 @@
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import { Container } from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { Batch } from './batch/batch';
 import { RunnerTaskConfig } from './batch/runner-task-config';
 
@@ -11,6 +11,7 @@ export function setupJobManagerContainer(): Container {
     const container = new Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
 
     container

--- a/packages/job-manager/src/worker/worker.ts
+++ b/packages/job-manager/src/worker/worker.ts
@@ -3,7 +3,7 @@
 import { Message, PoolMetricsInfo, Queue, StorageConfig } from 'azure-services';
 import { JobManagerConfig, ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import * as moment from 'moment';
 import { Batch } from '../batch/batch';
 import { JobTaskState } from '../batch/job-task';
@@ -23,7 +23,7 @@ export class Worker {
         @inject(PoolLoadGenerator) private readonly poolLoadGenerator: PoolLoadGenerator,
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         private readonly system: typeof System = System,
     ) {}
 

--- a/packages/logger/src/context-aware-app-insights-logger-client.ts
+++ b/packages/logger/src/context-aware-app-insights-logger-client.ts
@@ -5,7 +5,6 @@ import { TelemetryClient } from 'applicationinsights';
 import { inject, injectable } from 'inversify';
 import { AppInsightsLoggerClient } from './app-insights-logger-client';
 import { BaseAppInsightsLoggerClient } from './base-app-insights-logger-client';
-import { LogLevel } from './logger';
 
 @injectable()
 export class ContextAwareAppInsightsLoggerClient extends BaseAppInsightsLoggerClient {

--- a/packages/logger/src/context-aware-logger.ts
+++ b/packages/logger/src/context-aware-logger.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { injectable } from 'inversify';
 import { Logger } from './logger';
 import { LoggerClient } from './logger-client';
 

--- a/packages/logger/src/global-logger.ts
+++ b/packages/logger/src/global-logger.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { injectable } from 'inversify';
 import { BaseTelemetryProperties } from './base-telemetry-properties';
 import { Logger } from './logger';
 import { LoggerClient } from './logger-client';

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 export { Logger, LogLevel } from './logger';
 export { GlobalLogger } from './global-logger';
+export { ContextAwareLogger } from './context-aware-logger';
 export { loggerTypes } from './logger-types';
 export { registerGlobalLoggerToContainer, registerContextAwareLoggerToContainer } from './register-logger-to-container';
 export { BaseTelemetryProperties } from './base-telemetry-properties';

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -112,6 +112,10 @@ export abstract class Logger {
             return;
         }
 
-        throw new Error('The logger instance is not initialized. Ensure the setup() method is invoked by derived class implementation.');
+        throw new Error(
+            `The logger instance is not initialized. Ensure the setup() method is invoked by derived class implementation. - ${
+                new Error().stack
+            }`,
+        );
     }
 }

--- a/packages/logger/src/register-logger-to-container.spec.ts
+++ b/packages/logger/src/register-logger-to-container.spec.ts
@@ -76,15 +76,23 @@ describe(registerContextAwareLoggerToContainer, () => {
         verifyNonSingletonDependencyResolution(ContextAwareConsoleLoggerClient);
     });
 
-    it('verify context logger resolution', () => {
-        registerContextAwareLoggerToContainer(container);
+    describe('context logger', () => {
+        beforeEach(() => {
+            registerContextAwareLoggerToContainer(container);
+        });
 
-        const logger = container.get(Logger);
-        expect(logger instanceof ContextAwareLogger).toBeTruthy();
+        it('verify context logger resolution', () => {
+            const logger = container.get(Logger);
+            expect(logger instanceof ContextAwareLogger).toBeTruthy();
 
-        const telemetryClients = (logger as any).loggerClients as LoggerClient[];
-        expect(telemetryClients.filter(c => c instanceof ContextAwareAppInsightsLoggerClient)).toHaveLength(1);
-        expect(telemetryClients.filter(c => c instanceof ContextAwareConsoleLoggerClient)).toHaveLength(1);
+            const telemetryClients = (logger as any).loggerClients as LoggerClient[];
+            expect(telemetryClients.filter(c => c instanceof ContextAwareAppInsightsLoggerClient)).toHaveLength(1);
+            expect(telemetryClients.filter(c => c instanceof ContextAwareConsoleLoggerClient)).toHaveLength(1);
+        });
+
+        it('verify singleton resolution', () => {
+            verifySingletonDependencyResolution(Logger);
+        });
     });
 });
 

--- a/packages/logger/src/register-logger-to-container.ts
+++ b/packages/logger/src/register-logger-to-container.ts
@@ -32,12 +32,15 @@ export function registerContextAwareLoggerToContainer(container: Container): voi
         registerLoggerDependenciesToContainer(container);
     }
 
-    container.bind(Logger).toDynamicValue(context => {
-        const appInsightsLoggerClient = context.container.get(ContextAwareAppInsightsLoggerClient);
-        const consoleLoggerClient = context.container.get(ContextAwareConsoleLoggerClient);
+    container
+        .bind(Logger)
+        .toDynamicValue(context => {
+            const appInsightsLoggerClient = context.container.get(ContextAwareAppInsightsLoggerClient);
+            const consoleLoggerClient = context.container.get(ContextAwareConsoleLoggerClient);
 
-        return new ContextAwareLogger([appInsightsLoggerClient, consoleLoggerClient], context.container.get(loggerTypes.Process));
-    });
+            return new ContextAwareLogger([appInsightsLoggerClient, consoleLoggerClient], context.container.get(loggerTypes.Process));
+        })
+        .inSingletonScope();
 }
 
 function registerLoggerDependenciesToContainer(container: Container): void {

--- a/packages/logger/src/register-logger-to-container.ts
+++ b/packages/logger/src/register-logger-to-container.ts
@@ -10,14 +10,13 @@ import { ContextAwareAppInsightsLoggerClient } from './context-aware-app-insight
 import { ContextAwareConsoleLoggerClient } from './context-aware-console-logger-client';
 import { ContextAwareLogger } from './context-aware-logger';
 import { GlobalLogger } from './global-logger';
-import { Logger } from './logger';
 import { loggerTypes } from './logger-types';
 
 export function registerGlobalLoggerToContainer(container: Container): void {
     registerLoggerDependenciesToContainer(container);
 
     container
-        .bind(Logger)
+        .bind(GlobalLogger)
         .toDynamicValue(context => {
             const appInsightsLoggerClient = context.container.get(AppInsightsLoggerClient);
             const consoleLoggerClient = context.container.get(ConsoleLoggerClient);
@@ -28,12 +27,17 @@ export function registerGlobalLoggerToContainer(container: Container): void {
 }
 
 export function registerContextAwareLoggerToContainer(container: Container): void {
-    if (!container.isBound(Logger)) {
-        registerLoggerDependenciesToContainer(container);
-    }
+    container
+        .bind(ContextAwareAppInsightsLoggerClient)
+        .toSelf()
+        .inSingletonScope();
+    container
+        .bind(ContextAwareConsoleLoggerClient)
+        .toSelf()
+        .inSingletonScope();
 
     container
-        .bind(Logger)
+        .bind(ContextAwareLogger)
         .toDynamicValue(context => {
             const appInsightsLoggerClient = context.container.get(ContextAwareAppInsightsLoggerClient);
             const consoleLoggerClient = context.container.get(ContextAwareConsoleLoggerClient);

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
-import { Logger, loggerTypes, GlobalLogger } from 'logger';
+import { GlobalLogger, Logger, loggerTypes } from 'logger';
 import * as node_url from 'url';
 import { JSONLineExporter } from './hc-crawler';
 import {

--- a/packages/runner/src/crawler/hc-crawler-options-factory.ts
+++ b/packages/runner/src/crawler/hc-crawler-options-factory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
-import { Logger, loggerTypes } from 'logger';
+import { Logger, loggerTypes, GlobalLogger } from 'logger';
 import * as node_url from 'url';
 import { JSONLineExporter } from './hc-crawler';
 import {
@@ -16,7 +16,7 @@ import {
 @injectable()
 export class HCCrawlerOptionsFactory {
     constructor(
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
     ) {}
 

--- a/packages/runner/src/runner-entry-point.ts
+++ b/packages/runner/src/runner-entry-point.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Container } from 'inversify';
-import { BaseTelemetryProperties } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { Runner } from './runner/runner';
 
@@ -11,6 +11,8 @@ export class RunnerEntryPoint extends ProcessEntryPointBase {
     }
 
     protected async runCustomAction(container: Container): Promise<void> {
+        await container.get(ContextAwareLogger).setup();
+
         const runner = container.get<Runner>(Runner);
         await runner.run();
     }

--- a/packages/runner/src/runner/runner.ts
+++ b/packages/runner/src/runner/runner.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { Browser } from 'puppeteer';
 import { ScanMetadataConfig } from '../scan-metadata-config';
 import { CrawlerTask } from '../tasks/crawler-task';
@@ -23,7 +23,7 @@ export class Runner {
         @inject(StorageTask) private readonly storageTask: StorageTask,
         @inject(ScanMetadataConfig) private readonly scanMetadataConfig: ScanMetadataConfig,
         @inject(PageStateUpdaterTask) private readonly pageStateUpdaterTask: PageStateUpdaterTask,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
     ) {}
 
     public async run(): Promise<void> {

--- a/packages/runner/src/setup-runner-container.ts
+++ b/packages/runner/src/setup-runner-container.ts
@@ -3,7 +3,7 @@
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { registerScannerToContainer } from 'scanner';
 import { registerServiceLibraryToContainer } from 'service-library';
 
@@ -11,6 +11,7 @@ export function setupRunnerContainer(): inversify.Container {
     const container = new inversify.Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
     registerScannerToContainer(container);
     registerServiceLibraryToContainer(container);

--- a/packages/runner/src/tasks/crawler-task.ts
+++ b/packages/runner/src/tasks/crawler-task.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { Browser } from 'puppeteer';
 import { CrawlerScanResults } from '../crawler/crawler-scan-results';
 import { HCCrawler, HCCrawlerTyped } from '../crawler/hc-crawler';
@@ -9,16 +9,16 @@ import { HCCrawlerOptionsFactory } from '../crawler/hc-crawler-options-factory';
 import { CrawlerConnectOptions } from '../crawler/hc-crawler-types';
 import { LinkExplorer } from '../crawler/link-explorer';
 
-export type LinkExplorerFactory = (crawler: HCCrawlerTyped, connectOptions: CrawlerConnectOptions, logger: Logger) => LinkExplorer;
+export type LinkExplorerFactory = (crawler: HCCrawlerTyped, connectOptions: CrawlerConnectOptions, logger: GlobalLogger) => LinkExplorer;
 
-const linkExplorerFactoryImpl = (crawler: HCCrawlerTyped, connectOptions: CrawlerConnectOptions, logger: Logger): LinkExplorer =>
+const linkExplorerFactoryImpl = (crawler: HCCrawlerTyped, connectOptions: CrawlerConnectOptions, logger: GlobalLogger): LinkExplorer =>
     new LinkExplorer(crawler, connectOptions, logger);
 
 @injectable()
 export class CrawlerTask {
     constructor(
         @inject(HCCrawlerOptionsFactory) private readonly hcCrawlerOptionsFactory: HCCrawlerOptionsFactory,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         private readonly linkExplorerFactory: LinkExplorerFactory = linkExplorerFactoryImpl,
     ) {}
 

--- a/packages/runner/src/tasks/website-state-updater-task.ts
+++ b/packages/runner/src/tasks/website-state-updater-task.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { CosmosContainerClient, cosmosContainerClientTypes, RetryOptions } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { PageScanResult, Website } from 'storage-documents';
 import { VError } from 'verror';
 import { WebsiteFactory } from '../factories/website-factory';
@@ -14,7 +14,7 @@ export class WebsiteStateUpdaterTask {
     constructor(
         @inject(cosmosContainerClientTypes.A11yIssuesCosmosContainerClient) private readonly cosmosContainerClient: CosmosContainerClient,
         @inject(WebsiteFactory) private readonly websiteFactory: WebsiteFactory,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         private readonly retryOptions: RetryOptions = {
             timeoutMilliseconds: 15000,
             intervalMilliseconds: 500,

--- a/packages/scan-request-sender/src/scan-request-entry-point.ts
+++ b/packages/scan-request-sender/src/scan-request-entry-point.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Container } from 'inversify';
-import { BaseTelemetryProperties, Logger } from 'logger';
+import { BaseTelemetryProperties, Logger, GlobalLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { Dispatcher } from './sender/dispatcher';
 
@@ -12,7 +12,7 @@ export class ScanRequestEntryPoint extends ProcessEntryPointBase {
 
     protected async runCustomAction(container: Container): Promise<void> {
         const dispatcher = container.get(Dispatcher);
-        const logger = container.get(Logger);
+        const logger = container.get(GlobalLogger);
         await dispatcher.dispatchScanRequests();
         logger.logInfo(`[Sender] Scan requests sent successfully`);
     }

--- a/packages/scan-request-sender/src/scan-request-entry-point.ts
+++ b/packages/scan-request-sender/src/scan-request-entry-point.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Container } from 'inversify';
-import { BaseTelemetryProperties, ContextAwareLogger, GlobalLogger, Logger } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger, GlobalLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { Dispatcher } from './sender/dispatcher';
 

--- a/packages/scan-request-sender/src/scan-request-entry-point.ts
+++ b/packages/scan-request-sender/src/scan-request-entry-point.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Container } from 'inversify';
-import { BaseTelemetryProperties, Logger, GlobalLogger } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger, GlobalLogger, Logger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { Dispatcher } from './sender/dispatcher';
 
@@ -11,6 +11,8 @@ export class ScanRequestEntryPoint extends ProcessEntryPointBase {
     }
 
     protected async runCustomAction(container: Container): Promise<void> {
+        await container.get(ContextAwareLogger).setup();
+
         const dispatcher = container.get(Dispatcher);
         const logger = container.get(GlobalLogger);
         await dispatcher.dispatchScanRequests();

--- a/packages/scan-request-sender/src/sender/dispatcher.ts
+++ b/packages/scan-request-sender/src/sender/dispatcher.ts
@@ -3,7 +3,7 @@
 import { client, CosmosOperationResponse } from 'azure-services';
 import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { PageDocumentProvider } from 'service-library';
 import { WebsitePage } from 'storage-documents';
 import { ScanRequestSender } from './scan-request-sender';
@@ -12,7 +12,7 @@ import { ScanRequestSender } from './scan-request-sender';
 export class Dispatcher {
     constructor(
         @inject(PageDocumentProvider) private readonly pageDocumentProvider: PageDocumentProvider,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(ScanRequestSender) private readonly sender: ScanRequestSender,
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
     ) {}

--- a/packages/scan-request-sender/src/setup-scan-request-sender-container.ts
+++ b/packages/scan-request-sender/src/setup-scan-request-sender-container.ts
@@ -3,12 +3,13 @@
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 
 export function setupScanRequestSenderContainer(): inversify.Container {
     const container = new inversify.Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
 
     return container;

--- a/packages/scan-request-sender/src/source/seed-source.ts
+++ b/packages/scan-request-sender/src/source/seed-source.ts
@@ -3,14 +3,14 @@
 // tslint:disable: no-unsafe-any
 import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { ScanRequest, WebSite } from '../request-type/website';
 
 @injectable()
 export class SeedSource {
     constructor(
         @inject(cosmosContainerClientTypes.A11yIssuesCosmosContainerClient) private readonly cosmosContainerClient: CosmosContainerClient,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
     ) {}
 
     public async getWebSites(): Promise<WebSite[]> {

--- a/packages/scanner/src/page.ts
+++ b/packages/scanner/src/page.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { AxePuppeteer } from 'axe-puppeteer';
 import { inject, injectable } from 'inversify';
-import { Logger, LogLevel } from 'logger';
+import { GlobalLogger, LogLevel } from 'logger';
 import * as Puppeteer from 'puppeteer';
 import { AxeScanResults, ScanError, ScanErrorTypes } from './axe-scan-results';
 import { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';
@@ -17,7 +17,7 @@ export class Page {
     constructor(
         @inject('Factory<Browser>') private readonly browserFactory: PuppeteerBrowserFactory,
         @inject(AxePuppeteerFactory) private readonly axePuppeteerFactory: AxePuppeteerFactory,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
     ) {}
 
     public async create(): Promise<void> {

--- a/packages/scanner/src/register-scanner-to-container.spec.ts
+++ b/packages/scanner/src/register-scanner-to-container.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { Container } from 'inversify';
 
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { IMock, Mock } from 'typemoq';
 import { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';
 import { registerScannerToContainer } from './register-scanner-to-container';
@@ -21,7 +21,7 @@ describe(registerScannerToContainer, () => {
         container = new Container({ autoBindInjectable: true });
         loggerMock = Mock.ofType(MockableLogger);
 
-        container.bind(Logger).toConstantValue(loggerMock.object);
+        container.bind(GlobalLogger).toConstantValue(loggerMock.object);
     });
 
     it('should verify scanner resolution', () => {

--- a/packages/scanner/src/register-scanner-to-container.ts
+++ b/packages/scanner/src/register-scanner-to-container.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as inversify from 'inversify';
+import { GlobalLogger, Logger } from 'logger';
 import { Browser } from 'puppeteer';
 import { WebDriver } from 'service-library';
 import { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';

--- a/packages/scanner/src/register-scanner-to-container.ts
+++ b/packages/scanner/src/register-scanner-to-container.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as inversify from 'inversify';
-import { GlobalLogger, Logger } from 'logger';
 import { Browser } from 'puppeteer';
 import { WebDriver } from 'service-library';
 import { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';

--- a/packages/scanner/src/scanner.ts
+++ b/packages/scanner/src/scanner.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { PromiseUtils, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import * as util from 'util';
 import { AxeScanResults } from './axe-scan-results';
 import { Page } from './page';
@@ -11,7 +11,7 @@ import { Page } from './page';
 export class Scanner {
     constructor(
         @inject(Page) private readonly page: Page,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(PromiseUtils)
         private readonly promiseUtils: PromiseUtils,
         @inject(ServiceConfiguration)

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -4,7 +4,7 @@
 import { Batch, BatchConfig, JobTask, JobTaskState, Message, PoolMetricsInfo, Queue, StorageConfig } from 'azure-services';
 import { JobManagerConfig, ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import * as moment from 'moment';
 
 @injectable()
@@ -18,7 +18,7 @@ export abstract class BatchTaskCreator {
         @inject(Queue) protected readonly queue: Queue,
         @inject(BatchConfig) protected readonly batchConfig: BatchConfig,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) protected readonly logger: Logger,
+        @inject(GlobalLogger) protected readonly logger: GlobalLogger,
         protected readonly system: typeof System = System,
     ) {}
 

--- a/packages/service-library/src/process-entry-point-base.spec.ts
+++ b/packages/service-library/src/process-entry-point-base.spec.ts
@@ -6,7 +6,7 @@ import { ServiceConfiguration, TaskRuntimeConfig } from 'common';
 import { DotenvConfigOutput } from 'dotenv';
 import { Container } from 'inversify';
 import * as _ from 'lodash';
-import { BaseTelemetryProperties, Logger, loggerTypes } from 'logger';
+import { BaseTelemetryProperties, GlobalLogger, loggerTypes } from 'logger';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { ProcessEntryPointBase } from './process-entry-point-base';
 import { MockableLogger } from './test-utilities/mockable-logger';
@@ -256,7 +256,7 @@ describe(ProcessEntryPointBase, () => {
 
     function setupContainerForLogger(): void {
         containerMock
-            .setup(c => c.get(Logger))
+            .setup(c => c.get(GlobalLogger))
             .returns(() => loggerMock.object)
             .verifiable();
     }

--- a/packages/service-library/src/process-entry-point-base.ts
+++ b/packages/service-library/src/process-entry-point-base.ts
@@ -4,7 +4,7 @@ import { ServiceConfiguration, TaskRuntimeConfig } from 'common';
 import { DotenvConfigOutput } from 'dotenv';
 import { Container } from 'inversify';
 import { isNil } from 'lodash';
-import { BaseTelemetryProperties, GlobalLogger, Logger, loggerTypes } from 'logger';
+import { BaseTelemetryProperties, GlobalLogger, loggerTypes } from 'logger';
 
 // tslint:disable: no-any
 
@@ -63,7 +63,7 @@ export abstract class ProcessEntryPointBase {
 
     protected abstract async runCustomAction(container: Container, ...args: any[]): Promise<void>;
 
-    private async invokeCustomActionWithLogging(container: Container, logger: Logger, ...args: any[]): Promise<void> {
+    private async invokeCustomActionWithLogging(container: Container, logger: GlobalLogger, ...args: any[]): Promise<void> {
         try {
             await this.runCustomAction(container, ...args);
         } catch (error) {
@@ -72,7 +72,7 @@ export abstract class ProcessEntryPointBase {
         }
     }
 
-    private verifyDotEnvParsing(dotEnvConfig: DotenvConfigOutput, logger: Logger): void {
+    private verifyDotEnvParsing(dotEnvConfig: DotenvConfigOutput, logger: GlobalLogger): void {
         if (dotEnvConfig.parsed !== undefined) {
             logger.logInfo('[ProcessEntryPointBase] Config based environment variables:');
             logger.logInfo(`[ProcessEntryPointBase] ${JSON.stringify(dotEnvConfig.parsed, undefined, 2)}`);

--- a/packages/service-library/src/process-entry-point-base.ts
+++ b/packages/service-library/src/process-entry-point-base.ts
@@ -4,7 +4,7 @@ import { ServiceConfiguration, TaskRuntimeConfig } from 'common';
 import { DotenvConfigOutput } from 'dotenv';
 import { Container } from 'inversify';
 import { isNil } from 'lodash';
-import { BaseTelemetryProperties, Logger, loggerTypes } from 'logger';
+import { BaseTelemetryProperties, GlobalLogger, Logger, loggerTypes } from 'logger';
 
 // tslint:disable: no-any
 
@@ -13,7 +13,7 @@ export abstract class ProcessEntryPointBase {
 
     public async start(...args: any[]): Promise<void> {
         let loggerInitialized = false;
-        let logger: Logger;
+        let logger: GlobalLogger;
         let processExitCode = 0;
         const processObj = this.container.get<typeof process>(loggerTypes.Process);
         let taskConfig: TaskRuntimeConfig;
@@ -22,7 +22,7 @@ export abstract class ProcessEntryPointBase {
             const dotEnvConfig: DotenvConfigOutput = this.container.get(loggerTypes.DotEnvConfig);
             const serviceConfig: ServiceConfiguration = this.container.get(ServiceConfiguration);
             taskConfig = await serviceConfig.getConfigValue('taskConfig');
-            logger = this.container.get(Logger);
+            logger = this.container.get(GlobalLogger);
 
             await logger.setup(this.getTelemetryBaseProperties());
             loggerInitialized = true;

--- a/packages/service-library/src/register-service-library-to-container.spec.ts
+++ b/packages/service-library/src/register-service-library-to-container.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { Container } from 'inversify';
 
-import { Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { IMock, Mock } from 'typemoq';
 import { registerServiceLibraryToContainer } from './register-service-library-to-container';
 import { MockableLogger } from './test-utilities/mockable-logger';
@@ -20,7 +20,7 @@ describe(registerServiceLibraryToContainer, () => {
         container = new Container({ autoBindInjectable: true });
         loggerMock = Mock.ofType(MockableLogger);
 
-        container.bind(Logger).toConstantValue(loggerMock.object);
+        container.bind(GlobalLogger).toConstantValue(loggerMock.object);
     });
 
     it('should verify singleton resolution', () => {

--- a/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { Context } from '@azure/functions';
 import { Container } from 'inversify';
-import { Logger, loggerTypes, ContextAwareLogger } from 'logger';
+import { ContextAwareLogger, Logger, loggerTypes } from 'logger';
 import { IMock, Mock, Times } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 import { WebController } from './web-controller';

--- a/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { Context } from '@azure/functions';
 import { Container } from 'inversify';
-import { Logger, loggerTypes } from 'logger';
+import { Logger, loggerTypes, ContextAwareLogger } from 'logger';
 import { IMock, Mock, Times } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 import { WebController } from './web-controller';
@@ -56,7 +56,7 @@ describe(WebControllerDispatcher, () => {
         processLifeCycleContainerMock = Mock.ofType(Container);
 
         containerMock.setup(c => c.get(TestableWebController)).returns(() => testableWebController);
-        containerMock.setup(c => c.get(Logger)).returns(() => loggerMock.object);
+        containerMock.setup(c => c.get(ContextAwareLogger)).returns(() => loggerMock.object);
     });
 
     afterEach(() => {

--- a/packages/service-library/src/web-api/web-controller-dispatcher.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { Context } from '@azure/functions';
 import { Container } from 'inversify';
-import { BaseTelemetryProperties, Logger, loggerTypes } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger, Logger, loggerTypes } from 'logger';
 import { ProcessEntryPointBase } from '../process-entry-point-base';
 import { Newable } from './web-api-ioc-types';
 import { WebController } from './web-controller';
@@ -18,7 +18,7 @@ export class WebControllerDispatcher extends ProcessEntryPointBase {
         context: Context,
         ...args: unknown[]
     ): Promise<unknown> {
-        const logger = container.get(Logger);
+        const logger = container.get(ContextAwareLogger);
         await logger.setup();
 
         const controller = container.get(controllerType) as WebController;

--- a/packages/service-library/src/web-api/web-controller.ts
+++ b/packages/service-library/src/web-api/web-controller.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { Context } from '@azure/functions';
 import { inject, injectable } from 'inversify';
-import { ContextAwareLogger, Logger } from 'logger';
-import { ResultLevel } from 'storage-documents';
+import { ContextAwareLogger } from 'logger';
 
 // tslint:disable: no-any no-unsafe-any
 
@@ -13,7 +12,7 @@ export abstract class WebController {
     public abstract readonly apiName: string;
     public context: Context;
 
-    constructor(@inject(ContextAwareLogger) protected readonly logger: Logger) {}
+    constructor(@inject(ContextAwareLogger) protected readonly logger: ContextAwareLogger) {}
 
     public async invoke(requestContext: Context, ...args: any[]): Promise<unknown> {
         this.context = requestContext;

--- a/packages/service-library/src/web-api/web-controller.ts
+++ b/packages/service-library/src/web-api/web-controller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { Context } from '@azure/functions';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger, Logger } from 'logger';
 import { ResultLevel } from 'storage-documents';
 
 // tslint:disable: no-any no-unsafe-any
@@ -13,7 +13,7 @@ export abstract class WebController {
     public abstract readonly apiName: string;
     public context: Context;
 
-    constructor(@inject(Logger) protected readonly logger: Logger) {}
+    constructor(@inject(ContextAwareLogger) protected readonly logger: Logger) {}
 
     public async invoke(requestContext: Context, ...args: any[]): Promise<unknown> {
         this.context = requestContext;

--- a/packages/service-library/src/web-driver/web-driver.ts
+++ b/packages/service-library/src/web-driver/web-driver.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger, Logger } from 'logger';
 import * as Puppeteer from 'puppeteer';
 
 @injectable()
 export class WebDriver {
     public browser: Puppeteer.Browser;
 
-    constructor(@inject(Logger) private readonly logger: Logger, private readonly puppeteer: typeof Puppeteer = Puppeteer) {}
+    constructor(@inject(GlobalLogger) private readonly logger: Logger, private readonly puppeteer: typeof Puppeteer = Puppeteer) {}
 
     public async launch(): Promise<Puppeteer.Browser> {
         this.browser = await this.puppeteer.launch({

--- a/packages/web-api-scan-job-manager/src/setup-web-api-scan-job-manager-container.ts
+++ b/packages/web-api-scan-job-manager/src/setup-web-api-scan-job-manager-container.ts
@@ -8,13 +8,14 @@ import {
 } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import { Container } from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { ScannerBatchTaskPropertyProvider } from './batch/scanner-batch-task-property-provider';
 
 export function setupWebApiScanJobManagerContainer(): Container {
     const container = new Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
 
     container

--- a/packages/web-api-scan-job-manager/src/web-api-scan-job-manager-entry-point.ts
+++ b/packages/web-api-scan-job-manager/src/web-api-scan-job-manager-entry-point.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Container } from 'inversify';
-import { BaseTelemetryProperties } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { Worker } from './worker/worker';
 
@@ -12,6 +12,9 @@ export class WebApiScanJobManagerEntryPoint extends ProcessEntryPointBase {
     }
 
     protected async runCustomAction(container: Container): Promise<void> {
+        const logger = container.get(ContextAwareLogger);
+        await logger.setup();
+
         const worker = container.get<Worker>(Worker);
         await worker.init();
         await worker.run();

--- a/packages/web-api-scan-job-manager/src/worker/worker.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.ts
@@ -4,7 +4,7 @@ import { Batch, BatchConfig, JobTask, Message, PoolLoadGenerator, PoolLoadSnapsh
 import { ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
 import { isNil, mergeWith } from 'lodash';
-import { Logger } from 'logger';
+import { GlobalLogger, Logger } from 'logger';
 import { BatchPoolLoadSnapshotProvider, BatchTaskCreator, OnDemandPageScanRunResultProvider } from 'service-library';
 import { OnDemandPageScanResult, StorageDocument } from 'storage-documents';
 
@@ -30,7 +30,7 @@ export class Worker extends BatchTaskCreator {
         @inject(BatchConfig) batchConfig: BatchConfig,
         @inject(ServiceConfiguration) serviceConfig: ServiceConfiguration,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
-        @inject(Logger) logger: Logger,
+        @inject(GlobalLogger) logger: GlobalLogger,
         system: typeof System = System,
     ) {
         super(batch, queue, batchConfig, serviceConfig, logger, system);

--- a/packages/web-api-scan-job-manager/src/worker/worker.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.ts
@@ -4,7 +4,7 @@ import { Batch, BatchConfig, JobTask, Message, PoolLoadGenerator, PoolLoadSnapsh
 import { ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
 import { isNil, mergeWith } from 'lodash';
-import { GlobalLogger, Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { BatchPoolLoadSnapshotProvider, BatchTaskCreator, OnDemandPageScanRunResultProvider } from 'service-library';
 import { OnDemandPageScanResult, StorageDocument } from 'storage-documents';
 

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -3,7 +3,7 @@
 import { client, CosmosOperationResponse } from 'azure-services';
 import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger, Logger } from 'logger';
 import { PageScanRequestProvider } from 'service-library';
 import { OnDemandPageScanRequest } from 'storage-documents';
 import { OnDemandScanRequestSender } from './on-demand-scan-request-sender';
@@ -12,7 +12,7 @@ import { OnDemandScanRequestSender } from './on-demand-scan-request-sender';
 export class OnDemandDispatcher {
     constructor(
         @inject(PageScanRequestProvider) private readonly pageScanRequestProvider: PageScanRequestProvider,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(ContextAwareLogger) private readonly logger: ContextAwareLogger,
         @inject(OnDemandScanRequestSender) private readonly sender: OnDemandScanRequestSender,
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
     ) {}

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -3,7 +3,7 @@
 import { client, CosmosOperationResponse } from 'azure-services';
 import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { ContextAwareLogger, Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { PageScanRequestProvider } from 'service-library';
 import { OnDemandPageScanRequest } from 'storage-documents';
 import { OnDemandScanRequestSender } from './on-demand-scan-request-sender';

--- a/packages/web-api-scan-request-sender/src/setup-web-api-scan-request-sender-container.ts
+++ b/packages/web-api-scan-request-sender/src/setup-web-api-scan-request-sender-container.ts
@@ -4,12 +4,13 @@
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 
 export function setupWebApiScanRequestSenderContainer(): inversify.Container {
     const container = new inversify.Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
 
     return container;

--- a/packages/web-api-scan-request-sender/src/web-api-scan-request-sender-entry-point.ts
+++ b/packages/web-api-scan-request-sender/src/web-api-scan-request-sender-entry-point.ts
@@ -12,9 +12,12 @@ export class WebApiScanRequestSenderEntryPoint extends ProcessEntryPointBase {
     }
 
     protected async runCustomAction(container: Container): Promise<void> {
-        const dispatcher = container.get(OnDemandDispatcher);
         const logger = container.get(ContextAwareLogger);
+        await logger.setup();
+
+        const dispatcher = container.get(OnDemandDispatcher);
         await dispatcher.dispatchOnDemandScanRequests();
+
         logger.logInfo(`[Sender] Scan requests sent successfully`);
     }
 }

--- a/packages/web-api-scan-request-sender/src/web-api-scan-request-sender-entry-point.ts
+++ b/packages/web-api-scan-request-sender/src/web-api-scan-request-sender-entry-point.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Container } from 'inversify';
-import { BaseTelemetryProperties, Logger } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { OnDemandDispatcher } from './sender/on-demand-dispatcher';
 
@@ -13,7 +13,7 @@ export class WebApiScanRequestSenderEntryPoint extends ProcessEntryPointBase {
 
     protected async runCustomAction(container: Container): Promise<void> {
         const dispatcher = container.get(OnDemandDispatcher);
-        const logger = container.get(Logger);
+        const logger = container.get(ContextAwareLogger);
         await dispatcher.dispatchOnDemandScanRequests();
         logger.logInfo(`[Sender] Scan requests sent successfully`);
     }

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -3,7 +3,7 @@
 import { FeatureFlags, GuidGenerator, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty, isNil } from 'lodash';
-import { Logger, ScanTaskCompletedMeasurements } from 'logger';
+import { GlobalLogger, ScanTaskCompletedMeasurements } from 'logger';
 import { Browser } from 'puppeteer';
 import { AxeScanResults } from 'scanner';
 import { OnDemandPageScanRunResultProvider, PageScanRunReportService } from 'service-library';
@@ -33,7 +33,7 @@ export class Runner {
         @inject(ScannerTask) private readonly scannerTask: ScannerTask,
         @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
         @inject(WebDriverTask) private readonly webDriverTask: WebDriverTask,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(PageScanRunReportService) private readonly pageScanRunReportService: PageScanRunReportService,
         @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,

--- a/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
+++ b/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
@@ -3,7 +3,7 @@
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
-import { GlobalLogger, Logger, registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { registerScannerToContainer } from 'scanner';
 import { registerServiceLibraryToContainer } from 'service-library';
 import { registerReportGeneratorToContainer } from './report-generator/register-report-generator-to-container';

--- a/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
+++ b/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
@@ -3,7 +3,7 @@
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { GlobalLogger, Logger, registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { registerScannerToContainer } from 'scanner';
 import { registerServiceLibraryToContainer } from 'service-library';
 import { registerReportGeneratorToContainer } from './report-generator/register-report-generator-to-container';
@@ -12,6 +12,7 @@ export function setupWebApiScanRequestSenderContainer(): inversify.Container {
     const container = new inversify.Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
     registerScannerToContainer(container);
     registerServiceLibraryToContainer(container);

--- a/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.ts
+++ b/packages/web-api-scan-runner/src/tasks/notification-queue-message-sender.ts
@@ -3,7 +3,7 @@
 import { Queue, StorageConfig } from 'azure-services';
 import { ScanRunTimeConfig, ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger, loggerTypes } from 'logger';
+import { GlobalLogger, Logger, loggerTypes } from 'logger';
 import { OnDemandPageScanRunResultProvider } from 'service-library';
 import {
     NotificationError,
@@ -22,7 +22,7 @@ export class NotificationQueueMessageSender {
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
         @inject(Queue) private readonly queue: Queue,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
         private readonly system: typeof System = System,
     ) {}

--- a/packages/web-api-scan-runner/src/web-api-scan-runner-entry-point.ts
+++ b/packages/web-api-scan-runner/src/web-api-scan-runner-entry-point.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Container } from 'inversify';
-import { BaseTelemetryProperties } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { Runner } from './runner/runner';
 
@@ -12,6 +12,9 @@ export class WebApiScanRunnerEntryPoint extends ProcessEntryPointBase {
     }
 
     protected async runCustomAction(container: Container): Promise<void> {
+        const logger = container.get(ContextAwareLogger);
+        await logger.setup();
+
         const runner = container.get<Runner>(Runner);
         await runner.run();
     }

--- a/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.ts
+++ b/packages/web-api-send-notification-job-manager/src/setup-send-notification-job-manager-container.ts
@@ -3,13 +3,14 @@
 import { BatchTaskPropertyProvider, registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import { Container } from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { SendNotificationTaskPropertyProvider } from './task/send-notification-task-property-provider';
 
 export function setupSendNotificationJobManagerContainer(): Container {
     const container = new Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
 
     container

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
@@ -4,7 +4,7 @@
 import { Batch, BatchConfig, JobTask, Message, Queue, StorageConfig } from 'azure-services';
 import { ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
-import { GlobalLogger, Logger } from 'logger';
+import { GlobalLogger } from 'logger';
 import { BatchTaskCreator } from 'service-library';
 
 @injectable()
@@ -15,7 +15,7 @@ export class SendNotificationTaskCreator extends BatchTaskCreator {
         @inject(BatchConfig) batchConfig: BatchConfig,
         @inject(ServiceConfiguration) serviceConfig: ServiceConfiguration,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
-        @inject(GlobalLogger) logger: Logger,
+        @inject(GlobalLogger) logger: GlobalLogger,
         system: typeof System = System,
     ) {
         super(batch, queue, batchConfig, serviceConfig, logger, system);

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.ts
@@ -4,7 +4,7 @@
 import { Batch, BatchConfig, JobTask, Message, Queue, StorageConfig } from 'azure-services';
 import { ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { GlobalLogger, Logger } from 'logger';
 import { BatchTaskCreator } from 'service-library';
 
 @injectable()
@@ -15,7 +15,7 @@ export class SendNotificationTaskCreator extends BatchTaskCreator {
         @inject(BatchConfig) batchConfig: BatchConfig,
         @inject(ServiceConfiguration) serviceConfig: ServiceConfiguration,
         @inject(StorageConfig) private readonly storageConfig: StorageConfig,
-        @inject(Logger) logger: Logger,
+        @inject(GlobalLogger) logger: Logger,
         system: typeof System = System,
     ) {
         super(batch, queue, batchConfig, serviceConfig, logger, system);

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { ScanRunTimeConfig, ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger, loggerTypes } from 'logger';
+import { GlobalLogger, loggerTypes } from 'logger';
 import { OnDemandPageScanRunResultProvider } from 'service-library';
 import { NotificationError, NotificationState, OnDemandPageScanResult, ScanCompletedNotification } from 'storage-documents';
 import { NotificationSenderConfig } from '../notification-sender-config';
@@ -17,7 +17,7 @@ export class NotificationSender {
         @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
         @inject(NotificationSenderWebAPIClient) private readonly notificationSenderWebAPIClient: NotificationSenderWebAPIClient,
         @inject(NotificationSenderConfig) private readonly notificationSenderConfig: NotificationSenderConfig,
-        @inject(Logger) private readonly logger: Logger,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
         private readonly system: typeof System = System,

--- a/packages/web-api-send-notification-runner/src/setup-web-api-notification-sender-container.ts
+++ b/packages/web-api-send-notification-runner/src/setup-web-api-notification-sender-container.ts
@@ -3,13 +3,14 @@
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
-import { registerGlobalLoggerToContainer } from 'logger';
+import { registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { registerServiceLibraryToContainer } from 'service-library';
 
 export function setupWebApiNotificationSenderContainer(): inversify.Container {
     const container = new inversify.Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerGlobalLoggerToContainer(container);
+    registerContextAwareLoggerToContainer(container);
     registerAzureServicesToContainer(container);
     registerServiceLibraryToContainer(container);
 

--- a/packages/web-api-send-notification-runner/src/web-api-notification-sender-entry-point.ts
+++ b/packages/web-api-send-notification-runner/src/web-api-notification-sender-entry-point.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Container } from 'inversify';
-import { BaseTelemetryProperties } from 'logger';
+import { BaseTelemetryProperties, ContextAwareLogger } from 'logger';
 import { ProcessEntryPointBase } from 'service-library';
 import { NotificationSender } from './sender/notification-sender';
 
@@ -12,6 +12,9 @@ export class WebApiNotificationSenderEntryPoint extends ProcessEntryPointBase {
     }
 
     protected async runCustomAction(container: Container): Promise<void> {
+        const logger = container.get(ContextAwareLogger);
+        await logger.setup();
+
         const sender = container.get<NotificationSender>(NotificationSender);
         await sender.sendNotification();
     }

--- a/packages/web-api/src/controllers/batch-scan-result-controller.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.ts
@@ -3,7 +3,7 @@
 import { GuidGenerator, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
-import { Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { OnDemandPageScanRunResultProvider, ScanBatchRequest, ScanResultResponse, WebApiErrorCodes } from 'service-library';
 
 import { ScanResponseConverter } from '../converters/scan-response-converter';
@@ -19,7 +19,7 @@ export class BatchScanResultController extends BaseScanResultController {
         @inject(ScanResponseConverter) protected readonly scanResponseConverter: ScanResponseConverter,
         @inject(GuidGenerator) protected readonly guidGenerator: GuidGenerator,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
     ) {
         super(logger);
     }

--- a/packages/web-api/src/controllers/health-check-controller.ts
+++ b/packages/web-api/src/controllers/health-check-controller.ts
@@ -3,7 +3,7 @@
 import { ApplicationInsightsQueryResponse, Column, ResponseWithBodyType } from 'azure-services';
 import { AvailabilityTestConfig, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { ApiController, HealthReport, HttpResponse, TestEnvironment, TestRun, TestRunResult, WebApiErrorCodes } from 'service-library';
 import { ApplicationInsightsClientProvider, webApiTypeNames } from '../web-api-types';
 
@@ -18,7 +18,7 @@ export class HealthCheckController extends ApiController {
 
     public constructor(
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
         @inject(webApiTypeNames.ApplicationInsightsClientProvider)
         protected readonly appInsightsClientProvider: ApplicationInsightsClientProvider,
     ) {

--- a/packages/web-api/src/controllers/scan-report-controller.ts
+++ b/packages/web-api/src/controllers/scan-report-controller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { GuidGenerator, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { ApiController, HttpResponse, PageScanRunReportService, WebApiErrorCodes } from 'service-library';
 import { Readable } from 'stream';
 import { BodyParser } from './../utils/body-parser';
@@ -16,7 +16,7 @@ export class ScanReportController extends ApiController {
         @inject(PageScanRunReportService) private readonly pageScanRunReportService: PageScanRunReportService,
         @inject(GuidGenerator) protected readonly guidGenerator: GuidGenerator,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
         private readonly bodyParser: BodyParser = new BodyParser(),
     ) {
         super(logger);

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -3,7 +3,7 @@
 import { GuidGenerator, RestApiConfig, ServiceConfiguration, Url } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty, isNil } from 'lodash';
-import { BatchScanRequestMeasurements, Logger } from 'logger';
+import { BatchScanRequestMeasurements, ContextAwareLogger } from 'logger';
 import {
     ApiController,
     HttpResponse,
@@ -35,7 +35,7 @@ export class ScanRequestController extends ApiController {
         @inject(ScanDataProvider) private readonly scanDataProvider: ScanDataProvider,
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
     ) {
         super(logger);
     }

--- a/packages/web-api/src/controllers/scan-result-controller.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.ts
@@ -3,7 +3,7 @@
 import { GuidGenerator, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
-import { Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { HttpResponse, OnDemandPageScanRunResultProvider, WebApiErrorCodes } from 'service-library';
 import { ScanResponseConverter } from '../converters/scan-response-converter';
 import { BaseScanResultController } from './base-scan-result-controller';
@@ -18,7 +18,7 @@ export class ScanResultController extends BaseScanResultController {
         @inject(ScanResponseConverter) protected readonly scanResponseConverter: ScanResponseConverter,
         @inject(GuidGenerator) protected readonly guidGenerator: GuidGenerator,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
     ) {
         super(logger);
     }

--- a/packages/web-api/src/get-process-life-cycle-container.spec.ts
+++ b/packages/web-api/src/get-process-life-cycle-container.spec.ts
@@ -3,10 +3,10 @@
 
 import 'reflect-metadata';
 
-import { AzureServicesIocTypes, cosmosContainerClientTypes, CredentialType, SecretProvider } from 'azure-services';
+import { AzureServicesIocTypes, CredentialsProvider, CredentialType, SecretProvider } from 'azure-services';
 import { ServiceConfiguration } from 'common';
 import * as inversify from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger, GlobalLogger, Logger } from 'logger';
 import { IMock, Mock } from 'typemoq';
 import { getProcessLifeCycleContainer } from './get-process-life-cycle-container';
 import { ApplicationInsightsClientProvider, webApiTypeNames } from './web-api-types';
@@ -30,8 +30,15 @@ describe(getProcessLifeCycleContainer, () => {
 
     it('verifies dependencies resolution', () => {
         expect(testSubject.get(ServiceConfiguration)).toBeDefined();
-        expect(testSubject.get(Logger)).toBeDefined();
-        expect(testSubject.get(cosmosContainerClientTypes.OnDemandScanBatchRequestsCosmosContainerClient)).toBeDefined();
+        expect(testSubject.get(GlobalLogger)).toBeDefined();
+
+        expect(testSubject.get(CredentialsProvider)).toBeDefined();
+        expect(testSubject.get(SecretProvider)).toBeDefined();
+        expect(testSubject.get(CredentialsProvider)).toBeDefined();
+    });
+
+    test.each([Logger, ContextAwareLogger])('verifies not resolved for - %p', testCase => {
+        expect(() => testSubject.get(testCase)).toThrowError();
     });
 
     it('should not create more than one instance of container', () => {

--- a/packages/web-api/src/get-process-life-cycle-container.ts
+++ b/packages/web-api/src/get-process-life-cycle-container.ts
@@ -5,7 +5,7 @@ import { ApplicationInsightsClient, CredentialType, registerAzureServicesToConta
 import { IoC, setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
 import { isNil } from 'lodash';
-import { registerContextAwareLoggerToContainer } from 'logger';
+import { registerGlobalLoggerToContainer } from 'logger';
 import { webApiTypeNames } from './web-api-types';
 
 let processLifeCycleContainer: inversify.Container;
@@ -14,7 +14,7 @@ export function getProcessLifeCycleContainer(): inversify.Container {
     if (isNil(processLifeCycleContainer)) {
         processLifeCycleContainer = new inversify.Container({ autoBindInjectable: true });
         setupRuntimeConfigContainer(processLifeCycleContainer);
-        registerContextAwareLoggerToContainer(processLifeCycleContainer);
+        registerGlobalLoggerToContainer(processLifeCycleContainer);
         registerAzureServicesToContainer(processLifeCycleContainer, CredentialType.AppService);
 
         IoC.setupSingletonProvider<ApplicationInsightsClient>(

--- a/packages/web-api/src/setup-request-context-ioc-container.spec.ts
+++ b/packages/web-api/src/setup-request-context-ioc-container.spec.ts
@@ -3,6 +3,7 @@
 import 'reflect-metadata';
 
 import * as inversify from 'inversify';
+import { ContextAwareLogger, registerGlobalLoggerToContainer } from 'logger';
 import { setupRequestContextIocContainer } from './setup-request-context-ioc-container';
 
 @inversify.injectable()
@@ -23,5 +24,17 @@ describe(setupRequestContextIocContainer, () => {
         expect(testSubject.get(TestAutoInjectable)).toBeInstanceOf(TestAutoInjectable);
         // tslint:disable-next-line: no-backbone-get-set-outside-model
         expect(testSubject.get('parentBind1')).toBe('parentBind1Instance');
+    });
+
+    describe('Logger resolution', () => {
+        it('throws error if global logger not setup', () => {
+            expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
+        });
+
+        it('resolves context aware logger', () => {
+            registerGlobalLoggerToContainer(parentContainer);
+
+            expect(testSubject.get(ContextAwareLogger)).toBeDefined();
+        });
     });
 });

--- a/packages/web-api/src/setup-request-context-ioc-container.ts
+++ b/packages/web-api/src/setup-request-context-ioc-container.ts
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 import { Container } from 'inversify';
+import { registerContextAwareLoggerToContainer } from 'logger';
 
 export function setupRequestContextIocContainer(processLifeCycleContainer: Container): Container {
     const container = new Container({ autoBindInjectable: true });
     container.parent = processLifeCycleContainer;
+
+    registerContextAwareLoggerToContainer(container);
 
     return container;
 }

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.ts
@@ -3,7 +3,7 @@
 import { GuidGenerator, ServiceConfiguration } from 'common';
 import { functionalTestGroupTypes, TestGroupConstructor, TestRunner } from 'functional-tests';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { HealthReport, OnDemandPageScanRunResultProvider, ScanResultResponse, ScanRunResponse, WebController } from 'service-library';
 import { A11yServiceClientProvider, a11yServiceClientTypeNames } from 'web-api-client';
 import { ActivityAction } from '../contracts/activity-actions';
@@ -28,7 +28,7 @@ export class HealthMonitorClientController extends WebController {
 
     public constructor(
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
         @inject(a11yServiceClientTypeNames.A11yServiceClientProvider) protected readonly webApiClientProvider: A11yServiceClientProvider,
         @inject(OnDemandPageScanRunResultProvider) protected readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
         @inject(GuidGenerator) protected readonly guidGenerator: GuidGenerator,

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
@@ -6,7 +6,7 @@ import * as durableFunctions from 'durable-functions';
 import { IOrchestrationFunctionContext } from 'durable-functions/lib/src/classes';
 import { TestContextData } from 'functional-tests';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { WebController } from 'service-library';
 import { e2eTestGroupNames } from '../e2e-test-group-names';
 import { OrchestrationSteps, OrchestrationStepsImpl } from '../orchestration-steps';
@@ -18,7 +18,7 @@ export class HealthMonitorOrchestrationController extends WebController {
 
     public constructor(
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
         private readonly df = durableFunctions,
     ) {
         super(logger);

--- a/packages/web-workers/src/controllers/health-monitor-timer-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-timer-controller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { GuidGenerator, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger } from 'logger';
 import { WebController } from 'service-library';
 import { FunctionTimer } from '../contracts/function-timer';
 
@@ -16,7 +16,7 @@ export class HealthMonitorTimerController extends WebController {
 
     public constructor(
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
     ) {
         super(logger);

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -3,7 +3,7 @@
 import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
-import { Logger, ScanUrlsAddedMeasurements } from 'logger';
+import { ContextAwareLogger, Logger, ScanUrlsAddedMeasurements } from 'logger';
 import {
     OnDemandPageScanRunResultProvider,
     PageScanRequestProvider,
@@ -20,7 +20,6 @@ import {
     ScanCompletedNotification,
     ScanRunBatchRequest,
 } from 'storage-documents';
-import { isNullOrUndefined } from 'util';
 
 interface ScanRequestTelemetryProperties {
     scanUrl: string;
@@ -44,7 +43,7 @@ export class ScanBatchRequestFeedController extends WebController {
         @inject(ScanDataProvider) private readonly scanDataProvider: ScanDataProvider,
         @inject(PartitionKeyFactory) private readonly partitionKeyFactory: PartitionKeyFactory,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(Logger) logger: Logger,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
     ) {
         super(logger);
     }

--- a/packages/web-workers/src/get-process-life-cycle-container.spec.ts
+++ b/packages/web-workers/src/get-process-life-cycle-container.spec.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { AzureServicesIocTypes, cosmosContainerClientTypes, CredentialType, SecretProvider } from 'azure-services';
+import { AzureServicesIocTypes, cosmosContainerClientTypes, CredentialsProvider, CredentialType, SecretProvider } from 'azure-services';
 import { ServiceConfiguration } from 'common';
 import * as inversify from 'inversify';
-import { Logger } from 'logger';
+import { ContextAwareLogger, GlobalLogger, Logger } from 'logger';
 import { IMock, Mock } from 'typemoq';
 import { A11yServiceClientProvider, a11yServiceClientTypeNames } from 'web-api-client';
 import { getProcessLifeCycleContainer } from './get-process-life-cycle-container';
@@ -24,8 +24,15 @@ describe(getProcessLifeCycleContainer, () => {
 
     it('verifies dependencies resolution', () => {
         expect(testSubject.get(ServiceConfiguration)).toBeDefined();
-        expect(testSubject.get(Logger)).toBeDefined();
-        expect(testSubject.get(cosmosContainerClientTypes.OnDemandScanBatchRequestsCosmosContainerClient)).toBeDefined();
+        expect(testSubject.get(GlobalLogger)).toBeDefined();
+
+        expect(testSubject.get(CredentialsProvider)).toBeDefined();
+        expect(testSubject.get(SecretProvider)).toBeDefined();
+        expect(testSubject.get(CredentialsProvider)).toBeDefined();
+    });
+
+    test.each([Logger, ContextAwareLogger])('verifies not resolved for - %p', testCase => {
+        expect(() => testSubject.get(testCase)).toThrowError();
     });
 
     it('verifies A11yServiceClient registration', async () => {

--- a/packages/web-workers/src/get-process-life-cycle-container.ts
+++ b/packages/web-workers/src/get-process-life-cycle-container.ts
@@ -5,7 +5,7 @@ import { CredentialType, registerAzureServicesToContainer, SecretProvider } from
 import { IoC, setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
 import { isNil } from 'lodash';
-import { Logger, loggerTypes, registerContextAwareLoggerToContainer } from 'logger';
+import { GlobalLogger, Logger, loggerTypes, registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
 import { A11yServiceClient, a11yServiceClientTypeNames, A11yServiceCredential } from 'web-api-client';
 
 let processLifeCycleContainer: inversify.Container;
@@ -14,7 +14,7 @@ export function getProcessLifeCycleContainer(): inversify.Container {
     if (isNil(processLifeCycleContainer)) {
         processLifeCycleContainer = new inversify.Container({ autoBindInjectable: true });
         setupRuntimeConfigContainer(processLifeCycleContainer);
-        registerContextAwareLoggerToContainer(processLifeCycleContainer);
+        registerGlobalLoggerToContainer(processLifeCycleContainer);
         registerAzureServicesToContainer(processLifeCycleContainer, CredentialType.AppService);
 
         IoC.setupSingletonProvider<A11yServiceClient>(
@@ -25,7 +25,7 @@ export function getProcessLifeCycleContainer(): inversify.Container {
                 const restApiSpAppId = await secretProvider.getSecret('restApiSpAppId');
                 const restApiSpSecret = await secretProvider.getSecret('restApiSpSecret');
                 const authorityUrl = await secretProvider.getSecret('authorityUrl');
-                const logger = context.container.get(Logger);
+                const logger = context.container.get(GlobalLogger);
 
                 const a11yServiceCredential = new A11yServiceCredential(
                     restApiSpAppId,

--- a/packages/web-workers/src/get-process-life-cycle-container.ts
+++ b/packages/web-workers/src/get-process-life-cycle-container.ts
@@ -5,7 +5,7 @@ import { CredentialType, registerAzureServicesToContainer, SecretProvider } from
 import { IoC, setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
 import { isNil } from 'lodash';
-import { GlobalLogger, Logger, loggerTypes, registerContextAwareLoggerToContainer, registerGlobalLoggerToContainer } from 'logger';
+import { GlobalLogger, registerGlobalLoggerToContainer } from 'logger';
 import { A11yServiceClient, a11yServiceClientTypeNames, A11yServiceCredential } from 'web-api-client';
 
 let processLifeCycleContainer: inversify.Container;

--- a/packages/web-workers/src/setup-request-context-ioc-container.spec.ts
+++ b/packages/web-workers/src/setup-request-context-ioc-container.spec.ts
@@ -3,6 +3,7 @@
 import 'reflect-metadata';
 
 import * as inversify from 'inversify';
+import { ContextAwareLogger, Logger, registerGlobalLoggerToContainer } from 'logger';
 import { setupRequestContextIocContainer } from './setup-request-context-ioc-container';
 
 @inversify.injectable()
@@ -23,5 +24,17 @@ describe(setupRequestContextIocContainer, () => {
         expect(testSubject.get(TestAutoInjectable)).toBeInstanceOf(TestAutoInjectable);
         // tslint:disable-next-line: no-backbone-get-set-outside-model
         expect(testSubject.get('parentBind1')).toBe('parentBind1Instance');
+    });
+
+    describe('Logger resolution', () => {
+        it('throws error if global logger not setup', () => {
+            expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
+        });
+
+        it('resolves context aware logger', () => {
+            registerGlobalLoggerToContainer(parentContainer);
+
+            expect(testSubject.get(ContextAwareLogger)).toBeDefined();
+        });
     });
 });

--- a/packages/web-workers/src/setup-request-context-ioc-container.ts
+++ b/packages/web-workers/src/setup-request-context-ioc-container.ts
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 import { Container } from 'inversify';
+import { registerContextAwareLoggerToContainer } from 'logger';
 
 export function setupRequestContextIocContainer(processLifeCycleContainer: Container): Container {
     const container = new Container({ autoBindInjectable: true });
     container.parent = processLifeCycleContainer;
+
+    registerContextAwareLoggerToContainer(container);
 
     return container;
 }


### PR DESCRIPTION
**Issue:** I found that we are getting exceptions in web-workers when there is a failure in cosmos client (like 429 errors etc,) that context aware logger is not setup. & thus hiding the true failure message.

- We need to run .setup, before calling log functions.
   So, Context aware logger has to be singleton
- Enforcing to use either GlobalLogger or ContextAwareLogger in all classes.
  It is confusing to take dependency on Logger & not know which logger you would be getting.
  This introduces unexpected behaviors & bugs. As part of this change, I have changed to use GlobalLogger for all singleton types & under batch task packages & to use ContextAwareLogger for non-singleton types.
  It is safer to make the class aware of whether it will be getting global / context aware logger.
- We use ContextAwareLogger for classes that are not singleton, even for batch tasks. 
  ContextAwareLogger would inherit all the base properties of GlobalLogger. So, this change should 
  be a no-op for batch tasks flow. 

Validated the changes here - https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_releaseProgress?_a=release-pipeline-progress&releaseId=3516

#### Description of changes

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
