### PR TITLE
fix: increase timeout for controller tests

### DIFF
--- a/packages/web-api/src/process-request.spec.ts
+++ b/packages/web-api/src/process-request.spec.ts
@@ -51,7 +51,7 @@ describe(processWebRequest, () => {
         const response = (await processWebRequest(context, TestableController, args)) as TestRequestResponse;
 
         expect(response.message).toBe(`request handled with args ${args.toString()}`);
-    });
+    }, 10000);
 
     it('new loggers are created for each request', async () => {
         const args = ['arg1', 'arg2'];
@@ -67,5 +67,5 @@ describe(processWebRequest, () => {
         expect(logger1).toBeDefined();
         expect(logger2).toBeDefined();
         expect(logger1).not.toBe(logger2);
-    });
+    }, 10000);
 });

--- a/packages/web-workers/src/process-web-request.spec.ts
+++ b/packages/web-workers/src/process-web-request.spec.ts
@@ -51,7 +51,7 @@ describe(processWebRequest, () => {
         const response = (await processWebRequest(context, TestableController, args)) as TestRequestResponse;
 
         expect(response.message).toBe(`request handled with args ${args.toString()}`);
-    });
+    }, 10000);
 
     it('new loggers are created for each request', async () => {
         const args = ['arg1', 'arg2'];
@@ -65,5 +65,5 @@ describe(processWebRequest, () => {
         expect(logger1).toBeDefined();
         expect(logger2).toBeDefined();
         expect(logger1).not.toBe(logger2);
-    });
+    }, 10000);
 });


### PR DESCRIPTION
these tests loads the whole framework causing the test to take more time causing flakiness

#### Description of changes

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
