### PR TITLE
chore: Mark scans that failed to enqueue as failure with error info

### DIFF
--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -18,7 +18,8 @@ export type ScanErrorTypes =
     | 'NavigationError'
     | 'InvalidContentType'
     | 'UrlNotResolved'
-    | 'ScanTimeout';
+    | 'ScanTimeout'
+    | 'InternalError';
 
 export interface ScanError {
     errorType: ScanErrorTypes;

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -47,6 +47,7 @@
         "reflect-metadata": "^0.1.13",
         "service-library": "1.0.0",
         "storage-documents": "1.0.0",
+        "lodash": "^4.17.14",
         "why-is-node-running": "^2.1.0"
     }
 }

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-scan-request-sender.ts
@@ -2,8 +2,15 @@
 // Licensed under the MIT License.
 import { Queue, StorageConfig } from 'azure-services';
 import { inject, injectable } from 'inversify';
+import { isNil } from 'lodash';
 import { OnDemandPageScanRunResultProvider, PageScanRequestProvider } from 'service-library';
-import { OnDemandPageScanRequest, OnDemandPageScanResult, OnDemandScanRequestMessage } from 'storage-documents';
+import {
+    OnDemandPageScanRequest,
+    OnDemandPageScanResult,
+    OnDemandPageScanRunState,
+    OnDemandScanRequestMessage,
+    ScanError,
+} from 'storage-documents';
 
 @injectable()
 export class OnDemandScanRequestSender {
@@ -26,12 +33,16 @@ export class OnDemandScanRequestSender {
                 }
 
                 if (isEnqueueSuccessful === true) {
-                    await this.updateOnDemandPageResultDoc(resultDoc);
+                    await this.updateOnDemandPageResultDoc(resultDoc, 'queued');
+                } else {
+                    const error: ScanError = {
+                        errorType: 'InternalError',
+                        message: 'Failed to create scan message in queue.',
+                    };
+                    await this.updateOnDemandPageResultDoc(resultDoc, 'failed', error);
                 }
 
-                if (isEnqueueSuccessful !== false) {
-                    await this.pageScanRequestProvider.deleteRequests([page.id]);
-                }
+                await this.pageScanRequestProvider.deleteRequests([page.id]);
             }),
         );
     }
@@ -40,9 +51,16 @@ export class OnDemandScanRequestSender {
         return this.queue.getMessageCount(this.storageConfig.scanQueue);
     }
 
-    private async updateOnDemandPageResultDoc(resultDoc: OnDemandPageScanResult): Promise<void> {
-        resultDoc.run.state = 'queued';
+    private async updateOnDemandPageResultDoc(
+        resultDoc: OnDemandPageScanResult,
+        state: OnDemandPageScanRunState,
+        error?: ScanError,
+    ): Promise<void> {
+        resultDoc.run.state = state;
         resultDoc.run.timestamp = new Date().toJSON();
+        if (!isNil(error)) {
+            resultDoc.run.error = error;
+        }
 
         await this.onDemandPageScanRunResultProvider.writeScanRuns([resultDoc]);
     }


### PR DESCRIPTION
#### Description of changes
Mark scans that failed to enqueue as failed with error info and delete them in the scan request container.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
