### PR TITLE
fix: check successful response code instead of 200 for notification

### DIFF
--- a/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.ts
+++ b/packages/azure-services/src/azure-cosmos/cosmos-client-wrapper.ts
@@ -230,7 +230,7 @@ export class CosmosClientWrapper {
     }
 
     private getFailedOperationResponse<T>(error: any): CosmosOperationResponse<T> {
-        const errorResponse = client.getErrorResponse<T>(error);
+        const errorResponse = client.getErrorResponse(error);
         if (errorResponse !== undefined) {
             return errorResponse;
         } else {

--- a/packages/azure-services/src/storage/client.ts
+++ b/packages/azure-services/src/storage/client.ts
@@ -1,27 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { VError } from 'verror';
-import { CosmosOperationResponse } from '../azure-cosmos/cosmos-operation-response';
 
 // tslint:disable: no-any no-unsafe-any
 
+export interface ErrorResponse {
+    statusCode: number;
+    response: unknown;
+}
+
 export namespace client {
-    export function isSuccessStatusCode<T>(response: CosmosOperationResponse<T>): boolean {
+    export function isSuccessStatusCode<T>(response: { statusCode: number }): boolean {
         return response.statusCode !== undefined && response.statusCode >= 200 && response.statusCode <= 299;
     }
 
-    export function ensureSuccessStatusCode<T>(response: CosmosOperationResponse<T>): void {
+    export function ensureSuccessStatusCode<T>(response: { statusCode: number }): void {
         if (!isSuccessStatusCode(response)) {
             throw new VError(
                 `Failed request response - ${JSON.stringify({
                     statusCode: response.statusCode === undefined ? 'undefined' : response.statusCode,
-                    response: response.response === undefined ? 'undefined' : response.response,
+                    response: response === undefined ? 'undefined' : response,
                 })}`,
             );
         }
     }
 
-    export function getErrorResponse<T>(error: any): CosmosOperationResponse<T> {
+    export function getErrorResponse(error: any): ErrorResponse {
         if (error.code !== undefined) {
             return {
                 response: error.message,

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { client } from 'azure-services';
 import { ScanRunTimeConfig, ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
 import { GlobalLogger, loggerTypes } from 'logger';
@@ -21,6 +22,7 @@ export class NotificationSender {
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
         private readonly system: typeof System = System,
+        private readonly responseParser: typeof client = client,
     ) {}
 
     public async sendNotification(): Promise<void> {
@@ -57,7 +59,7 @@ export class NotificationSender {
                 response = await this.notificationSenderWebAPIClient.sendNotification(notificationSenderConfigData);
                 statusCode = response.statusCode;
 
-                if (response.statusCode === 200) {
+                if (this.responseParser.isSuccessStatusCode(response)) {
                     this.logger.trackEvent('SendNotificationTaskSucceeded');
                     this.logger.logInfo(`Notification sent Successfully!, try #${numberOfTries}`);
                     notificationState = 'sent';


### PR DESCRIPTION
#### Description of changes
This PR extends considering all result codes between 200-299 as successful instead of just 200.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
