### PR TITLE
fix: Set timeout when sending the notification request

### DIFF
--- a/packages/resource-deployment/runtime-config/runtime-config.ci.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ci.json
@@ -8,9 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-    "taskConfig": {
-        "taskTimeoutInMinutes": 3
-    },
 
     "scanConfig": {
         "minLastReferenceSeenInDays": 3,

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -8,9 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-    "taskConfig": {
-        "taskTimeoutInMinutes": 3
-    },
 
     "scanConfig": {
         "minLastReferenceSeenInDays": 3,

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -8,9 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 40
     },
-    "taskConfig": {
-        "taskTimeoutInMinutes": 5
-    },
 
     "scanConfig": {
         "minLastReferenceSeenInDays": 3,

--- a/packages/resource-deployment/runtime-config/runtime-config.prod.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.prod.json
@@ -9,7 +9,6 @@
         "maxQueueSize": 40
     },
     "taskConfig": {
-        "taskTimeoutInMinutes": 5,
         "exitOnComplete": true
     },
 

--- a/packages/resource-deployment/runtime-config/runtime-config.selftest.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.selftest.json
@@ -8,9 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-    "taskConfig": {
-        "taskTimeoutInMinutes": 3
-    },
     "scanConfig": {
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,

--- a/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.spec.ts
+++ b/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.spec.ts
@@ -69,7 +69,7 @@ describe(NotificationSenderWebAPIClient, () => {
         const requestBody = { scanId: scanId, runStatus: runStatus, scanStatus: scanStatus };
         const options = {
             body: requestBody,
-            timeout: 5000,
+            timeout: 30000,
         };
 
         postMock

--- a/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.spec.ts
+++ b/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.spec.ts
@@ -39,7 +39,7 @@ describe(NotificationSenderWebAPIClient, () => {
     describe('verify default options', () => {
         test.each([true, false])('verifies when throwOnFailure is %o', (throwOnFailure: boolean) => {
             // tslint:disable-next-line: no-empty
-            const defaultsMock = Mock.ofInstance((options: requestPromise.RequestPromiseOptions): any => {});
+            const defaultsMock = Mock.ofInstance((options: requestPromise.RequestPromiseOptions): any => { });
             requestStub.defaults = defaultsMock.object;
 
             defaultsMock
@@ -69,6 +69,7 @@ describe(NotificationSenderWebAPIClient, () => {
         const requestBody = { scanId: scanId, runStatus: runStatus, scanStatus: scanStatus };
         const options = {
             body: requestBody,
+            timeout: 5000,
         };
 
         postMock

--- a/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.spec.ts
+++ b/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.spec.ts
@@ -39,7 +39,7 @@ describe(NotificationSenderWebAPIClient, () => {
     describe('verify default options', () => {
         test.each([true, false])('verifies when throwOnFailure is %o', (throwOnFailure: boolean) => {
             // tslint:disable-next-line: no-empty
-            const defaultsMock = Mock.ofInstance((options: requestPromise.RequestPromiseOptions): any => { });
+            const defaultsMock = Mock.ofInstance((options: requestPromise.RequestPromiseOptions): any => {});
             requestStub.defaults = defaultsMock.object;
 
             defaultsMock

--- a/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.ts
+++ b/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.ts
@@ -36,7 +36,7 @@ export class NotificationSenderWebAPIClient {
             runStatus: notificationSenderConfigData.runStatus,
             scanStatus: notificationSenderConfigData.scanStatus,
         };
-        const options: requestPromise.RequestPromiseOptions = { body: requestBody, timeout: 5000 };
+        const options: requestPromise.RequestPromiseOptions = { body: requestBody, timeout: 30000 };
 
         return this.defaultRequestObject.post(notificationSenderConfigData.scanNotifyUrl, options);
     }

--- a/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.ts
+++ b/packages/web-api-send-notification-runner/src/tasks/notification-sender-web-api-client.ts
@@ -36,7 +36,7 @@ export class NotificationSenderWebAPIClient {
             runStatus: notificationSenderConfigData.runStatus,
             scanStatus: notificationSenderConfigData.scanStatus,
         };
-        const options: requestPromise.RequestPromiseOptions = { body: requestBody };
+        const options: requestPromise.RequestPromiseOptions = { body: requestBody, timeout: 5000 };
 
         return this.defaultRequestObject.post(notificationSenderConfigData.scanNotifyUrl, options);
     }


### PR DESCRIPTION
#### Description of changes
- If we don’t set time out, time out might take too much time especially if we keep retrying, so the task itself times out before the post request does, so it exists without updating the notification state.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
