### PR TITLE
chore: update build/deploy VM images to ubuntu 18.04

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -6,7 +6,6 @@ jobs:
     - job: 'BuildArtifactsAndRunSomeTests'
       pool:
           vmImage: 'ubuntu-18.04'
-          demands: npm
       steps:
           - template: ./azure-pipeline/build-artifacts-and-run-tests-job.yaml
             parameters: { totalTestSlices: 4, testSlicesToRun: '[0]' }
@@ -14,7 +13,6 @@ jobs:
     - job: 'RunRemainingTests'
       pool:
           vmImage: 'ubuntu-18.04'
-          demands: npm
       steps:
           - template: ./azure-pipeline/run-tests-job.yaml
             parameters: { totalTestSlices: 4, testSlicesToRun: '[1,2,3]' }

--- a/build.yaml
+++ b/build.yaml
@@ -5,7 +5,7 @@ name: $(Build.SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 jobs:
     - job: 'BuildArtifactsAndRunSomeTests'
       pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
           demands: npm
       steps:
           - template: ./azure-pipeline/build-artifacts-and-run-tests-job.yaml
@@ -13,7 +13,7 @@ jobs:
 
     - job: 'RunRemainingTests'
       pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
           demands: npm
       steps:
           - template: ./azure-pipeline/run-tests-job.yaml

--- a/packages/resource-deployment/README.md
+++ b/packages/resource-deployment/README.md
@@ -18,7 +18,7 @@ You can use the following PowerShell commands to accept the Azure Marketplace le
 ```PowerShell
 Add-AzureRmAccount
 Set-AzureRmContext -SubscriptionId <The name or id of the subscription> -TenantId <Tenant name or ID>
-Get-AzureRmMarketplaceTerms -Publisher 'microsoft-azure-batch' -Product 'ubuntu-server-container' -Name '16-04-lts' | Set-AzureRmMarketplaceTerms -Accept
+Get-AzureRmMarketplaceTerms -Publisher 'microsoft-azure-batch' -Product 'ubuntu-server-container' -Name '18-04-lts' | Set-AzureRmMarketplaceTerms -Accept
 ```
 
 ### 2. Clone the repository

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -118,10 +118,10 @@
                         "imageReference": {
                             "publisher": "microsoft-azure-batch",
                             "offer": "ubuntu-server-container",
-                            "sku": "16-04-lts",
+                            "sku": "18-04-lts",
                             "version": "latest"
                         },
-                        "nodeAgentSkuId": "batch.node.ubuntu 16.04"
+                        "nodeAgentSkuId": "batch.node.ubuntu 18.04"
                     }
                 },
                 "networkConfiguration": {
@@ -175,10 +175,10 @@
                         "imageReference": {
                             "publisher": "microsoft-azure-batch",
                             "offer": "ubuntu-server-container",
-                            "sku": "16-04-lts",
+                            "sku": "18-04-lts",
                             "version": "latest"
                         },
-                        "nodeAgentSkuId": "batch.node.ubuntu 16.04"
+                        "nodeAgentSkuId": "batch.node.ubuntu 18.04"
                     }
                 },
                 "networkConfiguration": {


### PR DESCRIPTION
#### Description of changes

Updates the batch pool and devops VM images to use latest ubuntu LTS (18.04), from 16.04.

This removes the "npm" demand from our pool specification; it isn't necessary since we install node explicitly anyway in all of our builds, and it causes a build failure ([example](https://dev.azure.com/accessibility-insights/Accessibility%20Insights%20Service/_build/results?buildId=8738&view=results)) where the builds to try to use a non-existent "Hosted Ubuntu 18.04" agent pool instead of the more typical "Azure Pipelines" default agent pool that all our other builds use.

I considered separating these to 2 PRs, but thought it was probably best to pin what we test against and what we deploy against to one another.

I'm not familiar with how the batch pools work, particularly, whether this is a change that might orphan old pool VMs somehow; would like a review from someone more familiar with how batch pool machine deployment works

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
