### PR TITLE
Enable Cosmos feed to start from beginning

### DIFF
--- a/packages/web-workers/host.json
+++ b/packages/web-workers/host.json
@@ -1,3 +1,4 @@
 {
-    "version": "2.0"
+    "version": "2.0",
+    "functionTimeout": "00:10:00"
 }

--- a/packages/web-workers/scan-batch-requests-feed-func/function.json
+++ b/packages/web-workers/scan-batch-requests-feed-func/function.json
@@ -8,7 +8,8 @@
             "connectionStringSetting": "COSMOS_CONNECTION_STRING",
             "databaseName": "onDemandScanner",
             "collectionName": "scanBatchRequests",
-            "createLeaseCollectionIfNotExists": true
+            "createLeaseCollectionIfNotExists": true,
+            "startFromBeginning": true
         }
     ],
     "scriptFile": "../scan-batch-requests-feed-func/index.js"


### PR DESCRIPTION
#### Description of changes

Enable Cosmos feed to start from beginning of batch collection if restarted.
Increase function runtime limit.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
