### PR TITLE
chore: adding support to generate summary html

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
         "webpack-node-externals": "^1.7.2"
     },
     "dependencies": {
+        "@types/escape-html": "^0.0.20",
         "accessibility-insights-report": "^1.0.2",
         "axe-core": "3.5.1",
         "axe-puppeteer": "^1.1.0",
@@ -59,8 +60,10 @@
         "dotenv": "^8.2.0",
         "filenamify-url": "^2.1.1",
         "filenamify": "^4.1.0",
+        "escape-html": "^1.0.3",
         "inversify": "^5.0.1",
         "lodash": "^4.17.14",
+        "pretty": "^2.0.0",
         "puppeteer": "^3.0.4",
         "react-helmet": "^6.0.0",
         "reflect-metadata": "^0.1.13",

--- a/packages/cli/src/report/report-disk-writer.spec.ts
+++ b/packages/cli/src/report/report-disk-writer.spec.ts
@@ -23,14 +23,15 @@ describe('ReportDiskWriter', () => {
         const format = 'html';
         const content = 'content';
 
-        const reportFileName = `${directory}/${filenamify(fileName, { replacement: '_' })}.${format}`;
+        const reportFileName = `${filenamify(fileName, { replacement: '_' })}.${format}`;
+        const reportFilePath = `${directory}/${reportFileName}`;
 
         fsMock
             .setup((fsm) => fsm.existsSync('.'))
             .returns(() => true)
             .verifiable(Times.once());
         fsMock
-            .setup((fsm) => fsm.writeFileSync(reportFileName, content))
+            .setup((fsm) => fsm.writeFileSync(reportFilePath, content))
             .returns(() => {})
             .verifiable(Times.once());
         fsMock
@@ -38,7 +39,7 @@ describe('ReportDiskWriter', () => {
             .returns(() => {})
             .verifiable(Times.never());
 
-        testSubject.writeToDirectory(directory, fileName, format, content);
+        expect(testSubject.writeToDirectory(directory, fileName, format, content)).toEqual(reportFileName);
 
         fsMock.verifyAll();
     });
@@ -49,14 +50,14 @@ describe('ReportDiskWriter', () => {
         const format = 'json';
         const content = 'content';
 
-        const reportFileName = `${directory}/${fileName}.${format}`;
-
+        const reportFileName = `${fileName}.${format}`;
+        const reportFilePath = `${directory}/${reportFileName}`;
         fsMock
             .setup((fsm) => fsm.existsSync('.'))
             .returns(() => false)
             .verifiable(Times.once());
         fsMock
-            .setup((fsm) => fsm.writeFileSync(reportFileName, content))
+            .setup((fsm) => fsm.writeFileSync(reportFilePath, content))
             .returns(() => {})
             .verifiable(Times.once());
         fsMock
@@ -64,7 +65,7 @@ describe('ReportDiskWriter', () => {
             .returns(() => {})
             .verifiable(Times.once());
 
-        testSubject.writeToDirectory(directory, fileName, format, content);
+        expect(testSubject.writeToDirectory(directory, fileName, format, content)).toEqual(reportFileName);
 
         fsMock.verifyAll();
     });
@@ -75,14 +76,15 @@ describe('ReportDiskWriter', () => {
         const format = 'html';
         const content = 'content';
 
-        const reportFileName = `${directory}/${filenamify(fileName, { replacement: '_' })}.${format}`;
+        const reportFileName = `${filenamify(fileName, { replacement: '_' })}.${format}`;
+        const reportFilePath = `${directory}/${reportFileName}`;
 
         fsMock
             .setup((fsm) => fsm.existsSync('.'))
             .returns(() => false)
             .verifiable(Times.once());
         fsMock
-            .setup((fsm) => fsm.writeFileSync(reportFileName, content))
+            .setup((fsm) => fsm.writeFileSync(reportFilePath, content))
             .returns(() => {})
             .verifiable(Times.once());
         fsMock
@@ -90,7 +92,7 @@ describe('ReportDiskWriter', () => {
             .returns(() => {})
             .verifiable(Times.once());
 
-        testSubject.writeToDirectory('', fileName, format, content);
+        expect(testSubject.writeToDirectory('', fileName, format, content)).toEqual(reportFileName);
 
         fsMock.verifyAll();
     });

--- a/packages/cli/src/report/report-disk-writer.ts
+++ b/packages/cli/src/report/report-disk-writer.ts
@@ -20,9 +20,9 @@ export class ReportDiskWriter {
         let reportFileName;
 
         try {
-            reportFileName = `${directory}/${filenamifyUrl(fileName, { replacement: '_' })}.${format}`;
+            reportFileName = `${filenamifyUrl(fileName, { replacement: '_' })}.${format}`;
         } catch {
-            reportFileName = `${directory}/${filenamify(fileName, { replacement: '_' })}.${format}`;
+            reportFileName = `${filenamify(fileName, { replacement: '_' })}.${format}`;
         }
 
         if (!this.fileSystemObj.existsSync(directory)) {
@@ -31,7 +31,7 @@ export class ReportDiskWriter {
             this.fileSystemObj.mkdirSync(directory);
         }
 
-        this.fileSystemObj.writeFileSync(reportFileName, content);
+        this.fileSystemObj.writeFileSync(`${directory}/${reportFileName}`, content);
 
         return reportFileName;
     }

--- a/packages/cli/src/report/summary-report/__snapshots__/html-summary-report-generator.spec.ts.snap
+++ b/packages/cli/src/report/summary-report/__snapshots__/html-summary-report-generator.spec.ts.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HtmlSummaryReportGenerator logs violation summary when has both failed & passed urls 1`] = `
+"<!DOCTYPE html>
+<html lang='en'>
+
+  <head>
+    <meta charset=\\"UTF-8\\">
+    <title>Accessibility Insights Summary Report</title>
+  </head>
+
+  <body>
+
+
+    <b>
+      Total Urls Scanned - 4
+    </b>
+
+    <ul>
+
+      <li>
+        Failed Urls
+        <ul>
+
+          <li>
+            <a href='./failed-url1.html'>https://www.failedUrl1.com</a>
+          </li>
+
+          <li>
+            <a href='./failed-url2.html'>https://www.failedUrl2.com</a>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        Passed Urls
+        <ul>
+
+          <li>
+            <a href='./passed-url1.html'>https://www.passedUrl1.com</a>
+          </li>
+
+          <li>
+            <a href='./passed-url2.html'>https://www.passedUrl2.com</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </body>
+
+</html>"
+`;
+
+exports[`HtmlSummaryReportGenerator logs violation summary when has failed urls only 1`] = `
+"<!DOCTYPE html>
+<html lang='en'>
+
+  <head>
+    <meta charset=\\"UTF-8\\">
+    <title>Accessibility Insights Summary Report</title>
+  </head>
+
+  <body>
+
+
+    <b>
+      Total Urls Scanned - 2
+    </b>
+
+    <ul>
+
+      <li>
+        Failed Urls
+        <ul>
+
+          <li>
+            <a href='./failed-url1.html'>https://www.failedUrl1.com</a>
+          </li>
+
+          <li>
+            <a href='./failed-url2.html'>https://www.failedUrl2.com</a>
+          </li>
+        </ul>
+      </li>
+
+    </ul>
+  </body>
+
+</html>"
+`;
+
+exports[`HtmlSummaryReportGenerator logs violation summary when has no scanned urls 1`] = `
+"<!DOCTYPE html>
+<html lang='en'>
+
+  <head>
+    <meta charset=\\"UTF-8\\">
+    <title>Accessibility Insights Summary Report</title>
+  </head>
+
+  <body>
+
+    <b>
+      Total Urls Scanned - 0
+    </b>
+
+  </body>
+
+</html>"
+`;
+
+exports[`HtmlSummaryReportGenerator logs violation summary when has passed urls only 1`] = `
+"<!DOCTYPE html>
+<html lang='en'>
+
+  <head>
+    <meta charset=\\"UTF-8\\">
+    <title>Accessibility Insights Summary Report</title>
+  </head>
+
+  <body>
+
+
+    <b>
+      Total Urls Scanned - 2
+    </b>
+
+    <ul>
+
+
+      <li>
+        Passed Urls
+        <ul>
+
+          <li>
+            <a href='./passed-url1.html'>https://www.passedUrl1.com</a>
+          </li>
+
+          <li>
+            <a href='./passed-url2.html'>https://www.passedUrl2.com</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </body>
+
+</html>"
+`;

--- a/packages/cli/src/report/summary-report/console-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/console-summary-report-generator.spec.ts
@@ -24,6 +24,7 @@ describe(ConsoleSummaryReportGenerator, () => {
                     rule1WithALongName11111111111111111: 10,
                     rule2: 3,
                 },
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
         [
@@ -32,6 +33,7 @@ describe(ConsoleSummaryReportGenerator, () => {
                 failedUrlToReportMap: { url1: 'file1' },
                 passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {},
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
     ])('logs summary when %s', async (testCaseName, testCase) => {

--- a/packages/cli/src/report/summary-report/console-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/console-summary-report-generator.spec.ts
@@ -18,7 +18,8 @@ describe(ConsoleSummaryReportGenerator, () => {
         [
             'has violations',
             {
-                urlToReportMap: { url1: 'file1' },
+                failedUrlToReportMap: { url1: 'file1' },
+                passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {
                     rule1WithALongName11111111111111111: 10,
                     rule2: 3,
@@ -28,7 +29,8 @@ describe(ConsoleSummaryReportGenerator, () => {
         [
             'has no violations',
             {
-                urlToReportMap: { url1: 'file1' },
+                failedUrlToReportMap: { url1: 'file1' },
+                passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {},
             } as SummaryReportData,
         ],

--- a/packages/cli/src/report/summary-report/html-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/html-summary-report-generator.spec.ts
@@ -21,6 +21,7 @@ describe(HtmlSummaryReportGenerator, () => {
                 failedUrlToReportMap: {},
                 passedUrlToReportMap: {},
                 violationCountByRuleMap: {},
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
         [
@@ -32,6 +33,7 @@ describe(HtmlSummaryReportGenerator, () => {
                 },
                 passedUrlToReportMap: {},
                 violationCountByRuleMap: { rule1: 3 },
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
         [
@@ -43,6 +45,7 @@ describe(HtmlSummaryReportGenerator, () => {
                     'https://www.passedUrl2.com': './passed-url2.html',
                 },
                 violationCountByRuleMap: {},
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
         [
@@ -59,6 +62,7 @@ describe(HtmlSummaryReportGenerator, () => {
                 violationCountByRuleMap: {
                     rule1: 3,
                 },
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
     ])('logs violation summary when %s', async (testCaseName, testCase) => {

--- a/packages/cli/src/report/summary-report/html-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/html-summary-report-generator.spec.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { HtmlSummaryReportGenerator } from './html-summary-report-generator';
+import { SummaryReportData } from './summary-report-data';
+
+// tslint:disable: no-object-literal-type-assertion
+
+describe(HtmlSummaryReportGenerator, () => {
+    let testSubject: HtmlSummaryReportGenerator;
+
+    beforeEach(() => {
+        testSubject = new HtmlSummaryReportGenerator();
+    });
+
+    test.each([
+        [
+            'has no scanned urls',
+            {
+                failedUrlToReportMap: {},
+                passedUrlToReportMap: {},
+                violationCountByRuleMap: {},
+            } as SummaryReportData,
+        ],
+        [
+            'has failed urls only',
+            {
+                failedUrlToReportMap: {
+                    'https://www.failedUrl1.com': './failed-url1.html',
+                    'https://www.failedUrl2.com': './failed-url2.html',
+                },
+                passedUrlToReportMap: {},
+                violationCountByRuleMap: { rule1: 3 },
+            } as SummaryReportData,
+        ],
+        [
+            'has passed urls only',
+            {
+                failedUrlToReportMap: {},
+                passedUrlToReportMap: {
+                    'https://www.passedUrl1.com': './passed-url1.html',
+                    'https://www.passedUrl2.com': './passed-url2.html',
+                },
+                violationCountByRuleMap: {},
+            } as SummaryReportData,
+        ],
+        [
+            'has both failed & passed urls',
+            {
+                failedUrlToReportMap: {
+                    'https://www.failedUrl1.com': './failed-url1.html',
+                    'https://www.failedUrl2.com': './failed-url2.html',
+                },
+                passedUrlToReportMap: {
+                    'https://www.passedUrl1.com': './passed-url1.html',
+                    'https://www.passedUrl2.com': './passed-url2.html',
+                },
+                violationCountByRuleMap: {
+                    rule1: 3,
+                },
+            } as SummaryReportData,
+        ],
+    ])('logs violation summary when %s', async (testCaseName, testCase) => {
+        expect(testSubject.generateReport(testCase)).toMatchSnapshot();
+    });
+});

--- a/packages/cli/src/report/summary-report/html-summary-report-generator.ts
+++ b/packages/cli/src/report/summary-report/html-summary-report-generator.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as escapeHtml from 'escape-html';
+import { injectable } from 'inversify';
+import { SummaryReportData, UrlToReportMap } from './summary-report-data';
+import { SummaryReportGenerator } from './summary-report-generator';
+
+// tslint:disable-next-line: no-var-requires no-require-imports no-unsafe-any
+const pretty: (html: string) => string = require('pretty');
+
+type HtmlSummaryLink = {
+    link: string;
+    fileName: string;
+};
+
+type HtmlSummaryData = {
+    passedLinks: HtmlSummaryLink[];
+    failedLinks: HtmlSummaryLink[];
+};
+
+@injectable()
+export class HtmlSummaryReportGenerator implements SummaryReportGenerator {
+    public generateReport(summaryReportData: SummaryReportData): string {
+        const htmlSummaryData: HtmlSummaryData = {
+            failedLinks: [],
+            passedLinks: [],
+        };
+
+        htmlSummaryData.failedLinks = this.getHtmlLinkData(summaryReportData.failedUrlToReportMap);
+        htmlSummaryData.passedLinks = this.getHtmlLinkData(summaryReportData.passedUrlToReportMap);
+
+        return pretty(`
+        <!DOCTYPE html>
+        <html lang='en'>
+            <head>
+                <meta charset="UTF-8">
+                <title>Accessibility Insights Summary Report</title>
+            </head>
+            <body>
+                ${this.getHtmlBody(htmlSummaryData)}
+            </body>
+        </html>
+        `);
+    }
+
+    private getHtmlBody(htmlSummaryData: HtmlSummaryData): string {
+        const totalUrlsScannedInfo = `
+        <b>
+            Total Urls Scanned - ${htmlSummaryData.failedLinks.length + htmlSummaryData.passedLinks.length}
+        </b>
+        `;
+        if (htmlSummaryData.failedLinks.length === 0 && htmlSummaryData.passedLinks.length === 0) {
+            return totalUrlsScannedInfo;
+        }
+
+        return `
+        ${totalUrlsScannedInfo}
+        <ul>
+            ${this.getFailedLinksHtml(htmlSummaryData)}
+            ${this.getPassedLinksHtml(htmlSummaryData)}
+        </ul>`;
+    }
+
+    private getFailedLinksHtml(htmlSummaryData: HtmlSummaryData): string {
+        if (htmlSummaryData.failedLinks.length === 0) {
+            return '';
+        }
+
+        return this.getLinksSection('Failed Urls', htmlSummaryData.failedLinks);
+    }
+
+    private getPassedLinksHtml(htmlSummaryData: HtmlSummaryData): string {
+        if (htmlSummaryData.passedLinks.length === 0) {
+            return '';
+        }
+
+        return this.getLinksSection('Passed Urls', htmlSummaryData.passedLinks);
+    }
+
+    private getLinksSection(sectionName: string, links: HtmlSummaryLink[]): string {
+        return `
+        <li>
+            ${sectionName}
+            <ul>
+                ${this.getHtmlLinks(links)}
+            </ul>
+        </li>`;
+    }
+
+    private getHtmlLinks(links: HtmlSummaryLink[]): string {
+        const htmlLinks: string[] = links.map((item) => {
+            return `
+            <li>
+                <a href='${item.link}'>${escapeHtml(item.fileName)}</a>
+            </li>`;
+        });
+
+        return htmlLinks.join('\n');
+    }
+
+    private getHtmlLinkData(urlMap: UrlToReportMap): HtmlSummaryLink[] {
+        const links: HtmlSummaryLink[] = [];
+
+        for (const url of Object.keys(urlMap)) {
+            links.push({
+                fileName: url,
+                link: urlMap[url],
+            });
+        }
+
+        return links;
+    }
+}

--- a/packages/cli/src/report/summary-report/json-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/json-summary-report-generator.spec.ts
@@ -18,7 +18,8 @@ describe(JsonSummaryReportGenerator, () => {
         [
             'has violations',
             {
-                urlToReportMap: { url1: 'file1' },
+                failedUrlToReportMap: { url1: 'file1' },
+                passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {
                     rule1WithALongName11111111111111111: 10,
                     rule2: 3,
@@ -28,7 +29,8 @@ describe(JsonSummaryReportGenerator, () => {
         [
             'has no violations',
             {
-                urlToReportMap: { url1: 'file1' },
+                failedUrlToReportMap: { url1: 'file1' },
+                passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {},
             } as SummaryReportData,
         ],

--- a/packages/cli/src/report/summary-report/json-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/json-summary-report-generator.spec.ts
@@ -24,6 +24,7 @@ describe(JsonSummaryReportGenerator, () => {
                     rule1WithALongName11111111111111111: 10,
                     rule2: 3,
                 },
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
         [
@@ -32,6 +33,7 @@ describe(JsonSummaryReportGenerator, () => {
                 failedUrlToReportMap: { url1: 'file1' },
                 passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {},
+                unScannableUrls: [],
             } as SummaryReportData,
         ],
     ])('logs violation summary when %s', async (testCaseName, testCase) => {

--- a/packages/cli/src/report/summary-report/summary-report-data.ts
+++ b/packages/cli/src/report/summary-report/summary-report-data.ts
@@ -11,5 +11,6 @@ export interface UrlToReportMap {
 
 export interface SummaryReportData {
     violationCountByRuleMap: ViolationCountMap;
-    urlToReportMap: UrlToReportMap;
+    failedUrlToReportMap: UrlToReportMap;
+    passedUrlToReportMap: UrlToReportMap;
 }

--- a/packages/cli/src/report/summary-report/summary-report-data.ts
+++ b/packages/cli/src/report/summary-report/summary-report-data.ts
@@ -13,4 +13,5 @@ export interface SummaryReportData {
     violationCountByRuleMap: ViolationCountMap;
     failedUrlToReportMap: UrlToReportMap;
     passedUrlToReportMap: UrlToReportMap;
+    unScannableUrls: string[];
 }

--- a/packages/cli/src/runner/file-command-runner.spec.ts
+++ b/packages/cli/src/runner/file-command-runner.spec.ts
@@ -3,160 +3,244 @@
 
 import 'reflect-metadata';
 
-import { AxeResults } from 'axe-core';
 import * as fs from 'fs';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ReportGenerator } from '../report/report-generator';
 import { ConsoleSummaryReportGenerator } from '../report/summary-report/console-summary-report-generator';
+import { HtmlSummaryReportGenerator } from '../report/summary-report/html-summary-report-generator';
 import { JsonSummaryReportGenerator } from '../report/summary-report/json-summary-report-generator';
+import { SummaryReportData, UrlToReportMap, ViolationCountMap } from '../report/summary-report/summary-report-data';
 import { AIScanner } from '../scanner/ai-scanner';
 import { AxeScanResults } from '../scanner/axe-scan-results';
 import { ScanArguments } from '../scanner/scan-arguments';
 import { FileCommandRunner } from './file-command-runner';
 
-// tslint:disable: no-empty no-unsafe-any no-any
-describe('FileCommandRunner', () => {
+// tslint:disable: no-object-literal-type-assertion non-literal-fs-path
+
+describe(FileCommandRunner, () => {
     let scannerMock: IMock<AIScanner>;
     let reportGeneratorMock: IMock<ReportGenerator>;
     let reportDiskWriterMock: IMock<ReportDiskWriter>;
     let fsMock: IMock<typeof fs>;
     let jsonSummaryReportGeneratorMock: IMock<JsonSummaryReportGenerator>;
+    let htmlSummaryReportGeneratorMock: IMock<HtmlSummaryReportGenerator>;
     let consoleSummaryReportGeneratorMock: IMock<ConsoleSummaryReportGenerator>;
     let testSubject: FileCommandRunner;
-    const testInputFile = 'innput file';
-    const htmlReportString = 'html report';
+    const testInputFile = 'input file';
     const testInput: ScanArguments = { inputFile: testInputFile, output: '/users/xyz' };
-    // tslint:disable-next-line: mocha-no-side-effect-code
 
-    describe('Run Command', () => {
+    beforeEach(() => {
+        scannerMock = Mock.ofType(AIScanner, MockBehavior.Strict);
+        reportGeneratorMock = Mock.ofType(ReportGenerator, MockBehavior.Strict);
+        reportDiskWriterMock = Mock.ofType(ReportDiskWriter, MockBehavior.Strict);
+        jsonSummaryReportGeneratorMock = Mock.ofType(JsonSummaryReportGenerator, MockBehavior.Strict);
+        htmlSummaryReportGeneratorMock = Mock.ofType(HtmlSummaryReportGenerator, MockBehavior.Strict);
+        consoleSummaryReportGeneratorMock = Mock.ofType(ConsoleSummaryReportGenerator, MockBehavior.Strict);
+        fsMock = Mock.ofInstance(fs, MockBehavior.Strict);
+
+        testSubject = new FileCommandRunner(
+            scannerMock.object,
+            reportGeneratorMock.object,
+            reportDiskWriterMock.object,
+            jsonSummaryReportGeneratorMock.object,
+            htmlSummaryReportGeneratorMock.object,
+            consoleSummaryReportGeneratorMock.object,
+            fsMock.object,
+        );
+    });
+
+    describe('runCommand', () => {
+        let fileContent: string;
+
         beforeEach(() => {
-            scannerMock = Mock.ofType<AIScanner>();
-            reportGeneratorMock = Mock.ofType<ReportGenerator>();
-            reportDiskWriterMock = Mock.ofType<ReportDiskWriter>();
-            jsonSummaryReportGeneratorMock = Mock.ofType<JsonSummaryReportGenerator>();
-            consoleSummaryReportGeneratorMock = Mock.ofType<ConsoleSummaryReportGenerator>();
-            fsMock = Mock.ofInstance(fs, MockBehavior.Strict);
-
-            testSubject = new FileCommandRunner(
-                scannerMock.object,
-                reportGeneratorMock.object,
-                reportDiskWriterMock.object,
-                jsonSummaryReportGeneratorMock.object,
-                consoleSummaryReportGeneratorMock.object,
-                fsMock.object,
-            );
-        });
-
-        afterEach(() => {
-            fsMock.verifyAll();
-            scannerMock.verifyAll();
-            reportGeneratorMock.verifyAll();
-            reportDiskWriterMock.verifyAll();
-            jsonSummaryReportGeneratorMock.verifyAll();
-            consoleSummaryReportGeneratorMock.verifyAll();
-        });
-
-        it('No Violation', async () => {
-            const lines = 'https://www.url1.com';
-            const jsonSummary = 'summary json';
-            const consoleSummary = 'console summary';
-            const scanResults = {
-                // tslint:disable-next-line: no-object-literal-type-assertion
-                results: { url: lines } as AxeResults,
-            } as AxeScanResults;
-
-            scannerMock
-                .setup((sm) => sm.scan(lines))
-                .returns(async () => Promise.resolve(scanResults))
-                .verifiable(Times.once());
-
-            reportGeneratorMock
-                .setup((rg) => rg.generateReport(scanResults))
-                .returns(() => htmlReportString)
-                .verifiable(Times.once());
-
-            reportDiskWriterMock
-                .setup((rdwm) => rdwm.writeToDirectory(testInput.output, lines, 'html', htmlReportString))
-                .returns(() => 'url1.html')
-                .verifiable(Times.once());
-
-            reportDiskWriterMock
-                .setup((rdwm) => rdwm.writeToDirectory(testInput.output, 'ViolationCountByRuleMap', 'json', jsonSummary))
-                .returns(() => 'summary.json')
-                .verifiable(Times.once());
-
-            jsonSummaryReportGeneratorMock
-                .setup((rdwm) => rdwm.generateReport(It.isAny()))
-                .returns(() => jsonSummary)
-                .verifiable(Times.once());
-
-            consoleSummaryReportGeneratorMock
-                .setup((rdwm) => rdwm.generateReport(It.isAny()))
-                .returns(() => consoleSummary)
-                .verifiable(Times.once());
-
             fsMock
-                .setup((fsm) => fsm.readFileSync(testInput.inputFile, 'UTF-8'))
-                .returns(() => lines)
+                .setup((f) => f.readFileSync(testInput.inputFile, 'UTF-8'))
+                .returns(() => fileContent)
                 .verifiable(Times.once());
+
+            setupScanAndReportWriteCalls();
+        });
+
+        it('with valid file content', async () => {
+            fileContent = `
+            pass-url-1\r\n
+            fail-url-1
+            un-scannable-url-1
+            pass-url-2\n
+            fail-url-2
+            un-scannable-url-2
+        `;
+            const allViolationsCountRuleMap: ViolationCountMap = {
+                'fail-url-1-rule-1': 1,
+                'fail-url-1-rule-2': 2,
+                'fail-url-2-rule-1': 1,
+                'fail-url-2-rule-2': 2,
+            };
+            const failedUrlToReportMap: UrlToReportMap = {
+                'fail-url-1': 'fail-url-1-report',
+                'fail-url-2': 'fail-url-2-report',
+            };
+
+            const passedUrlToReportMap: UrlToReportMap = {
+                'pass-url-1': 'pass-url-1-report',
+                'pass-url-2': 'pass-url-2-report',
+            };
+            const unScannableUrls = ['un-scannable-url-1', 'un-scannable-url-2'];
+
+            const expectedSummaryData: SummaryReportData = {
+                failedUrlToReportMap: failedUrlToReportMap,
+                passedUrlToReportMap: passedUrlToReportMap,
+                unScannableUrls: unScannableUrls,
+                violationCountByRuleMap: allViolationsCountRuleMap,
+            };
+
+            setupSummaryFileCreationCall(expectedSummaryData);
 
             await testSubject.runCommand(testInput);
         });
 
-        it('Violation, Duplication', async () => {
-            const lines = 'https://www.url1.com \n https://www.url1.com \n https://www.url2.com';
-            const jsonSummary = 'summary json';
-            const consoleSummary = 'console summary';
-            const scanResults = {
-                // tslint:disable-next-line: no-object-literal-type-assertion
-                results: {
-                    url: lines,
-                    violations: [
-                        {
-                            id: 'id1',
-                            nodes: [{}],
-                        },
-                    ],
-                } as AxeResults,
-            } as AxeScanResults;
+        it('with un scannable urls only', async () => {
+            fileContent = `
+            un-scannable-url-1
+            un-scannable-url-2
+            `;
 
-            scannerMock
-                .setup((sm) => sm.scan(It.isAny()))
-                .returns(async () => Promise.resolve(scanResults))
-                .verifiable(Times.exactly(2));
+            const expectedSummaryData: SummaryReportData = {
+                failedUrlToReportMap: {},
+                passedUrlToReportMap: {},
+                unScannableUrls: ['un-scannable-url-1', 'un-scannable-url-2'],
+                violationCountByRuleMap: {},
+            };
 
-            reportGeneratorMock
-                .setup((rg) => rg.generateReport(scanResults))
-                .returns(() => htmlReportString)
-                .verifiable(Times.exactly(2));
+            setupSummaryFileCreationCall(expectedSummaryData);
 
-            reportDiskWriterMock
-                .setup((rdwm) => rdwm.writeToDirectory(testInput.output, It.isAny(), 'html', htmlReportString))
-                .returns(() => 'url1.html')
-                .verifiable(Times.exactly(2));
+            await testSubject.runCommand(testInput);
+        });
 
-            reportDiskWriterMock
-                .setup((rdwm) => rdwm.writeToDirectory(testInput.output, 'ViolationCountByRuleMap', 'json', jsonSummary))
-                .returns(() => 'summary.json')
-                .verifiable(Times.once());
+        it('with invalid file content', async () => {
+            fileContent = `
+            \r\n
+        `;
 
-            jsonSummaryReportGeneratorMock
-                .setup((rdwm) => rdwm.generateReport(It.isAny()))
-                .returns(() => jsonSummary)
-                .verifiable(Times.once());
+            const expectedSummaryData: SummaryReportData = {
+                failedUrlToReportMap: {},
+                passedUrlToReportMap: {},
+                unScannableUrls: [],
+                violationCountByRuleMap: {},
+            };
 
-            consoleSummaryReportGeneratorMock
-                .setup((rdwm) => rdwm.generateReport(It.isAny()))
-                .returns(() => consoleSummary)
-                .verifiable(Times.once());
-
-            fsMock
-                .setup((fsm) => fsm.readFileSync(testInput.inputFile, 'UTF-8'))
-                .returns(() => lines)
-                .verifiable(Times.once());
+            setupSummaryFileCreationCall(expectedSummaryData);
 
             await testSubject.runCommand(testInput);
         });
     });
+    afterEach(() => {
+        fsMock.verifyAll();
+        scannerMock.verifyAll();
+        reportGeneratorMock.verifyAll();
+        reportDiskWriterMock.verifyAll();
+        jsonSummaryReportGeneratorMock.verifyAll();
+        htmlSummaryReportGeneratorMock.verifyAll();
+        consoleSummaryReportGeneratorMock.verifyAll();
+    });
+
+    function setupSummaryFileCreationCall(expectedSummaryData: SummaryReportData): void {
+        consoleSummaryReportGeneratorMock.setup((c) => c.generateReport(It.isValue(expectedSummaryData))).verifiable(Times.once());
+
+        jsonSummaryReportGeneratorMock
+            .setup((c) => c.generateReport(It.isValue(expectedSummaryData)))
+            .returns(() => 'json-summary-data')
+            .verifiable(Times.once());
+        htmlSummaryReportGeneratorMock
+            .setup((c) => c.generateReport(It.isValue(expectedSummaryData)))
+            .returns(() => 'html-summary-data')
+            .verifiable(Times.once());
+
+        reportDiskWriterMock
+            .setup((r) => r.writeToDirectory(testInput.output, 'scan-summary', 'json', 'json-summary-data'))
+            .returns(() => 'json-summary-data.json')
+            .verifiable(Times.once());
+
+        reportDiskWriterMock
+            .setup((r) => r.writeToDirectory(testInput.output, 'scan-summary', 'html', 'html-summary-data'))
+            .returns(() => 'html-summary-data.html')
+            .verifiable(Times.once());
+    }
+
+    function setupScanAndReportWriteCalls(): void {
+        scannerMock
+            .setup((s) => s.scan(It.is((url) => url.startsWith('pass'))))
+            .returns(async (url: string) => {
+                const result = {
+                    results: {
+                        passes: [
+                            {
+                                id: `${url}-rule-1`,
+                                nodes: [{}],
+                            },
+                        ],
+                        violations: [],
+                    },
+                } as AxeScanResults;
+
+                setupReportCreationCalls(url, result);
+
+                return result;
+            })
+            .verifiable(Times.atLeast(0));
+
+        scannerMock
+            .setup((s) => s.scan(It.is((url) => url.startsWith('fail'))))
+            .returns(async (url: string) => {
+                const result = {
+                    results: {
+                        passes: [
+                            {
+                                id: 'passed-id1',
+                                nodes: [{}],
+                            },
+                        ],
+                        violations: [
+                            {
+                                id: `${url}-rule-1`,
+                                nodes: [{}],
+                            },
+                            {
+                                id: `${url}-rule-2`,
+                                nodes: [{}, {}],
+                            },
+                        ],
+                    },
+                } as AxeScanResults;
+
+                setupReportCreationCalls(url, result);
+
+                return result;
+            })
+            .verifiable(Times.atLeast(0));
+
+        scannerMock
+            .setup((s) => s.scan(It.is((url) => url.startsWith('un-scannable'))))
+            .returns((url) =>
+                Promise.resolve({
+                    error: {
+                        message: 'unable to scan',
+                    },
+                } as AxeScanResults),
+            )
+            .verifiable(Times.atLeast(0));
+    }
+
+    function setupReportCreationCalls(url: string, result: AxeScanResults): void {
+        reportGeneratorMock
+            .setup((r) => r.generateReport(result))
+            .returns(() => 'report-content')
+            .verifiable(Times.once());
+
+        reportDiskWriterMock
+            .setup((r) => r.writeToDirectory(testInput.output, url, 'html', 'report-content'))
+            .returns(() => `${url}-report`)
+            .verifiable(Times.once());
+    }
 });

--- a/packages/cli/src/runner/file-command-runner.ts
+++ b/packages/cli/src/runner/file-command-runner.ts
@@ -39,7 +39,7 @@ export class FileCommandRunner implements CommandRunner {
     ) {}
 
     public async runCommand(scanArguments: ScanArguments): Promise<void> {
-        const spinner = new Spinner(`Running scanner...\n`);
+        const spinner = new Spinner(`Running scanner... %s \t`);
         spinner.start();
         // tslint:disable-next-line: no-any
         let promise = Promise.resolve();

--- a/packages/cli/src/runner/file-command-runner.ts
+++ b/packages/cli/src/runner/file-command-runner.ts
@@ -4,10 +4,11 @@
 import { Spinner } from 'cli-spinner';
 import * as fs from 'fs';
 import { inject, injectable } from 'inversify';
-import * as lodash from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ReportGenerator } from '../report/report-generator';
 import { ConsoleSummaryReportGenerator } from '../report/summary-report/console-summary-report-generator';
+import { HtmlSummaryReportGenerator } from '../report/summary-report/html-summary-report-generator';
 import { JsonSummaryReportGenerator } from '../report/summary-report/json-summary-report-generator';
 import { SummaryReportData } from '../report/summary-report/summary-report-data';
 import { AIScanner } from '../scanner/ai-scanner';
@@ -20,7 +21,9 @@ export class FileCommandRunner implements CommandRunner {
     // tslint:disable-next-line: no-object-literal-type-assertion
     private readonly summaryReportData = {
         violationCountByRuleMap: {},
-        urlToReportMap: {},
+        failedUrlToReportMap: {},
+        passedUrlToReportMap: {},
+        unScannableUrls: [],
     } as SummaryReportData;
 
     private readonly uniqueUrls = new Set();
@@ -30,6 +33,7 @@ export class FileCommandRunner implements CommandRunner {
         @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
         @inject(ReportDiskWriter) private readonly reportDiskWriter: ReportDiskWriter,
         @inject(JsonSummaryReportGenerator) private readonly jsonSummaryReportGenerator: JsonSummaryReportGenerator,
+        @inject(HtmlSummaryReportGenerator) private readonly htmlSummaryReportGenerator: HtmlSummaryReportGenerator,
         @inject(ConsoleSummaryReportGenerator) private readonly consoleSummaryReportGenerator: ConsoleSummaryReportGenerator,
         private readonly fileSystemObj: typeof fs = fs,
     ) {}
@@ -43,54 +47,69 @@ export class FileCommandRunner implements CommandRunner {
         try {
             const lines = this.fileSystemObj.readFileSync(scanArguments.inputFile, 'UTF-8').split(/\r?\n/);
 
-            lines.forEach((line) => {
-                // tslint:disable-next-line: no-parameter-reassignment
+            for (let line of lines) {
                 line = line.trim();
-                if (!lodash.isEmpty(line) && !this.uniqueUrls.has(line)) {
+                if (!isEmpty(line) && !this.uniqueUrls.has(line)) {
                     this.uniqueUrls.add(line);
-                    // tslint:disable-next-line: promise-function-async
-                    promise = promise.then(() => {
-                        return this.scanURL(line).then((reportContent) => {
-                            const reportName = this.reportDiskWriter.writeToDirectory(scanArguments.output, line, 'html', reportContent);
-                            this.summaryReportData.urlToReportMap[line] = reportName;
-                        });
-                    });
+                    await promise;
+                    promise = this.processUrl(line, scanArguments);
                 }
-            });
+            }
         } finally {
             spinner.stop();
         }
 
-        // tslint:disable-next-line: no-floating-promises
-        promise.then(() => {
-            console.log(this.consoleSummaryReportGenerator.generateReport(this.summaryReportData));
-            const jsonSummryReportName = this.reportDiskWriter.writeToDirectory(
-                scanArguments.output,
-                `ViolationCountByRuleMap`,
-                'json',
-                this.jsonSummaryReportGenerator.generateReport(this.summaryReportData),
-            );
-            console.log(`ViolationCountByRuleMap summary was saved in file ${jsonSummryReportName}`);
-        });
+        await promise;
+
+        await this.generateSummaryReport(scanArguments);
     }
 
-    private async scanURL(url: string): Promise<string> {
-        let axeResults: AxeScanResults;
+    private async generateSummaryReport(scanArguments: ScanArguments): Promise<void> {
+        console.log(this.consoleSummaryReportGenerator.generateReport(this.summaryReportData));
 
-        axeResults = await this.scanner.scan(url);
+        const jsonSummaryReportName = this.reportDiskWriter.writeToDirectory(
+            scanArguments.output,
+            `scan-summary`,
+            'json',
+            this.jsonSummaryReportGenerator.generateReport(this.summaryReportData),
+        );
+        console.log(`scan summary json was saved in file ${jsonSummaryReportName}`);
 
-        this.processURLScanResult(axeResults);
-
-        return this.reportGenerator.generateReport(axeResults);
+        const htmlSummaryReportName = this.reportDiskWriter.writeToDirectory(
+            scanArguments.output,
+            `scan-summary`,
+            'html',
+            this.htmlSummaryReportGenerator.generateReport(this.summaryReportData),
+        );
+        console.log(`scan summary html was saved in file ${htmlSummaryReportName}`);
     }
 
-    private processURLScanResult(axeResults: AxeScanResults): void {
-        axeResults.results.violations?.forEach((violation) => {
-            this.summaryReportData.violationCountByRuleMap[violation.id] =
-                // tslint:disable-next-line: strict-boolean-expressions
-                (this.summaryReportData.violationCountByRuleMap[violation.id]
-                    ? this.summaryReportData.violationCountByRuleMap[violation.id]
-                    : 0) + violation.nodes.length;
-        });
+    private async processUrl(url: string, scanArguments: ScanArguments): Promise<void> {
+        const axeResults = await this.scanner.scan(url);
+
+        if (isNil(axeResults.error)) {
+            const reportContent = this.reportGenerator.generateReport(axeResults);
+            const reportName = this.reportDiskWriter.writeToDirectory(scanArguments.output, url, 'html', reportContent);
+
+            this.processURLScanResult(url, reportName, axeResults);
+        } else {
+            this.summaryReportData.unScannableUrls.push(url);
+        }
+    }
+
+    private processURLScanResult(url: string, reportName: string, axeResults: AxeScanResults): void {
+        if (axeResults.results.violations?.length > 0) {
+            axeResults.results.violations.forEach((violation) => {
+                this.summaryReportData.violationCountByRuleMap[violation.id] =
+                    // tslint:disable-next-line: strict-boolean-expressions
+                    (this.summaryReportData.violationCountByRuleMap[violation.id]
+                        ? this.summaryReportData.violationCountByRuleMap[violation.id]
+                        : 0) + violation.nodes.length;
+            });
+
+            this.summaryReportData.failedUrlToReportMap[url] = reportName;
+        } else {
+            this.summaryReportData.passedUrlToReportMap[url] = reportName;
+        }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,6 +2321,11 @@
   dependencies:
     dotenv "*"
 
+"@types/escape-html@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-0.0.20.tgz#cae698714dd61ebee5ab3f2aeb9a34ba1011735a"
+  integrity sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -3953,7 +3958,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@^2.20.0, commander@~2.20.3:
+commander@^2.12.1, commander@^2.19.0, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4008,7 +4013,16 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-config-chain@^1.1.11:
+condense-newlines@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/condense-newlines/-/condense-newlines-0.2.1.tgz#3de985553139475d32502c83b02f60684d24c55f"
+  integrity sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-whitespace "^0.3.0"
+    kind-of "^3.0.2"
+
+config-chain@^1.1.11, config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
@@ -4655,6 +4669,16 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
+editorconfig@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
+
 electron-to-chromium@^1.3.390:
   version "1.3.412"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.412.tgz#da0475c653b48e5935f300aa9c875377bf8ddcf9"
@@ -4798,6 +4822,11 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
+
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -6212,6 +6241,11 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
+is-whitespace@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
+  integrity sha1-Fjnssb4DauxppUy7QBz77XEUq38=
+
 is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -6822,6 +6856,17 @@ jquery@^3.4.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
+js-beautify@^1.6.12:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.11.0.tgz#afb873dc47d58986360093dcb69951e8bcd5ded2"
+  integrity sha512-a26B+Cx7USQGSWnz9YxgJNMmML/QG2nqIaL7VVYPCXbqiKz8PN0waSNvroMtvAK6tY7g/wPdNWGEP+JTNIBr6A==
+  dependencies:
+    config-chain "^1.1.12"
+    editorconfig "^0.15.3"
+    glob "^7.1.3"
+    mkdirp "~1.0.3"
+    nopt "^4.0.3"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -7212,6 +7257,14 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lru-cache@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -7571,7 +7624,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
+mkdirp@*, mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -7805,7 +7858,7 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-nopt@^4.0.1:
+nopt@^4.0.1, nopt@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
   integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
@@ -8544,6 +8597,15 @@ pretty-format@^26.0.1:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
+  integrity sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=
+  dependencies:
+    condense-newlines "^0.2.1"
+    extend-shallow "^2.0.1"
+    js-beautify "^1.6.12"
+
 priorityqueuejs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz#2ee4f23c2560913e08c07ce5ccdd6de3df2c5af8"
@@ -8632,6 +8694,11 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.28:
   version "1.8.0"
@@ -9478,6 +9545,11 @@ shimmer@^1.1.0, shimmer@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -11043,6 +11115,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"


### PR DESCRIPTION
#### Description of changes

This will generate a basic summary html file. Look at the jest snapshot file to get  idea on how it will look.

Refactored file-command-runner & added support to capture unscannable urls
(unscannable urls list is not surfaced anywhere in the report yet)

Refactored unit tests for file-command-runner for better coverage

![scan](https://user-images.githubusercontent.com/29855291/81354657-0c506e00-9081-11ea-8313-25801f029d3d.gif)

![image](https://user-images.githubusercontent.com/29855291/81341724-df8f5d00-9066-11ea-868f-0264bdf27644.png)

![image](https://user-images.githubusercontent.com/29855291/81341710-d69e8b80-9066-11ea-808e-0a700289da6b.png)

![image](https://user-images.githubusercontent.com/29855291/81341818-064d9380-9067-11ea-8375-c0e4242ba728.png)


![image](https://user-images.githubusercontent.com/29855291/81341748-e9b15b80-9066-11ea-8ca1-c1fd502f63fa.png)



#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
