### PR TITLE
fix: Check response code before checking page content type

### DIFF
--- a/packages/cli/src/scanner/page.ts
+++ b/packages/cli/src/scanner/page.ts
@@ -56,7 +56,7 @@ export class Page {
         }
 
         if (!response.ok()) {
-            console.log('url navigation returned failed response', { statusCode: response.status().toString() });
+            console.log('The URL navigation returned an unsuccessful response code', { statusCode: response.status().toString() });
 
             return {
                 error: {

--- a/packages/cli/src/scanner/page.ts
+++ b/packages/cli/src/scanner/page.ts
@@ -55,6 +55,18 @@ export class Page {
             return { error: this.getScanErrorFromNavigationFailure((err as Error).message) };
         }
 
+        if (!response.ok()) {
+            console.log('url navigation returned failed response', { statusCode: response.status().toString() });
+
+            return {
+                error: {
+                    errorType: 'HttpErrorCode',
+                    responseStatusCode: response.status(),
+                    message: 'Page returned an unsuccessful response code',
+                },
+            };
+        }
+
         if (!this.isHtmlPage(response)) {
             const contentType = this.getContentType(response.headers());
 
@@ -66,18 +78,6 @@ export class Page {
                     errorType: 'InvalidContentType',
                     responseStatusCode: response.status(),
                     message: `Content type - ${contentType}`,
-                },
-            };
-        }
-
-        if (!response.ok()) {
-            console.log('url navigation returned failed response', { statusCode: response.status().toString() });
-
-            return {
-                error: {
-                    errorType: 'HttpErrorCode',
-                    responseStatusCode: response.status(),
-                    message: 'Page returned an unsuccessful response code',
                 },
             };
         }

--- a/packages/scanner/src/page.spec.ts
+++ b/packages/scanner/src/page.spec.ts
@@ -152,6 +152,38 @@ describe('Page', () => {
         expect(result).toEqual(errorResult);
     });
 
+    it('should check page response before cheking if page is not html', async () => {
+        const scanUrl = 'https://www.non-html-url.com';
+        const contentType = 'text/plain';
+
+        const errorResult: AxeScanResults = {
+            error: {
+                errorType: 'HttpErrorCode',
+                message: 'Page returned an unsuccessful response code',
+            },
+            pageResponseCode: 500,
+        };
+        const response: Puppeteer.Response = makeResponse({ contentType: contentType, statusCode: 500 });
+
+        gotoMock
+            .setup(async (goto) => goto(scanUrl, gotoOptions))
+            .returns(async () => Promise.resolve(response))
+            .verifiable(Times.once());
+
+        waitForNavigationMock.setup(async (wait) => wait(waitOptions)).verifiable(Times.once());
+
+        axePuppeteerMock.setup(async (o) => o.analyze()).verifiable(Times.never());
+        axePuppeteerFactoryMock
+            .setup(async (apfm) => apfm.createAxePuppeteer(page.puppeteerPage))
+            .returns(async () => Promise.resolve(axePuppeteerMock.object))
+            .verifiable(Times.once());
+
+        await page.create();
+        const result = await page.scanForA11yIssues(scanUrl);
+
+        expect(result).toEqual(errorResult);
+    });
+
     it('should analyze accessibility issues, even if error thrown when waitForNavigation', async () => {
         const scanUrl = 'https://www.example.com';
         const axeResults: AxeResults = createEmptyAxeResults(scanUrl);

--- a/packages/scanner/src/page.ts
+++ b/packages/scanner/src/page.ts
@@ -53,6 +53,18 @@ export class Page {
             return { error: this.getScanErrorFromNavigationFailure((err as Error).message), pageResponseCode: undefined };
         }
 
+        if (!response.ok()) {
+            this.log(LogLevel.error, url, 'url navigation returned failed response', { statusCode: response.status().toString() });
+
+            return {
+                error: {
+                    errorType: 'HttpErrorCode',
+                    message: 'Page returned an unsuccessful response code',
+                },
+                pageResponseCode: response.status(),
+            };
+        }
+
         if (!this.isHtmlPage(response)) {
             const contentType = this.getContentType(response.headers());
 
@@ -63,18 +75,6 @@ export class Page {
                 error: {
                     errorType: 'InvalidContentType',
                     message: `Content type - ${contentType}`,
-                },
-                pageResponseCode: response.status(),
-            };
-        }
-
-        if (!response.ok()) {
-            this.log(LogLevel.error, url, 'url navigation returned failed response', { statusCode: response.status().toString() });
-
-            return {
-                error: {
-                    errorType: 'HttpErrorCode',
-                    message: 'Page returned an unsuccessful response code',
                 },
                 pageResponseCode: response.status(),
             };

--- a/packages/scanner/src/page.ts
+++ b/packages/scanner/src/page.ts
@@ -54,7 +54,9 @@ export class Page {
         }
 
         if (!response.ok()) {
-            this.log(LogLevel.error, url, 'The URL navigation returned an unsuccessful response code', { statusCode: response.status().toString() });
+            this.log(LogLevel.error, url, 'The URL navigation returned an unsuccessful response code', {
+                statusCode: response.status().toString(),
+            });
 
             return {
                 error: {

--- a/packages/scanner/src/page.ts
+++ b/packages/scanner/src/page.ts
@@ -54,7 +54,7 @@ export class Page {
         }
 
         if (!response.ok()) {
-            this.log(LogLevel.error, url, 'url navigation returned failed response', { statusCode: response.status().toString() });
+            this.log(LogLevel.error, url, 'The URL navigation returned an unsuccessful response code', { statusCode: response.status().toString() });
 
             return {
                 error: {


### PR DESCRIPTION
#### Description of changes

- For a case like internal server error, the response code will be 500 and the page content will not be html.
- If we check the content first as we used to do, the error will be 'InvalidContentType' which is wrong.
- It should be 'HttpErrorCode', so if we check the reponse code first, we should be able to get the right error code.


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
