### PR TITLE
Set job manager max wall clock in sync with task run time

### DIFF
--- a/packages/resource-deployment/templates/on-demand-url-scan-schedule.template.json
+++ b/packages/resource-deployment/templates/on-demand-url-scan-schedule.template.json
@@ -6,7 +6,7 @@
     "jobSpecification": {
         "priority": 0,
         "constraints": {
-            "maxWallClockTime": "P2D",
+            "maxWallClockTime": "PT2H",
             "maxTaskRetryCount": 0
         },
         "jobManagerTask": {
@@ -21,7 +21,7 @@
                 }
             ],
             "constraints": {
-                "maxWallClockTime": "P1D",
+                "maxWallClockTime": "PT2H",
                 "retentionTime": "P3D",
                 "maxTaskRetryCount": 0
             },


### PR DESCRIPTION
#### Description of changes

Set job manager max wall clock in sync with task run time

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
