### PR TITLE
chore: enable https only on azure functions

### DIFF
--- a/packages/resource-deployment/templates/function-web-api-app-template.json
+++ b/packages/resource-deployment/templates/function-web-api-app-template.json
@@ -82,6 +82,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
+                "httpsOnly": true,
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/packages/resource-deployment/templates/function-web-workers-app-template.json
+++ b/packages/resource-deployment/templates/function-web-workers-app-template.json
@@ -75,6 +75,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
+                "httpsOnly": true,
                 "siteConfig": {
                     "appSettings": [
                         {


### PR DESCRIPTION
#### Description of changes

Enable https only on azure functions

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #497
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
