### PR TITLE
fix: move ip restriction step to API deployment

### DIFF
--- a/packages/resource-deployment/scripts/function-app-create.sh
+++ b/packages/resource-deployment/scripts/function-app-create.sh
@@ -151,18 +151,6 @@ function deployWebWorkersFunction {
     deployFunctionApp "web-workers-allyfuncapp" "${0%/*}/../templates/function-web-workers-app-template.json" "$webWorkersFuncAppName"
 }
 
-function restrictWebApiAccess {
-    echo "restricting access to APIM IP address"
-    apimIpAddress=$(az apim show --name "$apiManagementName" --resource-group "$resourceGroupName" --query "publicIpAddresses" -o tsv)
-    az functionapp config access-restriction add -g "$resourceGroupName" \
-                                                 -n "$webApiFuncAppName" \
-                                                 --rule-name "APIM" \
-                                                 --action "Allow" \
-                                                 --ip-address "$apimIpAddress" \
-                                                 --priority 100 1>/dev/null
-    
-}
-
 function enableManagedIdentityOnFunctions {
     getFunctionAppPrincipalId $webApiFuncAppName
     . "${0%/*}/key-vault-enable-msi.sh"
@@ -189,7 +177,6 @@ function setupAzureFunctions {
     runCommandsWithoutSecretsInParallel functionSetupProcesses
 
     enableManagedIdentityOnFunctions
-    restrictWebApiAccess
 
     functionSetupProcesses=(
         "publishWebApiScripts"


### PR DESCRIPTION
#### Description of changes

This will fix deployment failures in selftest due to accessing the APIM instance's IP address before it has been deployed

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
