### PR TITLE
feat(port-crawler-to-cli): set apify output directory

### DIFF
--- a/packages/crawler/src/apify-settings.spec.ts
+++ b/packages/crawler/src/apify-settings.spec.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+import { ApifySettings, setApifyEnvVars } from './apify-settings';
+
+describe('Apify settings', () => {
+    it('gets default settings', () => {
+        const expectedSettings: ApifySettings = {
+            APIFY_HEADLESS: 'true',
+        };
+
+        setApifyEnvVars();
+
+        Object.keys(expectedSettings).forEach((key: keyof ApifySettings) => {
+            expect(process.env[`${key}`]).toBe(expectedSettings[key]);
+        });
+    });
+
+    it('merges default settings', () => {
+        const settings: ApifySettings = {
+            APIFY_LOCAL_STORAGE_DIR: 'local storage dir',
+        };
+        const expectedSettings: ApifySettings = {
+            ...settings,
+            APIFY_HEADLESS: 'true',
+        };
+
+        setApifyEnvVars(settings);
+
+        Object.keys(expectedSettings).forEach((key: keyof ApifySettings) => {
+            expect(process.env[`${key}`]).toBe(expectedSettings[key]);
+        });
+    });
+
+    it('overrides default settings', () => {
+        const overrideSettings: ApifySettings = {
+            APIFY_HEADLESS: 'false',
+            APIFY_LOCAL_STORAGE_DIR: 'local storage dir',
+        };
+
+        setApifyEnvVars(overrideSettings);
+
+        Object.keys(overrideSettings).forEach((key: keyof ApifySettings) => {
+            expect(process.env[`${key}`]).toBe(overrideSettings[key]);
+        });
+    });
+});

--- a/packages/crawler/src/apify-settings.ts
+++ b/packages/crawler/src/apify-settings.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export interface ApifySettings {
+    APIFY_HEADLESS?: string;
+    APIFY_LOCAL_STORAGE_DIR?: string;
+}
+
+const defaultSettings: ApifySettings = {
+    APIFY_HEADLESS: 'true',
+};
+
+export function setApifyEnvVars(settings?: ApifySettings): void {
+    const allSettings = {
+        ...defaultSettings,
+        ...settings,
+    };
+    Object.keys(allSettings).forEach((key: keyof ApifySettings) => {
+        process.env[`${key}`] = allSettings[key];
+    });
+}

--- a/packages/crawler/src/crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler-engine.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import Apify, { PuppeteerCrawlerOptions } from 'apify';
+import Apify from 'apify';
 import { IMock, It, Mock } from 'typemoq';
 import { ApifyMainFunc, CrawlerEngine } from './crawler-engine';
 import { CrawlerFactory } from './crawler-factory';
@@ -62,7 +62,6 @@ describe(CrawlerEngine, () => {
 
     it('Run crawler with output dir specified', async () => {
         const outputDir = 'output dir';
-        const prevApifyStorageDir = 'prev output dir';
 
         // Env variable must be set when request queue and page processor are created
         setupCreateRequestQueue(() => {
@@ -76,14 +75,10 @@ describe(CrawlerEngine, () => {
 
         crawlerEngine = new CrawlerEngine(pageProcessorFactoryMock.object, crawlerFactoryMock.object, runApifyMock.object);
 
-        process.env.APIFY_LOCAL_STORAGE_DIR = prevApifyStorageDir;
-
         await crawlerEngine.start({
             baseUrl,
             localOutputDir: outputDir,
         });
-
-        expect(process.env.APIFY_LOCAL_STORAGE_DIR).toBe(prevApifyStorageDir);
     });
 
     afterEach(() => {
@@ -123,7 +118,7 @@ describe(CrawlerEngine, () => {
         puppeteerCrawlerMock.setup((pc) => pc.run()).verifiable();
     }
 
-    function setupCreatePuppeteerCrawler(crawlerOptions: PuppeteerCrawlerOptions): void {
+    function setupCreatePuppeteerCrawler(crawlerOptions: Apify.PuppeteerCrawlerOptions): void {
         crawlerFactoryMock
             .setup((cf) => cf.createPuppeteerCrawler(crawlerOptions))
             .returns(() => puppeteerCrawlerMock.object)

--- a/packages/crawler/src/crawler-engine.ts
+++ b/packages/crawler/src/crawler-engine.ts
@@ -3,12 +3,14 @@
 import Apify from 'apify';
 // @ts-ignore
 import * as cheerio from 'cheerio';
+import { isNil } from 'lodash';
 import { ApifyFactory, CrawlerFactory } from './crawler-factory';
 import { ClassicPageProcessorFactory } from './page-processors/classic-page-processor-factory';
 import { PageProcessorFactory } from './page-processors/page-processor-factory';
 
 export interface CrawlerRunOptions {
     baseUrl: string;
+    localOutputDir?: string;
     // existingUrls?: string[];
     // discoveryPatterns?: string[];
     // simulate?: boolean;
@@ -25,12 +27,15 @@ export class CrawlerEngine {
     ) {}
 
     public async start(crawlerRunOptions: CrawlerRunOptions): Promise<void> {
+        const oldLocalOutputDir = this.swapOutputDir(crawlerRunOptions.localOutputDir);
+
         // const requestList = await this.crawlerFactory.createRequestList(crawlerRunOptions.existingUrls);
         const requestQueue = await this.crawlerFactory.createRequestQueue(crawlerRunOptions.baseUrl);
         const pageProcessor = this.pageProcessorFactory.createPageProcessor({
             baseUrl: crawlerRunOptions.baseUrl,
             requestQueue,
         });
+
         this.runApify(async () => {
             const crawler = this.crawlerFactory.createPuppeteerCrawler({
                 // requestList,
@@ -41,5 +46,20 @@ export class CrawlerEngine {
             });
             await crawler.run();
         });
+
+        this.setLocalOutputDir(oldLocalOutputDir);
+    }
+
+    private swapOutputDir(outputDir?: string): string {
+        const oldValue = process.env.APIFY_LOCAL_STORAGE_DIR;
+        if (!isNil(outputDir)) {
+            this.setLocalOutputDir(outputDir);
+        }
+
+        return oldValue;
+    }
+
+    private setLocalOutputDir(outputDir: string): void {
+        process.env.APIFY_LOCAL_STORAGE_DIR = outputDir;
     }
 }

--- a/packages/crawler/src/crawler-engine.ts
+++ b/packages/crawler/src/crawler-engine.ts
@@ -4,6 +4,7 @@ import Apify from 'apify';
 // @ts-ignore
 import * as cheerio from 'cheerio';
 import { isNil } from 'lodash';
+import { setApifyEnvVars } from './apify-settings';
 import { ApifyFactory, CrawlerFactory } from './crawler-factory';
 import { ClassicPageProcessorFactory } from './page-processors/classic-page-processor-factory';
 import { PageProcessorFactory } from './page-processors/page-processor-factory';
@@ -27,7 +28,9 @@ export class CrawlerEngine {
     ) {}
 
     public async start(crawlerRunOptions: CrawlerRunOptions): Promise<void> {
-        const oldLocalOutputDir = this.swapOutputDir(crawlerRunOptions.localOutputDir);
+        if (!isNil(crawlerRunOptions.localOutputDir)) {
+            this.setLocalOutputDir(crawlerRunOptions.localOutputDir);
+        }
 
         // const requestList = await this.crawlerFactory.createRequestList(crawlerRunOptions.existingUrls);
         const requestQueue = await this.crawlerFactory.createRequestQueue(crawlerRunOptions.baseUrl);
@@ -46,20 +49,9 @@ export class CrawlerEngine {
             });
             await crawler.run();
         });
-
-        this.setLocalOutputDir(oldLocalOutputDir);
-    }
-
-    private swapOutputDir(outputDir?: string): string {
-        const oldValue = process.env.APIFY_LOCAL_STORAGE_DIR;
-        if (!isNil(outputDir)) {
-            this.setLocalOutputDir(outputDir);
-        }
-
-        return oldValue;
     }
 
     private setLocalOutputDir(outputDir: string): void {
-        process.env.APIFY_LOCAL_STORAGE_DIR = outputDir;
+        setApifyEnvVars({ APIFY_LOCAL_STORAGE_DIR: outputDir });
     }
 }


### PR DESCRIPTION
#### Description of changes

Apify doesn't provide a way to set the output directory besides setting the APIFY_LOCAL_STORAGE_DIR environment variable. This PR will allow us to pass in an outputDirectory parameter and set the env variable as part of running the crawler.

This PR also sets APIFY_HEADLESS to true by default.

#### Pull request checklist

- [x] Addresses an existing issue: #1760045
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
