### PR TITLE
feat(port-crawler-to-cli): Set max urls to crawl

### DIFF
--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -50,4 +50,22 @@ describe(CrawlerConfiguration, () => {
             expect(discoveryPatterns).toBe(expectedDiscoveryPatterns);
         });
     });
+
+    describe('getMaxRequestsPerCrawl', () => {
+        it('with no value provided', () => {
+            expect(pageProcessorFactory.getMaxRequestsPerCrawl(undefined)).toBe(100);
+        });
+
+        it('with +ve value provided', () => {
+            expect(pageProcessorFactory.getMaxRequestsPerCrawl(10)).toBe(10);
+        });
+
+        it('with -ve value provided', () => {
+            expect(pageProcessorFactory.getMaxRequestsPerCrawl(-10)).toBe(100);
+        });
+
+        it('with zero value provided', () => {
+            expect(pageProcessorFactory.getMaxRequestsPerCrawl(0)).toBe(100);
+        });
+    });
 });

--- a/packages/crawler/src/crawler/crawler-configuration.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.ts
@@ -16,4 +16,8 @@ export class CrawlerConfiguration {
     public getDefaultSelectors(selectors: string[]): string[] {
         return selectors === undefined || selectors.length === 0 ? ['button'] : selectors;
     }
+
+    public getMaxRequestsPerCrawl(maxRequestsPerCrawl: number): number {
+        return maxRequestsPerCrawl === undefined || maxRequestsPerCrawl <= 0 ? 100 : maxRequestsPerCrawl;
+    }
 }

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -7,7 +7,6 @@ require = require('esm')(module); // support ES6 module syntax for Office Fabric
 export { CrawlerEngine } from './crawler/crawler-engine';
 export { CrawlerRunOptions } from './types/run-options';
 
-import { System } from 'common';
 import * as dotenv from 'dotenv';
 import * as yargs from 'yargs';
 import { CrawlerEngine } from './crawler/crawler-engine';
@@ -17,13 +16,14 @@ interface Arguments {
     simulate: boolean;
     selectors: string[];
     output: string;
+    maxUrls: number;
 }
 
 (async () => {
     dotenv.config();
 
     const args = (yargs
-        .usage('Usage: $0 --url <url> [--simulate] [--selectors <selector1 ...>] [--output]')
+        .usage('Usage: $0 --url <url> [--simulate] [--selectors <selector1 ...>] [--output] [--maxUrls]')
         .options({
             url: {
                 type: 'string',
@@ -45,6 +45,13 @@ interface Arguments {
                 type: 'string',
                 describe: `Output directory`,
             },
+            maxUrls: {
+                type: 'number',
+                describe: ` Maximum number of pages that the crawler will open. The crawl will stop when this limit is reached.
+                            The default is 100.
+                            Note that in cases of parallel crawling, the actual number of pages visited might be slightly higher than this value.`,
+                default: 100,
+            },
         })
         .describe('help', 'Print command line options').argv as unknown) as Arguments;
 
@@ -55,8 +62,9 @@ interface Arguments {
         simulate: args.simulate,
         selectors: args.selectors,
         localOutputDir: args.output,
+        maxRequestsPerCrawl: args.maxUrls,
     });
 })().catch((error) => {
-    console.log('Exception: ', System.serializeError(error));
+    console.log('Exception: ', error);
     process.exit(1);
 });

--- a/packages/crawler/src/types/run-options.ts
+++ b/packages/crawler/src/types/run-options.ts
@@ -10,6 +10,7 @@ export interface CrawlerRunOptions {
     simulate?: boolean;
     selectors?: string[];
     localOutputDir?: string;
+    maxRequestsPerCrawl?: number;
 }
 
 export interface PageProcessorOptions {


### PR DESCRIPTION
#### Description of changes
  - Add another crawler option  that set the number of pages that the crawler will open. The crawl will stop when this limit is reached.
  - The default is 100.

**Note that in cases of parallel crawling, the actual number of pages visited might be slightly higher than this value.**

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
