### PR TITLE
feat(port-crawler-to-cli): Add option to restart crawl

### DIFF
--- a/packages/crawler/src/apify-resources/resource-creator.spec.ts
+++ b/packages/crawler/src/apify-resources/resource-creator.spec.ts
@@ -3,60 +3,112 @@
 import 'reflect-metadata';
 
 import Apify from 'apify';
-import { IMock, Mock } from 'typemoq';
+import * as fs from 'fs';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { apifySettingsHandler, ApifySettingsHandler } from '../apify-settings';
 import { getPromisableDynamicMock } from '../test-utilities/promisable-mock';
 import { ApifyResourceCreator } from './resource-creator';
 
 describe(ApifyResourceCreator, () => {
     let apifyMock: IMock<typeof Apify>;
+    let settingsHandlerMock: IMock<typeof apifySettingsHandler>;
+    let fsMock: IMock<typeof fs>;
+    let queueMock: IMock<Apify.RequestQueue>;
+
     let apifyResourceCreator: ApifyResourceCreator;
 
     const url = 'url';
+    const requestQueueName = 'scanRequests';
 
     beforeEach(() => {
         apifyMock = Mock.ofType<typeof Apify>();
-        apifyResourceCreator = new ApifyResourceCreator(apifyMock.object);
+        settingsHandlerMock = Mock.ofType<ApifySettingsHandler>();
+        fsMock = Mock.ofType<typeof fs>();
+        queueMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestQueue>());
+        apifyResourceCreator = new ApifyResourceCreator(apifyMock.object, settingsHandlerMock.object, fsMock.object);
     });
 
     afterEach(() => {
         apifyMock.verifyAll();
+        settingsHandlerMock.verifyAll();
+        fsMock.verifyAll();
     });
 
-    it('createRequestQueue', async () => {
-        const queueMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestQueue>());
+    describe('createRequestQueue', () => {
+        it('with empty=false', async () => {
+            setupCreateRequestQueue();
+            // tslint:disable-next-line: no-unsafe-any
+            fsMock.setup((fsm) => fsm.rmdirSync(It.isAny(), It.isAny())).verifiable(Times.never());
+
+            const queue = await apifyResourceCreator.createRequestQueue(url);
+
+            expect(queue).toBe(queueMock.object);
+        });
+
+        it('with empty=true and dir exists', async () => {
+            setupClearRequestQueue(true);
+            setupCreateRequestQueue();
+
+            const queue = await apifyResourceCreator.createRequestQueue(url, true);
+
+            expect(queue).toBe(queueMock.object);
+        });
+
+        it('with empty=true and dir does not exist', async () => {
+            setupClearRequestQueue(false);
+            setupCreateRequestQueue();
+
+            const queue = await apifyResourceCreator.createRequestQueue(url, true);
+
+            expect(queue).toBe(queueMock.object);
+        });
+    });
+
+    describe('createRequestList', () => {
+        it('with undefined list', async () => {
+            const listMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestList>());
+            apifyMock
+                .setup((a) => a.openRequestList('existingUrls', []))
+                .returns(async () => Promise.resolve(listMock.object))
+                .verifiable();
+
+            const list = await apifyResourceCreator.createRequestList(undefined);
+
+            expect(list).toBe(listMock.object);
+        });
+
+        it('with defined list', async () => {
+            const existingUrls = [url];
+            const listMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestList>());
+            apifyMock
+                .setup((a) => a.openRequestList('existingUrls', existingUrls))
+                .returns(async () => Promise.resolve(listMock.object))
+                .verifiable();
+
+            const list = await apifyResourceCreator.createRequestList(existingUrls);
+
+            expect(list).toBe(listMock.object);
+        });
+    });
+
+    function setupClearRequestQueue(dirExists: boolean): void {
+        const localStorageDir = 'storage dir';
+        const requestQueueDir = `${localStorageDir}/${requestQueueName}/`;
+        settingsHandlerMock
+            .setup((sh) => sh.getApifySettings())
+            .returns(() => {
+                return { APIFY_LOCAL_STORAGE_DIR: localStorageDir };
+            });
+        fsMock.setup((fsm) => fsm.existsSync(requestQueueDir)).returns(() => dirExists);
+        fsMock.setup((fsm) => fsm.rmdirSync(requestQueueDir, { recursive: true })).verifiable(dirExists ? Times.once() : Times.never());
+    }
+
+    function setupCreateRequestQueue(): void {
         apifyMock
-            .setup((a) => a.openRequestQueue())
+            // tslint:disable-next-line: no-unsafe-any
+            .setup((a) => a.openRequestQueue(requestQueueName))
             .returns(async () => Promise.resolve(queueMock.object))
             .verifiable();
         queueMock.setup((q) => q.addRequest({ url: url })).verifiable();
-
-        const queue = await apifyResourceCreator.createRequestQueue(url);
-
-        expect(queue).toBe(queueMock.object);
-    });
-
-    it('createRequestList with undefined list', async () => {
-        const listMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestList>());
-        apifyMock
-            .setup((a) => a.openRequestList('existingUrls', []))
-            .returns(async () => Promise.resolve(listMock.object))
-            .verifiable();
-
-        const list = await apifyResourceCreator.createRequestList(undefined);
-
-        expect(list).toBe(listMock.object);
-    });
-
-    it('createRequestList with defined list', async () => {
-        const existingUrls = [url];
-        const listMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestList>());
-        apifyMock
-            .setup((a) => a.openRequestList('existingUrls', existingUrls))
-            .returns(async () => Promise.resolve(listMock.object))
-            .verifiable();
-
-        const list = await apifyResourceCreator.createRequestList(existingUrls);
-
-        expect(list).toBe(listMock.object);
-    });
+    }
 });

--- a/packages/crawler/src/apify-settings.spec.ts
+++ b/packages/crawler/src/apify-settings.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import 'reflect-metadata';
-import { ApifySettings, setApifySettings } from './apify-settings';
+import { ApifySettings, apifySettingsHandler } from './apify-settings';
 
 describe('Apify settings', () => {
     const defaultEnv: ApifySettings = {
@@ -25,7 +25,7 @@ describe('Apify settings', () => {
 
         verifyEnvVarsSet(defaultEnv);
 
-        setApifySettings(overrideSettings);
+        apifySettingsHandler.setApifySettings(overrideSettings);
 
         verifyEnvVarsSet(overrideSettings);
     });
@@ -42,7 +42,7 @@ describe('Apify settings', () => {
         process.env.APIFY_LOCAL_STORAGE_DIR = presetLocalStorageDir;
         verifyEnvVarsSet(expectedEnvVars);
 
-        setApifySettings(settings);
+        apifySettingsHandler.setApifySettings(settings);
 
         verifyEnvVarsSet(expectedEnvVars);
     });

--- a/packages/crawler/src/apify-settings.ts
+++ b/packages/crawler/src/apify-settings.ts
@@ -6,10 +6,23 @@ export interface ApifySettings {
     APIFY_LOCAL_STORAGE_DIR?: string;
 }
 
-export function setApifySettings(settings?: ApifySettings): void {
-    Object.keys(settings).forEach((key: keyof ApifySettings) => {
-        if (settings[key] !== undefined) {
-            process.env[`${key}`] = settings[key];
-        }
-    });
+export interface ApifySettingsHandler {
+    setApifySettings(settings: ApifySettings): void;
+    getApifySettings(): ApifySettings;
 }
+
+export const apifySettingsHandler: ApifySettingsHandler = {
+    setApifySettings(settings: ApifySettings): void {
+        Object.keys(settings).forEach((key: keyof ApifySettings) => {
+            if (settings[key] !== undefined) {
+                process.env[`${key}`] = settings[key];
+            }
+        });
+    },
+
+    getApifySettings(): ApifySettings {
+        return {
+            ...process.env,
+        };
+    },
+};

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
+import { IMock, Mock } from 'typemoq';
+import { ApifySettings, ApifySettingsHandler } from '../apify-settings';
 import { CrawlerConfiguration } from './crawler-configuration';
 
 class TestableCrawlerConfiguration extends CrawlerConfiguration {
@@ -19,9 +21,11 @@ class TestableCrawlerConfiguration extends CrawlerConfiguration {
 
 describe(CrawlerConfiguration, () => {
     let crawlerConfig: TestableCrawlerConfiguration;
+    let apifySettingsHandlerMock: IMock<ApifySettingsHandler>;
 
     beforeEach(() => {
-        crawlerConfig = new TestableCrawlerConfiguration();
+        apifySettingsHandlerMock = Mock.ofType<ApifySettingsHandler>();
+        crawlerConfig = new TestableCrawlerConfiguration(apifySettingsHandlerMock.object);
     });
 
     describe('getDiscoveryPattern', () => {
@@ -69,20 +73,58 @@ describe(CrawlerConfiguration, () => {
         });
     });
 
-    it('setDefaultApifySettings', () => {
-        process.env.APIFY_HEADLESS = 'apify headless value';
+    describe('apify settings', () => {
+        let existingSettings: ApifySettings;
 
-        crawlerConfig.setDefaultApifySettings();
+        const prevApifyHeadless = 'prev apify headless value';
+        const prevApifyStorageDir = 'prev apify storage dir';
 
-        expect(process.env.APIFY_HEADLESS).toBe('1');
-    });
+        const defaultApifyHeadless = '1';
+        const defaultApifyStorageDir = './crawler_storage';
 
-    it('setLocalOutputDir', () => {
-        process.env.APIFY_LOCAL_STORAGE_DIR = 'previously set local output dir';
-        const localOutputDir = 'new local output dir';
+        beforeEach(() => {
+            existingSettings = {
+                APIFY_HEADLESS: prevApifyHeadless,
+                APIFY_LOCAL_STORAGE_DIR: prevApifyStorageDir,
+            };
+            apifySettingsHandlerMock.setup((ash) => ash.getApifySettings()).returns(() => existingSettings);
+        });
 
-        crawlerConfig.setLocalOutputDir(localOutputDir);
+        it('setDefaultApifySettings does not override existing APIFY_LOCAL_STORAGE_DIR', () => {
+            const expectedSettings = {
+                APIFY_HEADLESS: defaultApifyHeadless,
+                APIFY_LOCAL_STORAGE_DIR: prevApifyStorageDir,
+            };
+            apifySettingsHandlerMock.setup((ash) => ash.setApifySettings(expectedSettings)).verifiable();
 
-        expect(process.env.APIFY_LOCAL_STORAGE_DIR).toBe(localOutputDir);
+            crawlerConfig.setDefaultApifySettings();
+
+            apifySettingsHandlerMock.verifyAll();
+        });
+
+        it('setDefaultApifySettings sets APIFY_LOCAL_STORAGE_DIR if currently empty', () => {
+            const expectedSettings = {
+                APIFY_HEADLESS: defaultApifyHeadless,
+                APIFY_LOCAL_STORAGE_DIR: defaultApifyStorageDir,
+            };
+            apifySettingsHandlerMock.setup((ash) => ash.setApifySettings(expectedSettings)).verifiable();
+            existingSettings.APIFY_LOCAL_STORAGE_DIR = undefined;
+
+            crawlerConfig.setDefaultApifySettings();
+
+            apifySettingsHandlerMock.verifyAll();
+        });
+
+        it('setLocalOutputDir', () => {
+            const localOutputDir = 'new local output dir';
+            const expectedSettings = {
+                APIFY_LOCAL_STORAGE_DIR: localOutputDir,
+            };
+            apifySettingsHandlerMock.setup((ash) => ash.setApifySettings(expectedSettings)).verifiable();
+
+            crawlerConfig.setLocalOutputDir(localOutputDir);
+
+            apifySettingsHandlerMock.verifyAll();
+        });
     });
 });

--- a/packages/crawler/src/crawler/crawler-configuration.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { isEmpty } from 'lodash';
 import * as url from 'url';
-import { ApifySettings, setApifySettings } from '../apify-settings';
+import { ApifySettings, ApifySettingsHandler, apifySettingsHandler } from '../apify-settings';
 
 export class CrawlerConfiguration {
-    private static readonly defaultSettings: ApifySettings = {
-        APIFY_HEADLESS: '1',
-    };
+    public constructor(private readonly settingsHandler: ApifySettingsHandler = apifySettingsHandler) {}
 
     public getDiscoveryPattern(baseUrl: string, discoveryPatterns: string[]): string[] {
         return discoveryPatterns === undefined ? this.getDefaultDiscoveryPattern(baseUrl) : discoveryPatterns;
@@ -27,10 +26,21 @@ export class CrawlerConfiguration {
     }
 
     public setDefaultApifySettings(): void {
-        setApifySettings(CrawlerConfiguration.defaultSettings);
+        this.settingsHandler.setApifySettings(this.getDefaultApifySettings());
     }
 
     public setLocalOutputDir(outputDir: string): void {
-        setApifySettings({ APIFY_LOCAL_STORAGE_DIR: outputDir });
+        this.settingsHandler.setApifySettings({ APIFY_LOCAL_STORAGE_DIR: outputDir });
+    }
+
+    private getDefaultApifySettings(): ApifySettings {
+        const currentSettings = this.settingsHandler.getApifySettings();
+
+        return {
+            APIFY_HEADLESS: '1',
+            APIFY_LOCAL_STORAGE_DIR: isEmpty(currentSettings.APIFY_LOCAL_STORAGE_DIR)
+                ? './crawler_storage'
+                : currentSettings.APIFY_LOCAL_STORAGE_DIR,
+        };
     }
 }

--- a/packages/crawler/src/crawler/crawler-engine.ts
+++ b/packages/crawler/src/crawler/crawler-engine.ts
@@ -29,7 +29,7 @@ export class CrawlerEngine {
         this.crawlerConfiguration.setLocalOutputDir(crawlerRunOptions.localOutputDir);
 
         const requestList = await this.resourceCreator.createRequestList(crawlerRunOptions.existingUrls);
-        const requestQueue = await this.resourceCreator.createRequestQueue(crawlerRunOptions.baseUrl);
+        const requestQueue = await this.resourceCreator.createRequestQueue(crawlerRunOptions.baseUrl, crawlerRunOptions.restartCrawl);
 
         const pageProcessor = this.pageProcessorFactory.createPageProcessor(
             {

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -21,13 +21,14 @@ interface Arguments {
     selectors: string[];
     output: string;
     maxUrls: number;
+    restart: boolean;
 }
 
 (async () => {
     dotenv.config();
 
     const args = (yargs
-        .usage('Usage: $0 --url <url> --simulate <simulate> [--selectors <selector1 ...>] --output <output> --maxUrls <maxUrls>')
+        .usage('Usage: $0 --url <url> --simulate <simulate> [--selectors <selector1 ...>] --output <output> --maxUrls <maxUrls> --restart')
         .options({
             url: {
                 type: 'string',
@@ -47,7 +48,7 @@ interface Arguments {
             },
             output: {
                 type: 'string',
-                describe: `Output directory`,
+                describe: `Output directory. Defaults to the value of APIFY_LOCAL_STORAGE_DIR, if set, or ./crawler_storage, if not.`,
             },
             maxUrls: {
                 type: 'number',
@@ -55,6 +56,12 @@ interface Arguments {
                             The default is 100.
                             Note that in cases of parallel crawling, the actual number of pages visited might be slightly higher than this value.`,
                 default: 100,
+            },
+            restart: {
+                type: 'boolean',
+                describe:
+                    'if this flag is set, clear the queue of all pending and handled requests before crawling, otherwise resume the crawl from the last request in the queue.',
+                default: false,
             },
         })
         .describe('help', 'Print command line options').argv as unknown) as Arguments;
@@ -71,6 +78,7 @@ interface Arguments {
         selectors: args.selectors,
         localOutputDir: args.output,
         maxRequestsPerCrawl: args.maxUrls,
+        restartCrawl: args.restart,
     });
 })().catch((error) => {
     console.log('Exception: ', System.serializeError(error));

--- a/packages/crawler/src/types/run-options.ts
+++ b/packages/crawler/src/types/run-options.ts
@@ -11,6 +11,7 @@ export interface CrawlerRunOptions {
     selectors?: string[];
     localOutputDir?: string;
     maxRequestsPerCrawl?: number;
+    restartCrawl?: boolean;
 }
 
 export interface PageProcessorOptions {


### PR DESCRIPTION
#### Description of changes

Add the --restart flag and empty the request queue by deleting that directory if it is provided. Otherwise, the crawl will continue from the last request in the queue.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
