### PR TITLE
feat(port-crawler-to-cli): Add List of URLs to crawl 

### DIFF
--- a/packages/crawler/src/apify/apify-resource-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-resource-creator.spec.ts
@@ -84,7 +84,7 @@ describe(ApifyResourceCreator, () => {
             expect(queue).toBe(queueMock.object);
         });
 
-        it('with inputFile', async () => {
+        it('with existing urls"', async () => {
             const existingUrls = ['url1', 'url2'];
 
             setupCreateRequestQueue();

--- a/packages/crawler/src/apify/apify-resource-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-resource-creator.spec.ts
@@ -3,7 +3,6 @@
 import 'reflect-metadata';
 
 import Apify from 'apify';
-import { Url } from 'common';
 import * as fs from 'fs';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { apifySettingsHandler, ApifySettingsHandler } from '../apify/apify-settings';
@@ -15,7 +14,6 @@ describe(ApifyResourceCreator, () => {
     let settingsHandlerMock: IMock<typeof apifySettingsHandler>;
     let fsMock: IMock<typeof fs>;
     let queueMock: IMock<Apify.RequestQueue>;
-    let urlMock: IMock<typeof Url>;
 
     let apifyResourceCreator: ApifyResourceCreator;
 
@@ -27,15 +25,13 @@ describe(ApifyResourceCreator, () => {
         settingsHandlerMock = Mock.ofType<ApifySettingsHandler>();
         fsMock = Mock.ofType<typeof fs>();
         queueMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestQueue>());
-        urlMock = Mock.ofType<typeof Url>();
-        apifyResourceCreator = new ApifyResourceCreator(urlMock.object, apifyMock.object, settingsHandlerMock.object, fsMock.object);
+        apifyResourceCreator = new ApifyResourceCreator(apifyMock.object, settingsHandlerMock.object, fsMock.object);
     });
 
     afterEach(() => {
         apifyMock.verifyAll();
         settingsHandlerMock.verifyAll();
         fsMock.verifyAll();
-        urlMock.verifyAll();
     });
 
     describe('createRequestQueue', () => {
@@ -43,10 +39,6 @@ describe(ApifyResourceCreator, () => {
             setupCreateRequestQueue();
             // tslint:disable-next-line: no-unsafe-any
             fsMock.setup((fsm) => fsm.rmdirSync(It.isAny(), It.isAny())).verifiable(Times.never());
-            urlMock
-                .setup((um) => um.getRootUrl(url))
-                .returns(() => url)
-                .verifiable(Times.once());
 
             const queue = await apifyResourceCreator.createRequestQueue(url);
 
@@ -68,6 +60,39 @@ describe(ApifyResourceCreator, () => {
 
             const queue = await apifyResourceCreator.createRequestQueue(url, true);
 
+            expect(queue).toBe(queueMock.object);
+        });
+
+        it('with inputFile', async () => {
+            const inputFile = 'input file';
+            const fileContent = `url1\n
+                                    url2`;
+
+            setupCreateRequestQueue();
+
+            fsMock
+                .setup((f) => f.readFileSync(inputFile, 'utf-8'))
+                .returns(() => fileContent)
+                .verifiable(Times.once());
+
+            fsMock.setup((fsm) => fsm.existsSync(inputFile)).returns(() => true);
+
+            queueMock.setup((q) => q.addRequest({ url: 'ur1' }, { forefront: true })).verifiable();
+            queueMock.setup((q) => q.addRequest({ url: 'ur2' }, { forefront: true })).verifiable();
+
+            const queue = await apifyResourceCreator.createRequestQueue(url, false, inputFile);
+            expect(queue).toBe(queueMock.object);
+        });
+
+        it('with inputFile', async () => {
+            const existingUrls = ['url1', 'url2'];
+
+            setupCreateRequestQueue();
+
+            queueMock.setup((q) => q.addRequest({ url: 'ur1' }, { forefront: true })).verifiable();
+            queueMock.setup((q) => q.addRequest({ url: 'ur2' }, { forefront: true })).verifiable();
+
+            const queue = await apifyResourceCreator.createRequestQueue(url, false, undefined, existingUrls);
             expect(queue).toBe(queueMock.object);
         });
     });

--- a/packages/crawler/src/apify/apify-resource-creator.ts
+++ b/packages/crawler/src/apify/apify-resource-creator.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import Apify from 'apify';
-import { Url } from 'common';
 import * as fs from 'fs';
 import { injectable } from 'inversify';
+import { isEmpty } from 'lodash';
 import { ApifySettingsHandler, apifySettingsHandler } from '../apify/apify-settings';
 import { ResourceCreator } from '../types/resource-creator';
 
@@ -12,25 +12,59 @@ export class ApifyResourceCreator implements ResourceCreator {
     private readonly requestQueueName = 'scanRequests';
 
     public constructor(
-        private readonly urlObj: typeof Url = Url,
         private readonly apify: typeof Apify = Apify,
         private readonly settingsHandler: ApifySettingsHandler = apifySettingsHandler,
         private readonly filesystem: typeof fs = fs,
     ) {}
 
-    public async createRequestQueue(baseUrl: string, empty?: boolean): Promise<Apify.RequestQueue> {
+    public async createRequestQueue(
+        baseUrl: string,
+        empty?: boolean,
+        inputFile?: string,
+        existingUrls?: string[],
+    ): Promise<Apify.RequestQueue> {
         if (empty === true) {
             this.clearRequestQueue();
         }
 
         const requestQueue = await this.apify.openRequestQueue(this.requestQueueName);
-        await requestQueue.addRequest({ url: this.urlObj.getRootUrl(baseUrl) });
+        await requestQueue.addRequest({ url: baseUrl.trim() });
+
+        await this.addUrlsFromFile(requestQueue, inputFile);
+        await this.addUrlsFromExistingUrls(requestQueue, existingUrls);
 
         return requestQueue;
     }
 
     public async createRequestList(existingUrls: string[]): Promise<Apify.RequestList> {
         return this.apify.openRequestList('existingUrls', existingUrls === undefined ? [] : existingUrls);
+    }
+
+    private async addUrlsFromFile(requestQueue: Apify.RequestQueue, inputFile?: string): Promise<void> {
+        if (inputFile === undefined) {
+            return Promise.resolve();
+        }
+
+        if (!this.filesystem.existsSync(inputFile)) {
+            return Promise.resolve();
+        }
+
+        const lines = this.filesystem.readFileSync(inputFile, 'utf-8').split(/\r?\n/);
+
+        await this.addUrlsFromExistingUrls(requestQueue, lines);
+    }
+
+    private async addUrlsFromExistingUrls(requestQueue: Apify.RequestQueue, existingUrls?: string[]): Promise<void> {
+        if (existingUrls === undefined) {
+            return Promise.resolve();
+        }
+
+        for (let url of existingUrls) {
+            url = url.trim();
+            if (!isEmpty(url)) {
+                await requestQueue.addRequest({ url: url }, { forefront: true });
+            }
+        }
     }
 
     private clearRequestQueue(): void {

--- a/packages/crawler/src/crawler/crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/crawler-engine.spec.ts
@@ -50,7 +50,6 @@ describe(CrawlerEngine, () => {
             .verifiable();
 
         baseCrawlerOptions = {
-            requestList: undefined,
             requestQueue: requestQueueMock.object,
             handlePageFunction: pageProcessorStub.pageHandler,
             gotoFunction: pageProcessorStub.gotoFunction,
@@ -135,7 +134,7 @@ describe(CrawlerEngine, () => {
 
     function setupCreateRequestQueue(empty?: boolean, callback: () => void = () => null): void {
         resourceCreatorMock
-            .setup(async (cf) => cf.createRequestQueue(baseUrl, empty))
+            .setup(async (cf) => cf.createRequestQueue(baseUrl, empty, undefined, undefined))
             .returns(async () => {
                 callback();
 

--- a/packages/crawler/src/crawler/crawler-engine.ts
+++ b/packages/crawler/src/crawler/crawler-engine.ts
@@ -31,8 +31,12 @@ export class CrawlerEngine {
         this.crawlerConfiguration.setMemoryMBytes(crawlerRunOptions.memoryMBytes);
         this.crawlerConfiguration.setSilentMode(crawlerRunOptions.silentMode);
 
-        const requestList = await this.resourceCreator.createRequestList(crawlerRunOptions.existingUrls);
-        const requestQueue = await this.resourceCreator.createRequestQueue(crawlerRunOptions.baseUrl, crawlerRunOptions.restartCrawl);
+        const requestQueue = await this.resourceCreator.createRequestQueue(
+            crawlerRunOptions.baseUrl,
+            crawlerRunOptions.restartCrawl,
+            crawlerRunOptions.inputFile,
+            crawlerRunOptions.existingUrls,
+        );
 
         const pageProcessor = this.pageProcessorFactory.createPageProcessor({
             requestQueue,
@@ -41,7 +45,6 @@ export class CrawlerEngine {
 
         this.runApify(async () => {
             const crawler = this.crawlerFactory.createPuppeteerCrawler({
-                requestList,
                 requestQueue,
                 handlePageFunction: pageProcessor.pageHandler,
                 gotoFunction: pageProcessor.gotoFunction,

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -25,6 +25,9 @@ interface Arguments {
     snapshot: boolean;
     memoryMBytes: number;
     silentMode: boolean;
+    inputFile: string;
+    existingUrls: string[];
+    discoveryPatterns: string[];
 }
 
 (async () => {
@@ -32,7 +35,7 @@ interface Arguments {
 
     const args = (yargs
         .usage(
-            'Usage: $0 --url <url> --simulate <simulate> [--selectors <selector1 ...>] --output <output> --maxUrls <maxUrls> --restart <restart> --snapshot <snapshot> --memoryMBytes <memoryMBytes> --silentMode <silentMode>',
+            'Usage: $0 --url <url> --simulate <simulate> [--selectors <selector1 ...>] --output <output> --maxUrls <maxUrls> --restart <restart> --snapshot <snapshot> --memoryMBytes <memoryMBytes> --silentMode <silentMode> [--existingUrls <url1 ...>] [--discoveryPatterns <pattern1 ...>]',
         )
         .options({
             url: {
@@ -82,6 +85,18 @@ interface Arguments {
                 describe: 'Set to false if you want the browser to open the webpages while crawling',
                 default: true,
             },
+            inputFile: {
+                type: 'string',
+                describe: 'List of URLs to crawl in addition to URLs discovered from crawling base URL',
+            },
+            existingUrls: {
+                type: 'array',
+                describe: `List of URLs to crawl in addition to URLs discovered from crawling base URL`,
+            },
+            discoveryPatterns: {
+                type: 'array',
+                describe: `List of patterns to crawl in addition to the base url`,
+            },
         })
         .describe('help', 'Print command line options').argv as unknown) as Arguments;
 
@@ -95,6 +110,9 @@ interface Arguments {
         snapshot: args.snapshot,
         memoryMBytes: args.memoryMBytes,
         silentMode: args.silentMode,
+        inputFile: args.inputFile,
+        existingUrls: args.existingUrls,
+        discoveryPatterns: args.discoveryPatterns,
     });
 })().catch((error) => {
     console.log('Exception: ', System.serializeError(error));

--- a/packages/crawler/src/page-processors/page-processor-factory.spec.ts
+++ b/packages/crawler/src/page-processors/page-processor-factory.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
+import { Url } from 'common';
 import { Logger } from 'logger';
 import { IMock, Mock } from 'typemoq';
 import { CrawlerConfiguration } from '../crawler/crawler-configuration';
@@ -16,12 +17,19 @@ describe(PageProcessorFactory, () => {
     let crawlerConfigurationMock: IMock<CrawlerConfiguration>;
     let loggerMock: IMock<Logger>;
     let pageProcessorFactory: PageProcessorFactory;
+    let urlMock: IMock<typeof Url>;
     const baseUrl = 'base url';
 
     beforeEach(() => {
         crawlerConfigurationMock = Mock.ofType(CrawlerConfiguration);
         loggerMock = Mock.ofType<Logger>();
-        pageProcessorFactory = new PageProcessorFactory(crawlerConfigurationMock.object, loggerMock.object);
+        urlMock = Mock.ofType<typeof Url>();
+        pageProcessorFactory = new PageProcessorFactory(crawlerConfigurationMock.object, loggerMock.object, urlMock.object);
+
+        urlMock
+            .setup((um) => um.getRootUrl(baseUrl))
+            .returns(() => baseUrl)
+            .verifiable();
     });
 
     it('PageProcessorFactory, classic page processor', async () => {
@@ -66,5 +74,6 @@ describe(PageProcessorFactory, () => {
 
     afterEach(() => {
         crawlerConfigurationMock.verifyAll();
+        urlMock.verifyAll();
     });
 });

--- a/packages/crawler/src/page-processors/page-processor-factory.ts
+++ b/packages/crawler/src/page-processors/page-processor-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { reporterFactory } from 'accessibility-insights-report';
+import { Url } from 'common';
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { AxePuppeteerFactory } from '../axe-puppeteer/axe-puppeteer-factory';
@@ -22,6 +23,7 @@ export class PageProcessorFactory {
     constructor(
         @inject(CrawlerConfiguration) private readonly crawlerConfiguration: CrawlerConfiguration,
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        private readonly urlObj: typeof Url = Url,
     ) {}
 
     public createPageProcessor(pageProcessorOptions: PageProcessorOptions): PageProcessor {
@@ -37,7 +39,7 @@ export class PageProcessorFactory {
                     pageProcessorOptions.crawlerRunOptions.simulate,
                 ),
                 this.crawlerConfiguration.getDiscoveryPattern(
-                    pageProcessorOptions.crawlerRunOptions.baseUrl,
+                    this.urlObj.getRootUrl(pageProcessorOptions.crawlerRunOptions.baseUrl),
                     pageProcessorOptions.crawlerRunOptions.discoveryPatterns,
                 ),
             );
@@ -57,7 +59,7 @@ export class PageProcessorFactory {
                 pageProcessorOptions.crawlerRunOptions.simulate,
             ),
             this.crawlerConfiguration.getDiscoveryPattern(
-                pageProcessorOptions.crawlerRunOptions.baseUrl,
+                this.urlObj.getRootUrl(pageProcessorOptions.crawlerRunOptions.baseUrl),
                 pageProcessorOptions.crawlerRunOptions.discoveryPatterns,
             ),
         );

--- a/packages/crawler/src/types/resource-creator.ts
+++ b/packages/crawler/src/types/resource-creator.ts
@@ -4,5 +4,5 @@ import Apify from 'apify';
 
 export interface ResourceCreator {
     createRequestList(existingUrls: string[]): Promise<Apify.RequestList>;
-    createRequestQueue(baseUrl: string, empty?: boolean): Promise<Apify.RequestQueue>;
+    createRequestQueue(baseUrl: string, empty?: boolean, inputFile?: string, existingUrls?: string[]): Promise<Apify.RequestQueue>;
 }

--- a/packages/crawler/src/types/run-options.ts
+++ b/packages/crawler/src/types/run-options.ts
@@ -15,6 +15,7 @@ export interface CrawlerRunOptions {
     snapshot?: boolean;
     memoryMBytes?: number;
     silentMode?: boolean;
+    inputFile?: string;
 }
 
 export interface PageProcessorOptions {


### PR DESCRIPTION
### Description of changes

This PR add list of URLs to crawl/scan in addition to URLs discovered from crawling base URL by passing a link to an input file path or an array of urls in the arguments or both.
Also Add the option to pass more discovery patterns to be crawled in addition to the base url.

(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
