### PR TITLE
feat(port-crawler-to-cli): Create an error log for each unscannable url while running file scan without crawling

### DIFF
--- a/packages/cli/src/report/report-formats.ts
+++ b/packages/cli/src/report/report-formats.ts
@@ -1,3 +1,3 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export declare type ReportFormats = 'html' | 'json';
+export declare type ReportFormats = 'html' | 'json' | 'txt';

--- a/packages/cli/src/report/summary-report/__snapshots__/html-summary-report-generator.spec.ts.snap
+++ b/packages/cli/src/report/summary-report/__snapshots__/html-summary-report-generator.spec.ts.snap
@@ -175,7 +175,7 @@ exports[`HtmlSummaryReportGenerator logs violation summary when has unScannable 
         <ul>
 
           <li>
-            <a href='url'>url</a>
+            <a href='./unscannableUrl1'>https://www.unscannableUrl1.com</a>
           </li>
         </ul>
       </li>

--- a/packages/cli/src/report/summary-report/console-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/console-summary-report-generator.spec.ts
@@ -24,7 +24,7 @@ describe(ConsoleSummaryReportGenerator, () => {
                     rule1WithALongName11111111111111111: 10,
                     rule2: 3,
                 },
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
         [
@@ -33,7 +33,7 @@ describe(ConsoleSummaryReportGenerator, () => {
                 failedUrlToReportMap: { url1: 'file1' },
                 passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {},
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
     ])('logs summary when %s', async (testCaseName, testCase) => {

--- a/packages/cli/src/report/summary-report/html-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/html-summary-report-generator.spec.ts
@@ -21,7 +21,7 @@ describe(HtmlSummaryReportGenerator, () => {
                 failedUrlToReportMap: {},
                 passedUrlToReportMap: {},
                 violationCountByRuleMap: {},
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
         [
@@ -33,7 +33,7 @@ describe(HtmlSummaryReportGenerator, () => {
                 },
                 passedUrlToReportMap: {},
                 violationCountByRuleMap: { rule1: 3 },
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
         [
@@ -45,7 +45,7 @@ describe(HtmlSummaryReportGenerator, () => {
                     'https://www.passedUrl2.com': './passed-url2.html',
                 },
                 violationCountByRuleMap: {},
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
         [
@@ -62,7 +62,7 @@ describe(HtmlSummaryReportGenerator, () => {
                 violationCountByRuleMap: {
                     rule1: 3,
                 },
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
         [
@@ -71,7 +71,9 @@ describe(HtmlSummaryReportGenerator, () => {
                 failedUrlToReportMap: {},
                 passedUrlToReportMap: {},
                 violationCountByRuleMap: {},
-                unscannableUrls: ['url'],
+                unscannableUrls: {
+                    'https://www.unscannableUrl1.com': './unscannableUrl1',
+                },
             } as SummaryReportData,
         ],
     ])('logs violation summary when %s', async (testCaseName, testCase) => {

--- a/packages/cli/src/report/summary-report/html-summary-report-generator.ts
+++ b/packages/cli/src/report/summary-report/html-summary-report-generator.ts
@@ -18,7 +18,7 @@ type HtmlSummaryLink = {
 type HtmlSummaryData = {
     passedLinks: HtmlSummaryLink[];
     failedLinks: HtmlSummaryLink[];
-    unscannableUrls: string[];
+    unscannableUrls: HtmlSummaryLink[];
 };
 
 @injectable()
@@ -32,7 +32,7 @@ export class HtmlSummaryReportGenerator implements SummaryReportGenerator {
 
         htmlSummaryData.failedLinks = this.getHtmlLinkData(summaryReportData.failedUrlToReportMap);
         htmlSummaryData.passedLinks = this.getHtmlLinkData(summaryReportData.passedUrlToReportMap);
-        htmlSummaryData.unscannableUrls = summaryReportData.unscannableUrls;
+        htmlSummaryData.unscannableUrls = this.getHtmlLinkData(summaryReportData.unscannableUrls);
 
         return pretty(`
         <!DOCTYPE html>
@@ -93,14 +93,7 @@ export class HtmlSummaryReportGenerator implements SummaryReportGenerator {
             return '';
         }
 
-        const htmlLinks: HtmlSummaryLink[] = htmlSummaryData.unscannableUrls.map((url) => {
-            return {
-                fileName: url,
-                link: url,
-            };
-        });
-
-        return this.getLinksSection('UnScannable Urls', htmlLinks);
+        return this.getLinksSection('UnScannable Urls', htmlSummaryData.unscannableUrls);
     }
 
     private getLinksSection(sectionName: string, links: HtmlSummaryLink[]): string {

--- a/packages/cli/src/report/summary-report/json-summary-report-generator.spec.ts
+++ b/packages/cli/src/report/summary-report/json-summary-report-generator.spec.ts
@@ -24,7 +24,7 @@ describe(JsonSummaryReportGenerator, () => {
                     rule1WithALongName11111111111111111: 10,
                     rule2: 3,
                 },
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
         [
@@ -33,7 +33,7 @@ describe(JsonSummaryReportGenerator, () => {
                 failedUrlToReportMap: { url1: 'file1' },
                 passedUrlToReportMap: { url1: 'file1' },
                 violationCountByRuleMap: {},
-                unscannableUrls: [],
+                unscannableUrls: {},
             } as SummaryReportData,
         ],
     ])('logs violation summary when %s', async (testCaseName, testCase) => {

--- a/packages/cli/src/report/summary-report/summary-report-data.ts
+++ b/packages/cli/src/report/summary-report/summary-report-data.ts
@@ -13,5 +13,5 @@ export interface SummaryReportData {
     violationCountByRuleMap: ViolationCountMap;
     failedUrlToReportMap: UrlToReportMap;
     passedUrlToReportMap: UrlToReportMap;
-    unscannableUrls: string[];
+    unscannableUrls: UrlToReportMap;
 }

--- a/packages/cli/src/runner/file-command-runner.spec.ts
+++ b/packages/cli/src/runner/file-command-runner.spec.ts
@@ -87,7 +87,10 @@ describe(FileCommandRunner, () => {
                 'pass-url-1': 'pass-url-1-report',
                 'pass-url-2': 'pass-url-2-report',
             };
-            const unscannableUrls = { 'un-scannable-url-1': 'un-scannable-url-1', 'un-scannable-url-2': 'un-scannable-url-2' };
+            const unscannableUrls = {
+                'un-scannable-url-1': 'un-scannable-url-1-report',
+                'un-scannable-url-2': 'un-scannable-url-2-report',
+            };
 
             const expectedSummaryData: SummaryReportData = {
                 failedUrlToReportMap: failedUrlToReportMap,
@@ -110,7 +113,7 @@ describe(FileCommandRunner, () => {
             const expectedSummaryData: SummaryReportData = {
                 failedUrlToReportMap: {},
                 passedUrlToReportMap: {},
-                unscannableUrls: { 'un-scannable-url-1': 'un-scannable-url-1', 'un-scannable-url-2': 'un-scannable-url-2' },
+                unscannableUrls: { 'un-scannable-url-1': 'un-scannable-url-1-report', 'un-scannable-url-2': 'un-scannable-url-2-report' },
                 violationCountByRuleMap: {},
             };
 

--- a/packages/cli/src/runner/file-command-runner.spec.ts
+++ b/packages/cli/src/runner/file-command-runner.spec.ts
@@ -87,7 +87,7 @@ describe(FileCommandRunner, () => {
                 'pass-url-1': 'pass-url-1-report',
                 'pass-url-2': 'pass-url-2-report',
             };
-            const unscannableUrls = ['un-scannable-url-1', 'un-scannable-url-2'];
+            const unscannableUrls = { 'un-scannable-url-1': 'un-scannable-url-1', 'un-scannable-url-2': 'un-scannable-url-2' };
 
             const expectedSummaryData: SummaryReportData = {
                 failedUrlToReportMap: failedUrlToReportMap,
@@ -110,7 +110,7 @@ describe(FileCommandRunner, () => {
             const expectedSummaryData: SummaryReportData = {
                 failedUrlToReportMap: {},
                 passedUrlToReportMap: {},
-                unscannableUrls: ['un-scannable-url-1', 'un-scannable-url-2'],
+                unscannableUrls: { 'un-scannable-url-1': 'un-scannable-url-1', 'un-scannable-url-2': 'un-scannable-url-2' },
                 violationCountByRuleMap: {},
             };
 
@@ -127,7 +127,7 @@ describe(FileCommandRunner, () => {
             const expectedSummaryData: SummaryReportData = {
                 failedUrlToReportMap: {},
                 passedUrlToReportMap: {},
-                unscannableUrls: [],
+                unscannableUrls: {},
                 violationCountByRuleMap: {},
             };
 
@@ -167,7 +167,7 @@ describe(FileCommandRunner, () => {
                 passedUrlToReportMap: {
                     'pass-url-1': 'pass-url-1-report',
                 },
-                unscannableUrls: [],
+                unscannableUrls: {},
                 violationCountByRuleMap: {},
             };
 
@@ -267,13 +267,21 @@ describe(FileCommandRunner, () => {
 
         scannerMock
             .setup((s) => s.scan(It.is((url) => url.startsWith('un-scannable'))))
-            .returns((url) =>
-                Promise.resolve({
+            .returns(async (url: string) => {
+                const result = {
+                    results: {
+                        passes: [],
+                        violations: [],
+                    },
                     error: {
                         message: 'unable to scan',
                     },
-                } as AxeScanResults),
-            )
+                } as AxeScanResults;
+
+                setupErrorReportCreationCalls(url);
+
+                return result;
+            })
             .verifiable(Times.atLeast(0));
     }
 
@@ -285,6 +293,13 @@ describe(FileCommandRunner, () => {
 
         reportDiskWriterMock
             .setup((r) => r.writeToDirectory(testInput.output, url, 'html', 'report-content'))
+            .returns(() => `${url}-report`)
+            .verifiable(Times.once());
+    }
+
+    function setupErrorReportCreationCalls(url: string): void {
+        reportDiskWriterMock
+            .setup((r) => r.writeToDirectory(testInput.output, url, 'txt', 'unable to scan'))
             .returns(() => `${url}-report`)
             .verifiable(Times.once());
     }


### PR DESCRIPTION
#### Description of changes
This PR creates a log file for each failed scan url with the error details and add it in the html summary report.


(Give an overview. Add a technical description describing your changes.)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
