### PR TITLE
feat (cli-summary-report): Create error log for the whole CLI run

### DIFF
--- a/packages/cli/src/cli-entry-point.ts
+++ b/packages/cli/src/cli-entry-point.ts
@@ -3,7 +3,10 @@
 
 import { Container } from 'inversify';
 import { isEmpty } from 'lodash';
+import { ReportDiskWriter } from './report/report-disk-writer';
+import { ReportNameGenerator } from './report/report-name-generator';
 import { CommandRunner } from './runner/command-runner';
+import { CrawlerCommandRunner } from './runner/crawler-command-runner';
 import { FileCommandRunner } from './runner/file-command-runner';
 import { URLCommandRunner } from './runner/url-command-runner';
 import { ScanArguments } from './scanner/scan-arguments';
@@ -12,17 +15,37 @@ export class CliEntryPoint {
     constructor(private readonly container: Container) {}
 
     public async runScan(scanArguments: ScanArguments): Promise<void> {
-        const commandRunner = this.getCommandRunner(scanArguments);
-        await commandRunner.runCommand(scanArguments);
+        try {
+            const commandRunner = this.getCommandRunner(scanArguments);
+            await commandRunner.runCommand(scanArguments);
+        } catch (error) {
+            const reportDiskWriter = this.container.get(ReportDiskWriter);
+            const reportNameGenerator = this.container.get(ReportNameGenerator);
+
+            reportDiskWriter.writeToDirectory(
+                scanArguments.output,
+                reportNameGenerator.generateName('ai-cli-errors', new Date()),
+                'log',
+                `${error}`,
+            );
+        }
     }
 
     private getCommandRunner(scanArguments: ScanArguments): CommandRunner {
-        if (!isEmpty(scanArguments.url)) {
-            return this.container.get(URLCommandRunner);
-        } else if (!isEmpty(scanArguments.inputFile)) {
-            return this.container.get(FileCommandRunner);
+        if (scanArguments.crawl) {
+            if (!isEmpty(scanArguments.url)) {
+                return this.container.get(CrawlerCommandRunner);
+            } else {
+                throw new Error('You should provide a bse url to crawl.');
+            }
         } else {
-            throw new Error('You should provide either url or inputFile parameter only.');
+            if (!isEmpty(scanArguments.url)) {
+                return this.container.get(URLCommandRunner);
+            } else if (!isEmpty(scanArguments.inputFile)) {
+                return this.container.get(FileCommandRunner);
+            } else {
+                throw new Error('You should provide either url or inputFile parameter only.');
+            }
         }
     }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,7 +7,6 @@ import 'reflect-metadata';
 // tslint:disable-next-line: no-import-side-effect
 import './module-name-mapper';
 
-import { CrawlerEntryPoint, setupCrawlerContainer } from 'accessibility-insights-crawler';
 // @ts-ignore
 import * as cheerio from 'cheerio';
 import { isEmpty } from 'lodash';
@@ -18,7 +17,17 @@ import { setupCliContainer } from './setup-cli-container';
 
 // tslint:disable-next-line:max-func-body-length
 (async () => {
-    const scanArguments = (yargs
+    const scanArguments = readScanArguments();
+
+    const cliEntryPoint = new CliEntryPoint(setupCliContainer());
+    await cliEntryPoint.runScan(scanArguments);
+})().catch((error) => {
+    console.log('Exception occurred while running the tool: ', error);
+    process.exit(1);
+});
+
+function readScanArguments(): ScanArguments {
+    return (yargs
         .wrap(yargs.terminalWidth())
         .options({
             crawl: {
@@ -97,27 +106,4 @@ import { setupCliContainer } from './setup-cli-container';
             return true;
         })
         .describe('help', 'Show help').argv as unknown) as ScanArguments;
-
-    if (!scanArguments.crawl) {
-        const cliEntryPoint = new CliEntryPoint(setupCliContainer());
-        await cliEntryPoint.runScan(scanArguments);
-    } else {
-        await new CrawlerEntryPoint(setupCrawlerContainer()).crawl({
-            baseUrl: scanArguments.url,
-            simulate: scanArguments.simulate,
-            selectors: scanArguments.selectors,
-            localOutputDir: scanArguments.output,
-            maxRequestsPerCrawl: scanArguments.maxUrls,
-            restartCrawl: scanArguments.restart,
-            snapshot: scanArguments.snapshot,
-            memoryMBytes: scanArguments.memoryMBytes,
-            silentMode: scanArguments.silentMode,
-            inputFile: scanArguments.inputFile,
-            existingUrls: scanArguments.existingUrls,
-            discoveryPatterns: scanArguments.discoveryPatterns,
-        });
-    }
-})().catch((error) => {
-    console.log('Exception occurred while running the tool: ', error);
-    process.exit(1);
-});
+}

--- a/packages/cli/src/report/report-disk-writer.spec.ts
+++ b/packages/cli/src/report/report-disk-writer.spec.ts
@@ -35,7 +35,7 @@ describe('ReportDiskWriter', () => {
             .returns(() => {})
             .verifiable(Times.once());
         fsMock
-            .setup((fsm) => fsm.mkdirSync('.'))
+            .setup((fsm) => fsm.mkdirSync('.', { recursive: true }))
             .returns(() => {})
             .verifiable(Times.never());
 
@@ -61,7 +61,7 @@ describe('ReportDiskWriter', () => {
             .returns(() => {})
             .verifiable(Times.once());
         fsMock
-            .setup((fsm) => fsm.mkdirSync('.'))
+            .setup((fsm) => fsm.mkdirSync('.', { recursive: true }))
             .returns(() => {})
             .verifiable(Times.once());
 
@@ -88,7 +88,7 @@ describe('ReportDiskWriter', () => {
             .returns(() => {})
             .verifiable(Times.once());
         fsMock
-            .setup((fsm) => fsm.mkdirSync('.'))
+            .setup((fsm) => fsm.mkdirSync('.', { recursive: true }))
             .returns(() => {})
             .verifiable(Times.once());
 

--- a/packages/cli/src/report/report-disk-writer.ts
+++ b/packages/cli/src/report/report-disk-writer.ts
@@ -28,7 +28,7 @@ export class ReportDiskWriter {
         if (!this.fileSystemObj.existsSync(directory)) {
             console.log('output directory does not exists.');
             console.log(`creating output directory - ${directory}`);
-            this.fileSystemObj.mkdirSync(directory);
+            this.fileSystemObj.mkdirSync(directory, { recursive: true });
         }
 
         this.fileSystemObj.writeFileSync(`${directory}/${reportFileName}`, content);

--- a/packages/cli/src/report/report-formats.ts
+++ b/packages/cli/src/report/report-formats.ts
@@ -1,3 +1,3 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export declare type ReportFormats = 'html' | 'json' | 'txt';
+export declare type ReportFormats = 'html' | 'json' | 'txt' | 'log';

--- a/packages/cli/src/report/report-name-generator-builder.test.ts
+++ b/packages/cli/src/report/report-name-generator-builder.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ReportNameGeneratorBuilder } from './report-name-generator-builder';
+
+describe('ReportNameGeneratorBuilder', () => {
+    let testObject: ReportNameGeneratorBuilder;
+
+    beforeEach(() => {
+        testObject = new ReportNameGeneratorBuilder();
+    });
+
+    it('generates single digit date', () => {
+        const date = new Date(2018, 0, 1);
+
+        const actual = testObject.getDateSegment(date);
+
+        const expected = '20180101';
+        expect(actual).toEqual(expected);
+    });
+
+    it('generates maximum date', () => {
+        const date = new Date(2017, 11, 31);
+
+        const actual = testObject.getDateSegment(date);
+
+        const expected = '20171231';
+        expect(actual).toEqual(expected);
+    });
+
+    it('generates single digit time', () => {
+        const date = new Date(0, 0, 0, 0, 1, 1);
+
+        const actual = testObject.getTimeSegment(date);
+
+        const expected = '000101';
+        expect(actual).toEqual(expected);
+    });
+
+    it('generates double digits time', () => {
+        const date = new Date(0, 0, 0, 23, 11, 31);
+
+        const actual = testObject.getTimeSegment(date);
+
+        const expected = '231131';
+        expect(actual).toEqual(expected);
+    });
+
+    it('truncates long title', () => {
+        const theTitle = 'TitleTitleTitleTitleTitle';
+
+        const actual = testObject.getTitleSegment(theTitle);
+
+        const expected = 'TitleTitleTitleTitle';
+        expect(actual).toEqual(expected);
+    });
+
+    it('excludes invalid title characters', () => {
+        const theTitle = '^Tit%le&';
+
+        const actual = testObject.getTitleSegment(theTitle);
+
+        const expected = 'Title';
+        expect(actual).toEqual(expected);
+    });
+});

--- a/packages/cli/src/report/report-name-generator-builder.ts
+++ b/packages/cli/src/report/report-name-generator-builder.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { injectable } from 'inversify';
+import { padStart } from 'lodash';
+
+@injectable()
+export class ReportNameGeneratorBuilder {
+    public getDateSegment(scanDate: Date): string {
+        return `${scanDate.getFullYear()}${this.padStartWithZero(scanDate.getMonth() + 1, 2)}${this.padStartWithZero(
+            scanDate.getDate(),
+            2,
+        )}`;
+    }
+
+    public getTitleSegment(pageTitle: string): string {
+        return Array.from(pageTitle).filter(this.isValidCharForTitle).slice(0, 20).join('');
+    }
+
+    public getTimeSegment(scanDate: Date): string {
+        return (
+            this.padStartWithZero(scanDate.getHours(), 2) +
+            this.padStartWithZero(scanDate.getMinutes(), 2) +
+            this.padStartWithZero(scanDate.getSeconds(), 2)
+        );
+    }
+
+    private padStartWithZero(num: number, digits: number): string {
+        return padStart(num.toString(), digits, '0');
+    }
+
+    private isValidCharForTitle(character: string): boolean {
+        return /[A-Za-z0-9]/.test(character);
+    }
+}

--- a/packages/cli/src/report/report-name-generator.test.ts
+++ b/packages/cli/src/report/report-name-generator.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IMock, Mock, Times } from 'typemoq';
+import { ReportNameGenerator } from './report-name-generator';
+import { ReportNameGeneratorBuilder } from './report-name-generator-builder';
+
+describe('UnifiedReportNameGenerator', () => {
+    const theBase = 'BASE';
+    const theDate = new Date();
+
+    const dateSegment = 'date segment';
+    const timeSegment = 'time segment';
+
+    let reportNameGeneratorBuilderMock: IMock<ReportNameGeneratorBuilder>;
+    let testObject: ReportNameGenerator;
+
+    beforeEach(() => {
+        reportNameGeneratorBuilderMock = Mock.ofType(ReportNameGeneratorBuilder);
+        testObject = new ReportNameGenerator(reportNameGeneratorBuilderMock.object);
+
+        reportNameGeneratorBuilderMock
+            .setup((rngbm) => rngbm.getDateSegment(theDate))
+            .returns(() => dateSegment)
+            .verifiable(Times.once());
+        reportNameGeneratorBuilderMock
+            .setup((rngbm) => rngbm.getTimeSegment(theDate))
+            .returns(() => timeSegment)
+            .verifiable(Times.once());
+    });
+
+    it('generateName', () => {
+        const actual = testObject.generateName(theBase, theDate);
+
+        const expected = `${theBase}-${dateSegment}-${timeSegment}`;
+        expect(actual).toEqual(expected);
+
+        reportNameGeneratorBuilderMock.verifyAll();
+    });
+});

--- a/packages/cli/src/report/report-name-generator.ts
+++ b/packages/cli/src/report/report-name-generator.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inject, injectable } from 'inversify';
+import { ReportNameGeneratorBuilder } from './report-name-generator-builder';
+
+@injectable()
+export class ReportNameGenerator {
+    constructor(@inject(ReportNameGeneratorBuilder) private readonly reportNameGeneratorBuilder: ReportNameGeneratorBuilder) {}
+
+    public generateName(baseName: string, scanDate: Date): string {
+        return `${baseName}-${this.reportNameGeneratorBuilder.getDateSegment(scanDate)}-${this.reportNameGeneratorBuilder.getTimeSegment(
+            scanDate,
+        )}`;
+    }
+}

--- a/packages/cli/src/runner/crawler-command-runner.spec.ts
+++ b/packages/cli/src/runner/crawler-command-runner.spec.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { CrawlerEntryPoint, CrawlerRunOptions } from 'accessibility-insights-crawler';
+import { IMock, Mock, Times } from 'typemoq';
+import { ScanArguments } from '../scanner/scan-arguments';
+import { CrawlerCommandRunner } from './crawler-command-runner';
+
+// tslint:disable: no-empty
+describe('CrawlerCommandRunner', () => {
+    let crawlerEntryPointMock: IMock<CrawlerEntryPoint>;
+    let testSubject: CrawlerCommandRunner;
+    // tslint:disable-next-line: no-http-string
+    const testUrl = 'http://www.bing.com';
+    const testInput: ScanArguments = { url: testUrl, output: '/users/xyz' };
+    // tslint:disable-next-line: mocha-no-side-effect-code
+    beforeEach(() => {
+        crawlerEntryPointMock = Mock.ofType<CrawlerEntryPoint>();
+
+        testSubject = new CrawlerCommandRunner(crawlerEntryPointMock.object);
+    });
+
+    it('Run Command', async () => {
+        const crawlerOption: CrawlerRunOptions = {
+            baseUrl: testInput.url,
+            localOutputDir: testInput.output,
+            existingUrls: undefined,
+            discoveryPatterns: undefined,
+            simulate: undefined,
+            selectors: undefined,
+            maxRequestsPerCrawl: undefined,
+            restartCrawl: undefined,
+            snapshot: undefined,
+            memoryMBytes: undefined,
+            silentMode: undefined,
+            inputFile: undefined,
+        };
+
+        crawlerEntryPointMock
+            // tslint:disable-next-line:no-object-literal-type-assertion
+            .setup((cem) => cem.crawl(crawlerOption))
+            .returns(async () => Promise.resolve())
+            .verifiable(Times.once());
+
+        await testSubject.runCommand(testInput);
+
+        crawlerEntryPointMock.verifyAll();
+    });
+});

--- a/packages/cli/src/runner/crawler-command-runner.ts
+++ b/packages/cli/src/runner/crawler-command-runner.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CrawlerEntryPoint, setupCrawlerContainer } from 'accessibility-insights-crawler';
+import { injectable } from 'inversify';
+import { ScanArguments } from '../scanner/scan-arguments';
+import { CommandRunner } from './command-runner';
+
+@injectable()
+export class CrawlerCommandRunner implements CommandRunner {
+    constructor(private readonly crawlerEntryPoint: CrawlerEntryPoint = new CrawlerEntryPoint(setupCrawlerContainer())) {}
+
+    public async runCommand(scanArguments: ScanArguments): Promise<void> {
+        await this.crawlerEntryPoint.crawl({
+            baseUrl: scanArguments.url,
+            simulate: scanArguments.simulate,
+            selectors: scanArguments.selectors,
+            localOutputDir: scanArguments.output,
+            maxRequestsPerCrawl: scanArguments.maxUrls,
+            restartCrawl: scanArguments.restart,
+            snapshot: scanArguments.snapshot,
+            memoryMBytes: scanArguments.memoryMBytes,
+            silentMode: scanArguments.silentMode,
+            inputFile: scanArguments.inputFile,
+            existingUrls: scanArguments.existingUrls,
+            discoveryPatterns: scanArguments.discoveryPatterns,
+        });
+    }
+}


### PR DESCRIPTION
#### Description of changes
- Create new Crawler command runner.
- Create Report name builder.
- Create report name generator.
- Create an error log for the whole CLI run if it fails.
- Fix create directory to be recursive.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
