### PR TITLE
chore: Revert "chore(deps): bump apify-shared from 0.2.17 to 0.4.5 (#1030)"

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "dependencies": {
         "accessibility-insights-report": "2.1.1",
         "apify": "^0.21.4",
-        "apify-shared": "^0.4.5",
+        "apify-shared": "^0.2.12",
         "axe-core": "4.0.1",
         "axe-puppeteer": "^1.1.0",
         "cheerio": "^1.0.0-rc.3",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -48,7 +48,7 @@
         "@medv/finder": "^2.0.0",
         "accessibility-insights-report": "2.1.1",
         "apify": "^0.21.4",
-        "apify-shared": "^0.4.5",
+        "apify-shared": "^0.2.12",
         "axe-core": "4.0.1",
         "axe-puppeteer": "^1.1.0",
         "cheerio": "^1.0.0-rc.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3384,10 +3384,27 @@ apify-shared@^0.1.45:
     underscore "^1.9.1"
     url "^0.11.0"
 
-apify-shared@^0.4.0, apify-shared@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.4.5.tgz#1a400e3d848a7018293f874d6e0cdb5a3e852e15"
-  integrity sha512-SFgEl14NPUcH9nKknrLaFw81spMi2u5fOQQk5DJ9timIbVpWiQy/FCQXmHwjk6oYtC9Ft5CMuC7PitMYVbA+UQ==
+apify-shared@^0.2.12:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.2.17.tgz#985cb613da94e026f6354dbc24b8204cef54bc14"
+  integrity sha512-zz892mS/MC2PR2M+8FO/jO/Np33gwVpfiD4KrBIbjZ/kmSz5IKmq3U7iV7tvwQMwBG0TlVvf1X2d8CdKXxizOg==
+  dependencies:
+    bluebird "^3.7.2"
+    chalk "^4.0.0"
+    cherow "^1.6.9"
+    clone "^2.1.1"
+    countries-list "^2.5.1"
+    is-buffer "^2.0.3"
+    marked "^1.0.0"
+    request "^2.88.0"
+    slugg "^1.2.1"
+    underscore "^1.9.1"
+    url "^0.11.0"
+
+apify-shared@^0.4.0:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/apify-shared/-/apify-shared-0.4.3.tgz#ab959395b9ab47361130b20752a018cfa19aecb8"
+  integrity sha512-o/9oXp7h09DIfQKNBYAJlVjAUbPEN5caEQfVegWQjtscdIytLP/7l2XaFvxxecfrS4hI2wbW9GFI0gF9llVE1A==
   dependencies:
     axios "^0.19.2"
     bluebird "^3.7.2"
@@ -3396,8 +3413,7 @@ apify-shared@^0.4.0, apify-shared@^0.4.5:
     clone "^2.1.1"
     countries-list "^2.5.1"
     is-buffer "^2.0.3"
-    marked "^1.1.0"
-    match-all "^1.2.6"
+    marked "^1.0.0"
     moment "^2.27.0"
     request "^2.88.0"
     slugg "^1.2.1"
@@ -8685,15 +8701,10 @@ marked@1.0.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
   integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
 
-marked@^1.1.0:
+marked@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
   integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
-
-match-all@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
-  integrity sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
This reverts commit 8231ba1578f70cf67121e8ee62eaed5a9f0ed7a7.

#### Description of changes

Revert this update before we release the cli package

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
