### PR TITLE
Log browser scan error event

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,20 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug current test file in VSCode",
             "type": "node",
             "request": "launch",
-            "runtimeArgs": [
-                "--inspect-brk",
-                "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                "--runInBand",
-                "${fileBasename}",
-                "--coverage",
-                "false"
-            ],
+            "name": "Debug current unit test file",
+            "program": "${workspaceFolder:root}/node_modules/jest/bin/jest",
+            // ${relativeFile} returns path with back slash. jest can't find the file if we use back slash. So, just passing file name instead
+            "args": ["${fileBasename}", "--runInBand", "--coverage=false"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "port": 9229
+            "cwd": "${fileDirname}"
         }
     ]
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -15,6 +15,7 @@ export {
     TelemetryMeasurements,
     ScanRequestAcceptedMeasurements,
     ScanRequestQueuedMeasurements,
+    BrowserScanFailedMeasurements,
 } from './logger-event-measurements';
 export { AvailabilityTelemetry } from './availability-telemetry';
 export { LoggerProperties } from './logger-properties';

--- a/packages/logger/src/logger-event-measurements.ts
+++ b/packages/logger/src/logger-event-measurements.ts
@@ -85,6 +85,10 @@ export interface SendNotificationTaskFailedMeasurements extends BaseTelemetryMea
     failedScanNotificationTasks: number;
 }
 
+export interface BrowserScanFailedMeasurements extends BaseTelemetryMeasurements {
+    failedBrowserScans: number;
+}
+
 export type TelemetryMeasurements = {
     HealthCheck: null;
     FunctionalTest: null;
@@ -104,4 +108,5 @@ export type TelemetryMeasurements = {
     SendNotificationTaskStarted: SendNotificationTaskStartedMeasurements;
     SendNotificationTaskCompleted: SendNotificationTaskCompletedMeasurements;
     SendNotificationTaskFailed: SendNotificationTaskFailedMeasurements;
+    BrowserScanFailed: BrowserScanFailedMeasurements;
 };

--- a/packages/logger/src/logger-event.ts
+++ b/packages/logger/src/logger-event.ts
@@ -19,4 +19,5 @@ export declare type LoggerEvent =
     | 'ScanTaskFailed'
     | 'SendNotificationTaskStarted'
     | 'SendNotificationTaskCompleted'
-    | 'SendNotificationTaskFailed';
+    | 'SendNotificationTaskFailed'
+    | 'BrowserScanFailed';

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -334,11 +334,13 @@ describe(Runner, () => {
 
         loggerMock.setup((lm) => lm.trackEvent('ScanRequestRunning', undefined, { runningScanRequests: 1 })).verifiable();
         loggerMock.setup((lm) => lm.trackEvent('ScanRequestCompleted', undefined, { completedScanRequests: 1 })).verifiable();
-        loggerMock.setup((lm) => lm.trackEvent('ScanRequestFailed', undefined, { failedScanRequests: 1 })).verifiable();
+        loggerMock.setup((lm) => lm.trackEvent('ScanRequestFailed', undefined, { failedScanRequests: 1 })).verifiable(Times.never());
 
         loggerMock.setup((lm) => lm.trackEvent('ScanTaskStarted', undefined, scanStartedMeasurements)).verifiable();
         loggerMock.setup((lm) => lm.trackEvent('ScanTaskCompleted', undefined, scanCompletedMeasurements)).verifiable();
-        loggerMock.setup((lm) => lm.trackEvent('ScanTaskFailed', undefined, { failedScanTasks: 1 })).verifiable();
+        loggerMock.setup((lm) => lm.trackEvent('ScanTaskFailed', undefined, { failedScanTasks: 1 })).verifiable(Times.never());
+
+        loggerMock.setup((lm) => lm.trackEvent('BrowserScanFailed', undefined, { failedBrowserScans: 1 })).verifiable();
 
         setupTryUpdateScanRunResultCall(getRunningJobStateScanResult());
         scannerMock


### PR DESCRIPTION
#### Description of changes

This change is to separate browser originates scan issues (page not found, timeout, etc,..) from service unhandled errors. This is prerequisite for service availability based on all scan requests in addition to synthetic availability metrics

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
