### PR TITLE
fix: add network security group to vnet template

### DIFF
--- a/packages/resource-deployment/templates/vnet.template.json
+++ b/packages/resource-deployment/templates/vnet.template.json
@@ -29,9 +29,27 @@
         "enableDdosProtection": {
             "type": "bool",
             "defaultValue": false
+        },
+        "securityGroupName": {
+            "type": "string",
+            "defaultValue": "[concat('network-security-group-a11y',toLower(uniqueString(resourceGroup().id)))]",
+            "metadata": {
+                "description": "The name of the Virtual Network's security group"
+            }
         }
     },
     "resources": [
+        {
+            "name": "[parameters('securityGroupName')]",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "apiVersion": "2020-05-01",
+            "location": "[parameters('location')]",
+            "tags": {},
+            "properties": {
+                "securityRules": []
+            },
+            "resources": []
+        },
         {
             "apiVersion": "2019-04-01",
             "name": "[parameters('name')]",
@@ -46,12 +64,16 @@
                         "name": "[parameters('subnetName')]",
                         "properties": {
                             "addressPrefix": "[parameters('subnetAddressPrefix')]",
-                            "addressPrefixes": []
+                            "addressPrefixes": [],
+                            "networkSecurityGroup": {
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('securityGroupName'))]"
+                            }
                         }
                     }
                 ],
                 "enableDdosProtection": "[parameters('enableDdosProtection')]"
-            }
+            },
+            "dependsOn": ["[resourceId('Microsoft.Network/networkSecurityGroups', parameters('securityGroupName'))]"]
         }
     ]
 }

--- a/packages/resource-deployment/templates/vnet.template.json
+++ b/packages/resource-deployment/templates/vnet.template.json
@@ -46,7 +46,44 @@
             "location": "[parameters('location')]",
             "tags": {},
             "properties": {
-                "securityRules": []
+                "securityRules": [
+                    {
+                        "name": "AllowBatchPortsInbound",
+                        "properties": {
+                            "description": "Allow inbound traffic on ports needed by azure batch",
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "29876-29877",
+                            "sourceAddressPrefix": "BatchNodeManagement",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 200,
+                            "direction": "Inbound",
+                            "sourcePortRanges": [],
+                            "destinationPortRanges": [],
+                            "sourceAddressPrefixes": [],
+                            "destinationAddressPrefixes": []
+                        }
+                    },
+                    {
+                        "name": "AllowStoragePortOutBound",
+                        "properties": {
+                            "description": "Allow outbound traffic from port used by azure storage",
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "443",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "Storage",
+                            "access": "Allow",
+                            "priority": 200,
+                            "direction": "Outbound",
+                            "sourcePortRanges": [],
+                            "destinationPortRanges": [],
+                            "sourceAddressPrefixes": [],
+                            "destinationAddressPrefixes": []
+                        }
+                    }
+                ]
             },
             "resources": []
         },


### PR DESCRIPTION
#### Description of changes

Create a network security group for our vnet with rules needed to allow azure batch to access the vm nodes. This fixes an alert from the Armory tool for ARM template scanning, which is now required in our SDL pipeline.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
