### PR TITLE
feat: save site and reportGroups data from scan run request

### DIFF
--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -143,6 +143,23 @@ components:
                         value is 0.
                     default: 0
                     type: integer
+                site:
+                    type: object
+                    required:
+                        - baseUrl
+                    properties:
+                        baseUrl:
+                            description: The web site root URL to be displayed in 'Scan Details' report section
+                            type: string
+                reportGroups:
+                    type: array
+                    items:
+                        required:
+                            - consolidatedId
+                        properties:
+                            consolidatedId:
+                                description: The unique report ID for the given reporting period
+                                type: string
         ScanRunResponse:
             type: object
             required:

--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -143,6 +143,8 @@ components:
                         value is 0.
                     default: 0
                     type: integer
+                scanNotifyUrl:
+                    type: string
                 site:
                     type: object
                     required:

--- a/packages/service-library/src/web-api/web-api-error-codes.ts
+++ b/packages/service-library/src/web-api/web-api-error-codes.ts
@@ -17,7 +17,8 @@ export declare type WebApiErrorCodeName =
     | 'OutOfRangePriority'
     | 'MalformedBody'
     | 'MissingReleaseVersion'
-    | 'InvalidScanNotifyUrl';
+    | 'InvalidScanNotifyUrl'
+    | 'MissingSiteOrReportGroups';
 
 export interface WebApiErrorCode {
     statusCode: number;
@@ -139,6 +140,15 @@ export class WebApiErrorCodes {
             code: 'InvalidScanNotifyUrl',
             codeId: 4012,
             message: 'The reply URL is not valid.',
+        },
+    };
+
+    public static missingSiteOrReportGroups: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'MissingSiteOrReportGroups',
+            codeId: 4013,
+            message: 'The request is missing either the site or report groups property.',
         },
     };
 

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -92,6 +92,34 @@ describe(ScanRequestController, () => {
             expect(context.res.body[0].error).toEqual(WebApiErrorCodes.invalidScanNotifyUrl.error);
         });
 
+        it('rejects request with only one of \'site\' or \'reportGroups\' property', async () => {
+            context.req.rawBody = JSON.stringify([
+                {
+                    url: 'https://abs/path/',
+                    site: { baseUrl: 'https://base/path' },
+                },
+                {
+                    url: 'https://cde/path/',
+                    reportGroups: [{ consolidatedId: 'reportGroupId' }],
+                },
+            ]);
+
+            const expectedResponse = [
+                { url: 'https://abs/path/', error: WebApiErrorCodes.missingSiteOrReportGroups.error },
+                { url: 'https://cde/path/', error: WebApiErrorCodes.missingSiteOrReportGroups.error },
+            ];
+
+            scanRequestController = createScanRequestController(context);
+
+            await scanRequestController.handleRequest();
+
+            // normalize random result order
+            const expectedResponseSorted = sortData(expectedResponse);
+            const responseSorted = sortData(<ScanRunResponse[]>(<unknown>context.res.body));
+
+            expect(responseSorted).toEqual(expectedResponseSorted);
+        })
+
         it('accepts valid request only', async () => {
             const guid1 = '1e9cefa6-538a-6df0-aaaa-ffffffffffff';
             const guid2 = '1e9cefa6-538a-6df0-bbbb-ffffffffffff';

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -92,7 +92,7 @@ describe(ScanRequestController, () => {
             expect(context.res.body[0].error).toEqual(WebApiErrorCodes.invalidScanNotifyUrl.error);
         });
 
-        it('rejects request with only one of \'site\' or \'reportGroups\' property', async () => {
+        it("rejects request with only one of 'site' or 'reportGroups' property", async () => {
             context.req.rawBody = JSON.stringify([
                 {
                     url: 'https://abs/path/',
@@ -118,7 +118,7 @@ describe(ScanRequestController, () => {
             const responseSorted = sortData(<ScanRunResponse[]>(<unknown>context.res.body));
 
             expect(responseSorted).toEqual(expectedResponseSorted);
-        })
+        });
 
         it('accepts valid request only', async () => {
             const guid1 = '1e9cefa6-538a-6df0-aaaa-ffffffffffff';

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -99,7 +99,13 @@ describe(ScanRequestController, () => {
             guidGeneratorMock.setup((g) => g.createGuidFromBaseGuid(guid1)).returns(() => guid2);
 
             context.req.rawBody = JSON.stringify([
-                { url: 'https://abs/path/', priority: 1, scanNotifyUrl: 'https://notify/path/' }, // valid request
+                {
+                    url: 'https://abs/path/',
+                    priority: 1,
+                    scanNotifyUrl: 'https://notify/path/',
+                    site: { baseUrl: 'https://base/path' },
+                    reportGroups: [{ consolidatedId: 'reportGroupId' }],
+                }, // valid request
                 { url: '/invalid/url' }, // invalid URL
                 { url: 'https://cde/path/', priority: 9999 }, // invalid priority range
             ]);
@@ -109,7 +115,14 @@ describe(ScanRequestController, () => {
                 { url: 'https://cde/path/', error: WebApiErrorCodes.outOfRangePriority.error },
             ];
             const expectedSavedRequest: ScanRunBatchRequest[] = [
-                { scanId: guid2, url: 'https://abs/path/', priority: 1, scanNotifyUrl: 'https://notify/path/' },
+                {
+                    scanId: guid2,
+                    url: 'https://abs/path/',
+                    priority: 1,
+                    scanNotifyUrl: 'https://notify/path/',
+                    site: { baseUrl: 'https://base/path' },
+                    reportGroups: [{ consolidatedId: 'reportGroupId' }],
+                },
             ];
             scanDataProviderMock.setup(async (o) => o.writeScanRunBatchRequest(guid1, expectedSavedRequest)).verifiable(Times.once());
 

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -166,6 +166,10 @@ export class ScanRequestController extends ApiController {
             return { valid: false, error: WebApiErrorCodes.outOfRangePriority.error };
         }
 
+        if (isEmpty(scanRunRequest.site) !== isEmpty(scanRunRequest.reportGroups)) {
+            return { valid: false, error: WebApiErrorCodes.missingSiteOrReportGroups.error };
+        }
+
         return { valid: true };
     }
 

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -128,6 +128,8 @@ export class ScanRequestController extends ApiController {
                     priority: isNil(scanRunRequest.priority) ? 0 : scanRunRequest.priority,
                     url: scanRunRequest.url,
                     ...(isEmpty(scanRunRequest.scanNotifyUrl) ? {} : { scanNotifyUrl: scanRunRequest.scanNotifyUrl }),
+                    ...(isEmpty(scanRunRequest.site) ? {} : { site: scanRunRequest.site }),
+                    ...(isEmpty(scanRunRequest.reportGroups) ? {} : { reportGroups: scanRunRequest.reportGroups }),
                 });
 
                 scanResponses.push({

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -4,10 +4,17 @@ import 'reflect-metadata';
 
 import { Context } from '@azure/functions';
 import { ServiceConfiguration } from 'common';
-import { isNil } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import * as MockDate from 'mockdate';
 import { OnDemandPageScanRunResultProvider, PageScanRequestProvider, PartitionKeyFactory, ScanDataProvider } from 'service-library';
-import { ItemType, OnDemandPageScanBatchRequest, OnDemandPageScanRequest, OnDemandPageScanResult, PartitionKey } from 'storage-documents';
+import {
+    ItemType,
+    OnDemandPageScanBatchRequest,
+    OnDemandPageScanRequest,
+    OnDemandPageScanResult,
+    PartitionKey,
+    ReportGroup,
+} from 'storage-documents';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { MockableLogger } from '../test-utilities/mockable-logger';
@@ -93,6 +100,10 @@ describe(ScanBatchRequestFeedController, () => {
                         url: 'url-1',
                         priority: 1,
                         scanNotifyUrl: 'reply-url-1',
+                        site: {
+                            baseUrl: 'base-url-1',
+                        },
+                        reportGroups: [{ consolidatedId: 'consolidated-id-1' }],
                     },
                     {
                         scanId: 'scan-2',
@@ -161,6 +172,16 @@ function setupOnDemandPageScanRunResultProviderMock(documents: OnDemandPageScanB
                         scanNotifyUrl: request.scanNotifyUrl,
                     };
                 }
+                if (request.site !== undefined) {
+                    res.site = request.site;
+                }
+                if (!isEmpty(request.reportGroups)) {
+                    res.reportGroups = request.reportGroups.map<ReportGroup>((reportGroup) => {
+                        return {
+                            consolidatedId: reportGroup.consolidatedId,
+                        } as ReportGroup;
+                    });
+                }
 
                 return res;
             });
@@ -183,6 +204,13 @@ function setupPageScanRequestProviderMock(documents: OnDemandPageScanBatchReques
 
                 if (!isNil(request.scanNotifyUrl)) {
                     res.scanNotifyUrl = request.scanNotifyUrl;
+                }
+                if (!isNil(request.site)) {
+                    res.site = request.site;
+                }
+
+                if (!isEmpty(request.reportGroups)) {
+                    res.reportGroups = request.reportGroups;
                 }
 
                 return res;

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -17,6 +17,7 @@ import {
     OnDemandPageScanRequest,
     OnDemandPageScanResult,
     PartitionKey,
+    ReportGroup,
     ScanRunBatchRequest,
 } from 'storage-documents';
 
@@ -118,6 +119,14 @@ export class ScanBatchRequestFeedController extends WebController {
                               scanNotifyUrl: request.scanNotifyUrl,
                           },
                       }),
+                ...(isEmpty(request.site) ? {} : { site: request.site }),
+                ...(isEmpty(request.reportGroups)
+                    ? {}
+                    : {
+                          reportGroups: request.reportGroups.map<ReportGroup>((reportGroup) => {
+                              return { consolidatedId: reportGroup.consolidatedId } as ReportGroup;
+                          }),
+                      }),
             };
         });
 
@@ -143,6 +152,8 @@ export class ScanBatchRequestFeedController extends WebController {
                 itemType: ItemType.onDemandPageScanRequest,
                 partitionKey: PartitionKey.pageScanRequestDocuments,
                 ...scanNotifyUrl,
+                ...(isEmpty(request.site) ? {} : { site: request.site }),
+                ...(isEmpty(request.reportGroups) ? {} : { reportGroups: request.reportGroups }),
             };
         });
 


### PR DESCRIPTION
#### Description of changes

<!--- (Give an overview. Add a technical description describing your changes.) -->

- Updated `ScanRunRequest` schema in ai-scan-api.yaml to include properties from `ScanRunBatchRequest`
- Saved 'site' and 'reportGroups' properties from request in scan-request-controller and scan-batch-request-feed-controller
- Added check to validate that both 'site' and 'reportGroups' properties are present if either one is present

#### Pull request checklist

- [x] Addresses an existing issue: # 1782241
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
