### PR TITLE
feat: return mock consolidated html report link

### DIFF
--- a/packages/web-api-scan-runner/src/report-generator/axe-result-to-consolidated-html-converter.spec.ts
+++ b/packages/web-api-scan-runner/src/report-generator/axe-result-to-consolidated-html-converter.spec.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Report, Reporter, ReporterFactory } from 'accessibility-insights-report';
+import { AxeResults } from 'axe-core';
+import * as MockDate from 'mockdate';
+import { IMock, Mock, Times } from 'typemoq';
+import { ReportGenerationParams } from './axe-result-converter';
+import { AxeResultToConsolidatedHtmlConverter } from './axe-result-to-consolidated-html-converter';
+import { htmlReportStrings } from './html-report-strings';
+
+describe('AxeResultToConsolidatedHtmlConverter', () => {
+    let axeConsolidatedHtmlResultConverter: AxeResultToConsolidatedHtmlConverter;
+    let reporterMock: IMock<Reporter>;
+    let htmlReport: Report;
+    const htmlReportString = 'html report';
+    const scanUrl = 'scan url';
+    let axeResults: AxeResults;
+    const params: ReportGenerationParams = {
+        pageTitle: 'page title',
+    };
+    let time: Date;
+
+    beforeEach(() => {
+        reporterMock = Mock.ofType<Reporter>();
+        const reporterFactory: ReporterFactory = () => reporterMock.object;
+        axeConsolidatedHtmlResultConverter = new AxeResultToConsolidatedHtmlConverter(reporterFactory);
+        axeResults = ({
+            url: scanUrl,
+        } as unknown) as AxeResults;
+        htmlReport = {
+            asHTML: () => htmlReportString,
+        };
+        time = new Date(2019, 2, 3);
+        MockDate.set(time);
+    });
+
+    it('has correct report type', () => {
+        expect(axeConsolidatedHtmlResultConverter.targetReportFormat).toEqual('consolidated-html');
+    });
+
+    it('convert', () => {
+        const reportParameters = {
+            results: axeResults,
+            description: `Automated report for accessibility scan of url ${scanUrl} completed at ${time.toUTCString()}.`,
+            serviceName: htmlReportStrings.serviceName,
+            scanContext: {
+                pageTitle: params.pageTitle,
+            },
+        };
+
+        reporterMock
+            .setup((rm) => rm.fromAxeResult(reportParameters))
+            .returns(() => htmlReport)
+            .verifiable(Times.once());
+
+        const report = axeConsolidatedHtmlResultConverter.convert(axeResults, params);
+
+        reporterMock.verifyAll();
+        expect(report).toEqual(htmlReportString);
+    });
+});

--- a/packages/web-api-scan-runner/src/report-generator/axe-result-to-consolidated-html-converter.ts
+++ b/packages/web-api-scan-runner/src/report-generator/axe-result-to-consolidated-html-converter.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AxeReportParameters, ReporterFactory } from 'accessibility-insights-report';
+import { AxeResults } from 'axe-core';
+import { inject, injectable } from 'inversify';
+import { ReportFormat } from 'storage-documents';
+import { iocTypeNames } from '../ioc-types';
+import { AxeResultConverter, ReportGenerationParams } from './axe-result-converter';
+import { htmlReportStrings } from './html-report-strings';
+
+@injectable()
+export class AxeResultToConsolidatedHtmlConverter implements AxeResultConverter {
+    public readonly targetReportFormat: ReportFormat = 'consolidated-html';
+
+    constructor(@inject(iocTypeNames.ReporterFactory) private readonly reporterFactoryFunc: ReporterFactory) {}
+
+    public convert(results: AxeResults, params: ReportGenerationParams): string {
+        const reporter = this.reporterFactoryFunc();
+
+        const htmlReportParams: AxeReportParameters = {
+            results: results,
+            description: this.createDescription(results),
+            serviceName: htmlReportStrings.serviceName,
+            scanContext: {
+                pageTitle: params.pageTitle,
+            },
+        };
+
+        return reporter.fromAxeResult(htmlReportParams).asHTML();
+    }
+
+    private createDescription(results: AxeResults): string {
+        const reportGenerationTime = new Date();
+
+        return `Automated report for accessibility scan of url ${results.url} completed at ${reportGenerationTime.toUTCString()}.`;
+    }
+}

--- a/packages/web-api-scan-runner/src/report-generator/register-report-generator-to-container.spec.ts
+++ b/packages/web-api-scan-runner/src/report-generator/register-report-generator-to-container.spec.ts
@@ -27,10 +27,11 @@ describe('registerReportGeneratorToContainer', () => {
 
     it('container has both sarif and html report generators', () => {
         const axeResultConverters: AxeResultConverter[] = container.get(iocTypeNames.AxeResultConverters);
-        expect(axeResultConverters.length).toBe(2);
+        expect(axeResultConverters.length).toBe(3);
 
         const axeResultConverterTypes = axeResultConverters.map((converter) => converter.targetReportFormat);
         expect(axeResultConverterTypes).toContain('html');
         expect(axeResultConverterTypes).toContain('sarif');
+        expect(axeResultConverterTypes).toContain('consolidated-html');
     });
 });

--- a/packages/web-api-scan-runner/src/report-generator/register-report-generator-to-container.ts
+++ b/packages/web-api-scan-runner/src/report-generator/register-report-generator-to-container.ts
@@ -5,6 +5,7 @@ import { reporterFactory } from 'accessibility-insights-report';
 import { convertAxeToSarif } from 'axe-sarif-converter';
 import { Container } from 'inversify';
 import { iocTypeNames } from '../ioc-types';
+import { AxeResultToConsolidatedHtmlConverter } from './axe-result-to-consolidated-html-converter';
 import { AxeResultToHtmlConverter } from './axe-result-to-html-converter';
 import { AxeResultToSarifConverter } from './axe-result-to-sarif-converter';
 
@@ -16,5 +17,6 @@ export function registerReportGeneratorToContainer(container: Container): void {
         .toConstantValue([
             container.get<AxeResultToSarifConverter>(AxeResultToSarifConverter),
             container.get<AxeResultToHtmlConverter>(AxeResultToHtmlConverter),
+            container.get<AxeResultToConsolidatedHtmlConverter>(AxeResultToConsolidatedHtmlConverter),
         ]);
 }

--- a/packages/web-api/src/converters/scan-response-converter.spec.ts
+++ b/packages/web-api/src/converters/scan-response-converter.spec.ts
@@ -205,10 +205,10 @@ describe(ScanResponseConverter, () => {
     });
 
     it('includes consolidated-html report in response when consolidatedId is present', () => {
-        let pageScanDbResult = getPageScanResult('completed', true);
+        const pageScanDbResult = getPageScanResult('completed', true);
         pageScanDbResult.reportGroups = [{ consolidatedId: 'consolidatedId', reportId: 'reportId' }];
 
-        let responseExpected = getScanResultClientResponseFull('completed', true) as ScanRunResultResponse;
+        const responseExpected = getScanResultClientResponseFull('completed', true) as ScanRunResultResponse;
         responseExpected.reports.push({
             reportId: 'reportIdConsolidatedHtml',
             format: 'consolidated-html',

--- a/packages/web-api/src/converters/scan-response-converter.ts
+++ b/packages/web-api/src/converters/scan-response-converter.ts
@@ -4,7 +4,6 @@ import { inject, injectable } from 'inversify';
 import { isEmpty, isNil } from 'lodash';
 import { ScanCompletedNotification as NotificationResponse, ScanReport, ScanResultResponse } from 'service-library';
 import { OnDemandPageScanResult, OnDemandPageScanRunState, ScanCompletedNotification as NotificationDb } from 'storage-documents';
-
 import { ScanErrorConverter } from './scan-error-converter';
 
 @injectable()
@@ -88,7 +87,15 @@ export class ScanResponseConverter {
 
         const baseUrlFixed = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
 
-        return pageScanResultDocument.reports.map((report) => {
+        let scanReports = pageScanResultDocument.reports;
+
+        if (isEmpty(pageScanResultDocument.reportGroups)) {
+            scanReports = pageScanResultDocument.reports.filter((report) => {
+                return report.format !== 'consolidated-html';
+            });
+        }
+
+        return scanReports.map((report) => {
             return {
                 reportId: report.reportId,
                 format: report.format,


### PR DESCRIPTION
#### Description of changes

<!--- (Give an overview. Add a technical description describing your changes.) -->
- Created axe-result-to-consolidated-html-converter that currently converts axe results to html report (will be updated in another feature to convert to an actual consolidated report)
- Registered the axe-result-to-consolidated-html-converter
- Updated scan-response-converter to include the consolidated-html report only if there is a consolidatedId

#### Pull request checklist

- [x] Addresses an existing issue: # 1782243
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
