### PR TITLE
Use MSI to access CosmosDB

### DIFF
--- a/packages/azure-services/src/azure-cosmos/cosmos-key-provider.spec.ts
+++ b/packages/azure-services/src/azure-cosmos/cosmos-key-provider.spec.ts
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { ResponseWithBodyType, RetryHelper, System } from 'common';
+import { ExtendOptions, Got, Options } from 'got';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { AccessToken } from '@azure/identity';
+import { ARMServiceTokenProvider } from '../credentials/arm-service-token-provider';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { CosmosDbKeys, CosmosKeyProvider } from './cosmos-key-provider';
+
+describe(CosmosKeyProvider, () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let gotStub: any;
+    let extendMock: IMock<(options: ExtendOptions) => Got>;
+    let postMock: IMock<(url: string, options: Options) => unknown>;
+    let tokenProviderMock: IMock<ARMServiceTokenProvider>;
+    let loggerMock: IMock<MockableLogger>;
+    let retryHelperMock: IMock<RetryHelper<ResponseWithBodyType<CosmosDbKeys>>>;
+
+    const apiVersion = 'api version';
+    const maxRetries = 3;
+
+    let testSubject: CosmosKeyProvider;
+
+    beforeEach(() => {
+        extendMock = Mock.ofInstance(() => null);
+        extendMock.setup((e) => e(It.isAny())).returns(() => gotStub);
+        postMock = Mock.ofInstance(() => null);
+        gotStub = {
+            extend: extendMock.object,
+            post: postMock.object,
+        };
+        tokenProviderMock = Mock.ofType<ARMServiceTokenProvider>();
+        loggerMock = Mock.ofType<MockableLogger>();
+        retryHelperMock = Mock.ofType<RetryHelper<ResponseWithBodyType<CosmosDbKeys>>>();
+    });
+
+    it('sets default options', () => {
+        const expectedOptions: ExtendOptions = {
+            searchParams: {
+                'api-version': apiVersion,
+            },
+            responseType: 'json',
+            throwHttpErrors: true,
+        };
+        extendMock.setup((e) => e(expectedOptions)).verifiable(Times.once());
+
+        testSubject = new CosmosKeyProvider(
+            tokenProviderMock.object,
+            loggerMock.object,
+            retryHelperMock.object,
+            gotStub,
+            apiVersion,
+            maxRetries,
+        );
+
+        extendMock.verifyAll();
+    });
+
+    describe('getCosmosKey', () => {
+        const baseUrl = 'https://url.com';
+        const listKeysEndpoint = `${baseUrl}/listKeys`;
+        const token = { token: 'test token' } as AccessToken;
+        const primaryKey = 'master key';
+
+        beforeEach(() => {
+            testSubject = new CosmosKeyProvider(
+                tokenProviderMock.object,
+                loggerMock.object,
+                retryHelperMock.object,
+                gotStub,
+                apiVersion,
+                maxRetries,
+            );
+            tokenProviderMock.setup((tp) => tp.getToken()).returns(async () => token);
+        });
+
+        afterEach(() => {
+            retryHelperMock.verifyAll();
+            loggerMock.verifyAll();
+            postMock.verifyAll();
+        });
+
+        it('successfully retrieves key', async () => {
+            retryHelperMock
+                .setup((rh) => rh.executeWithRetries(It.isAny(), It.isAny(), maxRetries))
+                .returns(async (action, onRetry, maxRetryCount: number) => action())
+                .verifiable(Times.once());
+            setupRequest(getResponse(primaryKey));
+
+            const key = await testSubject.getCosmosKey(baseUrl);
+
+            expect(key).toBe(primaryKey);
+        });
+
+        it('Logs error on retry', async () => {
+            const error = new Error('test error');
+            const expectedLogMessage = 'Failed to retrieve CosmosDB key. Retrying on error.';
+            const response = getResponse(primaryKey);
+
+            retryHelperMock
+                .setup((rh) => rh.executeWithRetries(It.isAny(), It.isAny(), maxRetries))
+                .returns(async (action, onRetry, maxRetryCount: number) => {
+                    onRetry(error);
+
+                    return response;
+                })
+                .verifiable(Times.once());
+            loggerMock.setup((l) => l.logError(expectedLogMessage, { error: System.serializeError(error) })).verifiable(Times.once());
+
+            const key = await testSubject.getCosmosKey(baseUrl);
+
+            expect(key).toBe(primaryKey);
+        });
+
+        it('Throws error if body does not contain primary key', async () => {
+            const expectedLogMessage = 'Response body did not contain CosmosDB primary key.';
+            const expectedError = new Error('Failed to retrieve CosmosDB primary key');
+            const response = getResponse(null);
+
+            retryHelperMock
+                .setup((rh) => rh.executeWithRetries(It.isAny(), It.isAny(), maxRetries))
+                .returns(async (action, onRetry, maxRetryCount: number) => action())
+                .verifiable(Times.once());
+            setupRequest(response);
+            loggerMock.setup((l) => l.logError(expectedLogMessage, { response: JSON.stringify(response) })).verifiable(Times.once());
+
+            try {
+                await testSubject.getCosmosKey(baseUrl);
+                fail('test should throw an error');
+            } catch (e) {
+                expect(e).toEqual(expectedError);
+            }
+        });
+
+        function setupRequest(response: ResponseWithBodyType<CosmosDbKeys>): void {
+            const expectedOptions = {
+                headers: {
+                    authorization: `Bearer ${token.token}`,
+                },
+            };
+            postMock
+                .setup((p) => p(listKeysEndpoint, expectedOptions))
+                .returns(() => response)
+                .verifiable(Times.once());
+        }
+
+        function getResponse(key: string | null): ResponseWithBodyType<CosmosDbKeys> {
+            return {
+                body: {
+                    primaryMasterKey: key,
+                },
+            } as ResponseWithBodyType<CosmosDbKeys>;
+        }
+    });
+});

--- a/packages/azure-services/src/azure-cosmos/cosmos-key-provider.ts
+++ b/packages/azure-services/src/azure-cosmos/cosmos-key-provider.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { getSerializableResponse, ResponseWithBodyType, RetryHelper, System } from 'common';
+import got, { Got, Options } from 'got';
+import { inject, injectable } from 'inversify';
+import { isNil } from 'lodash';
+import { GlobalLogger } from 'logger';
+import { ARMServiceTokenProvider } from '../credentials/arm-service-token-provider';
+
+export type CosmosDbKeys = {
+    primaryMasterKey: string;
+    primaryReadonlyMasterKey: string;
+    secondaryMasterKey: string;
+    secondaryReadonlyMasterKey: string;
+};
+
+@injectable()
+export class CosmosKeyProvider {
+    private readonly defaultRequestObject: Got;
+
+    constructor(
+        @inject(ARMServiceTokenProvider) private readonly tokenProvider: ARMServiceTokenProvider,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(RetryHelper) private readonly retryHelper: RetryHelper<ResponseWithBodyType<CosmosDbKeys>>,
+        requestObject: Got = got,
+        private readonly apiVersion: string = '2020-04-01',
+        private readonly maxRetries: number = 3,
+    ) {
+        this.defaultRequestObject = requestObject.extend({
+            searchParams: {
+                'api-version': this.apiVersion,
+            },
+            responseType: 'json',
+            throwHttpErrors: true,
+        });
+    }
+
+    public async getCosmosKey(cosmosDbApiBaseUrl: string): Promise<string> {
+        const token = await this.tokenProvider.getToken();
+
+        const endpoint = `${cosmosDbApiBaseUrl}/listKeys`;
+        const options: Options = {
+            headers: {
+                authorization: `Bearer ${token.token}`,
+            },
+        };
+
+        const response = await this.retryHelper.executeWithRetries(
+            async () => (await this.defaultRequestObject.post(endpoint, options)) as ResponseWithBodyType<CosmosDbKeys>,
+            async (e: Error) => {
+                this.logger.logError('Failed to retrieve CosmosDB key. Retrying on error.', { error: System.serializeError(e) });
+            },
+            this.maxRetries,
+        );
+
+        if (isNil(response.body?.primaryMasterKey)) {
+            const serializedResponse = JSON.stringify(getSerializableResponse(response));
+            this.logger.logError('Response body did not contain CosmosDB primary key.', { response: serializedResponse });
+            throw new Error('Failed to retrieve CosmosDB primary key');
+        }
+
+        return response.body.primaryMasterKey;
+    }
+}

--- a/packages/azure-services/src/credentials/arm-service-token-provider.spec.ts
+++ b/packages/azure-services/src/credentials/arm-service-token-provider.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { AccessToken, ChainedTokenCredential } from '@azure/identity';
+import { RetryHelper, System } from 'common';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { ARMServiceTokenProvider } from './arm-service-token-provider';
+
+describe(ARMServiceTokenProvider, () => {
+    let retryHelperMock: IMock<RetryHelper<AccessToken>>;
+    let loggerMock: IMock<MockableLogger>;
+    let tokenProviderMock: IMock<ChainedTokenCredential>;
+    const scope = 'scope';
+    const maxRetries = 3;
+
+    let testSubject: ARMServiceTokenProvider;
+
+    beforeEach(() => {
+        retryHelperMock = Mock.ofType<RetryHelper<AccessToken>>();
+        loggerMock = Mock.ofType<MockableLogger>();
+        tokenProviderMock = Mock.ofType<ChainedTokenCredential>();
+
+        testSubject = new ARMServiceTokenProvider(
+            retryHelperMock.object,
+            loggerMock.object,
+            () => tokenProviderMock.object,
+            scope,
+            maxRetries,
+        );
+    });
+
+    afterEach(() => {
+        retryHelperMock.verifyAll();
+        tokenProviderMock.verifyAll();
+        loggerMock.verifyAll();
+    });
+
+    it('retrieves token with retries', async () => {
+        const accessTokenStub = {} as AccessToken;
+
+        retryHelperMock
+            .setup((rh) => rh.executeWithRetries(It.isAny(), It.isAny(), maxRetries))
+            .returns(async (action, onRetry, maxRetryCount) => action())
+            .verifiable(Times.once());
+
+        tokenProviderMock
+            .setup((tp) => tp.getToken(scope))
+            .returns(async () => accessTokenStub)
+            .verifiable(Times.once());
+
+        const recievedToken = await testSubject.getToken();
+
+        expect(recievedToken).toBe(accessTokenStub);
+    });
+
+    it('Logs error on retry', async () => {
+        const error = new Error('test error');
+        const expectedLogMessage = 'Failed to get ARM service token. Retrying on error';
+
+        retryHelperMock
+            .setup((rh) => rh.executeWithRetries(It.isAny(), It.isAny(), maxRetries))
+            .returns(async (action, onRetry, maxRetryCount) => onRetry(error))
+            .verifiable(Times.once());
+
+        loggerMock.setup((l) => l.logError(expectedLogMessage, { error: System.serializeError(error) })).verifiable(Times.once());
+
+        await testSubject.getToken();
+    });
+});

--- a/packages/azure-services/src/credentials/arm-service-token-provider.ts
+++ b/packages/azure-services/src/credentials/arm-service-token-provider.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AccessToken, ChainedTokenCredential, DefaultAzureCredential } from '@azure/identity';
+import { RetryHelper, System } from 'common';
+import { inject, injectable } from 'inversify';
+import { GlobalLogger } from 'logger';
+
+const ARMApiScope = 'https://management.azure.com/';
+
+export type TokenCredentialProvider = () => ChainedTokenCredential;
+const getDefaultTokenProvider = () => new DefaultAzureCredential();
+
+@injectable()
+export class ARMServiceTokenProvider {
+    constructor(
+        @inject(RetryHelper) private readonly retryHelper: RetryHelper<AccessToken>,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        private readonly tokenCredentialProvider: TokenCredentialProvider = getDefaultTokenProvider,
+        private readonly scope: string = ARMApiScope,
+        private readonly maxRetries: number = 3,
+    ) {}
+
+    public async getToken(): Promise<AccessToken> {
+        return this.retryHelper.executeWithRetries(
+            () => this.tokenCredentialProvider().getToken(this.scope),
+            async (e: Error) => {
+                this.logger.logError('Failed to get ARM service token. Retrying on error', { error: System.serializeError(e) });
+            },
+            this.maxRetries,
+        );
+    }
+}

--- a/packages/azure-services/src/key-vault/secret-names.ts
+++ b/packages/azure-services/src/key-vault/secret-names.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 export const secretNames = {
     cosmosDbUrl: 'cosmosDbUrl',
+    cosmosDbApiUrl: 'cosmosDbApiUrl',
     cosmosDbKey: 'cosmosDbKey',
     storageAccountName: 'storageAccountName',
     storageAccountKey: 'storageAccountKey',

--- a/packages/azure-services/src/key-vault/secret-names.ts
+++ b/packages/azure-services/src/key-vault/secret-names.ts
@@ -3,7 +3,6 @@
 export const secretNames = {
     cosmosDbUrl: 'cosmosDbUrl',
     cosmosDbApiUrl: 'cosmosDbApiUrl',
-    cosmosDbKey: 'cosmosDbKey',
     storageAccountName: 'storageAccountName',
     storageAccountKey: 'storageAccountKey',
     restApiSpAppId: 'restApiSpAppId',

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -22,6 +22,7 @@ import { cosmosContainerClientTypes, iocTypeNames } from './ioc-types';
 import { secretNames } from './key-vault/secret-names';
 import { SecretProvider } from './key-vault/secret-provider';
 import { CosmosContainerClient } from './storage/cosmos-container-client';
+import { CosmosKeyProvider } from './azure-cosmos/cosmos-key-provider';
 
 export interface StorageKey {
     accountName: string;
@@ -47,6 +48,8 @@ export function registerAzureServicesToContainer(
     container.bind(SecretProvider).toSelf().inSingletonScope();
 
     container.bind(StorageConfig).toSelf().inSingletonScope();
+
+    container.bind(CosmosKeyProvider).toSelf().inSingletonScope();
 
     setupSingletonCosmosClientProvider(container, cosmosClientFactory);
 
@@ -156,15 +159,21 @@ function setupSingletonCosmosClientProvider(
     cosmosClientFactory: (options: CosmosClientOptions) => CosmosClient,
 ): void {
     IoC.setupSingletonProvider<CosmosClient>(iocTypeNames.CosmosClientProvider, container, async (context) => {
-        if (process.env.COSMOS_DB_URL !== undefined && process.env.COSMOS_DB_KEY !== undefined) {
-            return cosmosClientFactory({ endpoint: process.env.COSMOS_DB_URL, key: process.env.COSMOS_DB_KEY });
+        let cosmosDbUrl: string;
+        let cosmosDbApiUrl: string;
+        if (process.env.COSMOS_DB_URL !== undefined && process.env.COSMOS_DB_API_URL !== undefined) {
+            cosmosDbUrl = process.env.COSMOS_DB_URL;
+            cosmosDbApiUrl = process.env.COSMOS_DB_API_URL;
         } else {
             const secretProvider = context.container.get(SecretProvider);
-            const cosmosDbUrl = await secretProvider.getSecret(secretNames.cosmosDbUrl);
-            const cosmosDbKey = await secretProvider.getSecret(secretNames.cosmosDbKey);
-
-            return cosmosClientFactory({ endpoint: cosmosDbUrl, key: cosmosDbKey });
+            cosmosDbUrl = await secretProvider.getSecret(secretNames.cosmosDbUrl);
+            cosmosDbApiUrl = await secretProvider.getSecret(secretNames.cosmosDbApiUrl);
         }
+
+        const cosmosKeyProvider = context.container.get(CosmosKeyProvider);
+        const cosmosDbKey = await cosmosKeyProvider.getCosmosKey(cosmosDbApiUrl);
+
+        return cosmosClientFactory({ endpoint: cosmosDbUrl, key: cosmosDbKey });
     });
 }
 

--- a/packages/resource-deployment/scripts/create-env-file-for-debug.sh
+++ b/packages/resource-deployment/scripts/create-env-file-for-debug.sh
@@ -23,15 +23,6 @@ getCosmosDbUrl() {
     fi
 }
 
-getCosmosDbAccessKey() {
-    cosmosDbAccessKey=$(az cosmosdb keys list --name "$cosmosAccountName" --resource-group "$resourceGroupName" --query "primaryMasterKey" -o tsv)
-
-    if [[ -z $cosmosDbAccessKey ]]; then
-        echo "Unable to get access key for cosmos DB account $cosmosAccountName"
-        exit 1
-    fi
-}
-
 getCosmosDbApiUrl() {
     cosmosDbApiUrl="https://management.azure.com/subscriptions/$subscription/resourceGroups/$resourceGroupName/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosAccountName"
 }
@@ -110,7 +101,6 @@ KEY_VAULT_URL=https://$keyVault.vault.azure.net/
 APPINSIGHTS_INSTRUMENTATIONKEY=$appInsightInstrumentationKey
 
 COSMOS_DB_URL=$cosmosDbUrl
-COSMOS_DB_KEY=$cosmosDbAccessKey
 COSMOS_DB_API_URL=$cosmosDbApiUrl
 
 AZURE_STORAGE_NAME=$storageAccountName

--- a/packages/resource-deployment/scripts/create-env-file-for-debug.sh
+++ b/packages/resource-deployment/scripts/create-env-file-for-debug.sh
@@ -32,6 +32,10 @@ getCosmosDbAccessKey() {
     fi
 }
 
+getCosmosDbApiUrl() {
+    cosmosDbApiUrl="https://management.azure.com/subscriptions/$subscription/resourceGroups/$resourceGroupName/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosAccountName"
+}
+
 getStorageAccessKey() {
     storageAccountKey=$(az storage account keys list --account-name "$storageAccountName" --query "[0].value" -o tsv)
 
@@ -77,6 +81,7 @@ fi
 
 getCosmosDbUrl
 getCosmosDbAccessKey
+getCosmosDbApiUrl
 getStorageAccessKey
 getAppInsightKey
 getBatchAccountEndpoint
@@ -106,6 +111,7 @@ APPINSIGHTS_INSTRUMENTATIONKEY=$appInsightInstrumentationKey
 
 COSMOS_DB_URL=$cosmosDbUrl
 COSMOS_DB_KEY=$cosmosDbAccessKey
+COSMOS_DB_API_URL=$cosmosDbApiUrl
 
 AZURE_STORAGE_NAME=$storageAccountName
 AZURE_STORAGE_KEY=$storageAccountKey

--- a/packages/resource-deployment/scripts/function-app-create.sh
+++ b/packages/resource-deployment/scripts/function-app-create.sh
@@ -156,16 +156,26 @@ function enableStorageAccess() {
     . "${0%/*}/role-assign-for-sp.sh"
 }
 
+function enableCosmosAccess() {
+    cosmosAccountId=$(az cosmosdb show --name "$cosmosAccountName" --resource-group "$resourceGroupName" --query id -o tsv)
+    scope="--scope $cosmosAccountId"
+    
+    role="DocumentDB Account Contributor"
+    . "${0%/*}/role-assign-for-sp.sh"
+}
+
 function enableManagedIdentityOnFunctions() {
     getFunctionAppPrincipalId $webApiFuncAppName
     . "${0%/*}/key-vault-enable-msi.sh"
 
     enableStorageAccess
+    enableCosmosAccess
 
     getFunctionAppPrincipalId $webWorkersFuncAppName
     . "${0%/*}/key-vault-enable-msi.sh"
 
     enableStorageAccess
+    enableCosmosAccess
 }
 
 function publishWebApiScripts() {

--- a/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
+++ b/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
@@ -91,6 +91,10 @@ getCosmosAccessKey() {
     fi
 }
 
+getCosmosDbApiUrl() {
+    cosmosDbApiUrl="https://management.azure.com/subscriptions/$subscription/resourceGroups/$resourceGroupName/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosAccountName"
+}
+
 getStorageAccessKey() {
     storageAccountKey=$(az storage account keys list --account-name "$storageAccountName" --query "[0].value" -o tsv)
 
@@ -144,6 +148,9 @@ if [[ -z $resourceGroupName ]] || [[ -z $webApiAdClientId ]] || [[ -z $webApiAdC
     exitWithUsageInfo
 fi
 
+# Get the default subscription
+subscription=$(az account show --query "id" -o tsv)
+
 . "${0%/*}/get-resource-names.sh"
 
 echo "Pushing secrets to keyvault $keyVault in resourceGroup $resourceGroupName"
@@ -155,6 +162,9 @@ grantWritePermissionToKeyVault
 
 getCosmosDbUrl
 pushSecretToKeyVault "cosmosDbUrl" "$cosmosDbUrl"
+
+getCosmosDbApiUrl
+pushSecretToKeyVault "cosmosDbApiUrl" "$cosmosDbApiUrl"
 
 getCosmosAccessKey
 pushSecretToKeyVault "cosmosDbKey" "$cosmosAccessKey"

--- a/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
+++ b/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
@@ -10,7 +10,6 @@ export resourceGroupName
 export storageAccountName
 export cosmosAccountName
 export cosmosDbUrl
-export cosmosAccessKey
 export containerRegistryName
 
 export loggedInUserType
@@ -78,15 +77,6 @@ getCosmosDbUrl() {
 
     if [[ -z $cosmosDbUrl ]]; then
         echo "Unable to get cosmos db url for cosmos account $cosmosAccountName under resource group $resourceGroupName"
-        exit 1
-    fi
-}
-
-getCosmosAccessKey() {
-    cosmosAccessKey=$(az cosmosdb keys list --name "$cosmosAccountName" --resource-group "$resourceGroupName" --query "primaryMasterKey" -o tsv)
-
-    if [[ -z $cosmosAccessKey ]]; then
-        echo "Unable to get accessKey for cosmos db account $cosmosAccountName under resource group $resourceGroupName"
         exit 1
     fi
 }
@@ -165,9 +155,6 @@ pushSecretToKeyVault "cosmosDbUrl" "$cosmosDbUrl"
 
 getCosmosDbApiUrl
 pushSecretToKeyVault "cosmosDbApiUrl" "$cosmosDbApiUrl"
-
-getCosmosAccessKey
-pushSecretToKeyVault "cosmosDbKey" "$cosmosAccessKey"
 
 pushSecretToKeyVault "storageAccountName" "$storageAccountName"
 


### PR DESCRIPTION
#### Description of changes

Instead of storing the cosmosdb access key in keyvault, use [MSI and the azure REST API](https://docs.microsoft.com/en-us/azure/cosmos-db/managed-identity-based-authentication) to retrieve the key at runtime.

- Add cosmosDB contributor roles for function apps and batch pools
- Add classes to retrieve the cosmosdb access key
- Remove the cosmosdb key from keyvault and store the base URL for the listKeys REST call instead
- Refactor azure services setup code to fetch the key with an MSI token instead of pulling the key from keyvault

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5068
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
