### PR TITLE
chore(deps): Use @azure/keyvault-secrets

### DIFF
--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -46,7 +46,7 @@
         "@azure/batch": "^7.0.0",
         "@azure/cosmos": "^3.9.1",
         "@azure/identity": "^1.1.0",
-        "@azure/keyvault": "^0.1.0",
+        "@azure/keyvault-secrets": "^4.1.0",
         "@azure/ms-rest-nodeauth": "^1.1.1",
         "@azure/storage-blob": "12.2.1",
         "@azure/storage-queue": "^10.1.0",

--- a/packages/azure-services/src/credentials/credentials-provider.spec.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.spec.ts
@@ -17,15 +17,15 @@ describe(CredentialsProvider, () => {
         msiCredProviderMock = Mock.ofType(MSICredentialsProvider);
     });
 
-    it('gets key vault credentials with MSI auth', async () => {
+    it('gets batch credentials with MSI auth', async () => {
         testSubject = new CredentialsProvider(msiCredProviderMock.object);
 
         msiCredProviderMock
-            .setup(async (r) => r.getCredentials('https://vault.azure.net'))
+            .setup(async (r) => r.getCredentials('https://batch.core.windows.net/'))
             .returns(async () => Promise.resolve(credentialsStub))
             .verifiable(Times.once());
 
-        const actualCredentials = await testSubject.getCredentialsForKeyVault();
+        const actualCredentials = await testSubject.getCredentialsForBatch();
 
         expect(actualCredentials).toBe(credentialsStub);
         msiCredProviderMock.verifyAll();

--- a/packages/azure-services/src/credentials/credentials-provider.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.ts
@@ -7,11 +7,6 @@ import { Credentials, MSICredentialsProvider } from './msi-credential-provider';
 export class CredentialsProvider {
     constructor(@inject(MSICredentialsProvider) private readonly msiCredentialProvider: MSICredentialsProvider) {}
 
-    public async getCredentialsForKeyVault(): Promise<Credentials> {
-        // referred https://azure.microsoft.com/en-us/resources/samples/app-service-msi-keyvault-node/
-        return this.getCredentialsForResource('https://vault.azure.net');
-    }
-
     public async getCredentialsForBatch(): Promise<Credentials> {
         // eslint-disable-next-line max-len
         // referred https://docs.microsoft.com/en-us/rest/api/batchservice/authenticate-requests-to-the-azure-batch-service#authentication-via-azure-ad

--- a/packages/azure-services/src/ioc-types.ts
+++ b/packages/azure-services/src/ioc-types.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { BatchServiceClient } from '@azure/batch';
 import { CosmosClient } from '@azure/cosmos';
-import { KeyVaultClient } from '@azure/keyvault';
+import { SecretClient } from '@azure/keyvault-secrets';
 import { BlobServiceClient } from '@azure/storage-blob';
 import { MessageIdURL, MessagesURL, QueueURL, ServiceURL } from '@azure/storage-queue';
 
@@ -20,7 +20,7 @@ export const iocTypeNames = {
     BatchServiceClientProvider: 'BatchServiceClientProvider',
 };
 
-export type AzureKeyVaultClientProvider = () => Promise<KeyVaultClient>;
+export type AzureKeyVaultClientProvider = () => Promise<SecretClient>;
 export type BlobServiceClientProvider = () => Promise<BlobServiceClient>;
 export type CosmosClientProvider = () => Promise<CosmosClient>;
 export type QueueURLProvider = typeof QueueURL.fromServiceURL;

--- a/packages/azure-services/src/key-vault/secret-provider.ts
+++ b/packages/azure-services/src/key-vault/secret-provider.ts
@@ -1,20 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { EnvironmentSettings } from 'common';
+import { SecretClient } from '@azure/keyvault-secrets';
 import { inject, injectable } from 'inversify';
 import { AzureKeyVaultClientProvider, iocTypeNames } from '../ioc-types';
 
 @injectable()
 export class SecretProvider {
-    constructor(
-        @inject(iocTypeNames.AzureKeyVaultClientProvider) private readonly keyVaultClientProvider: AzureKeyVaultClientProvider,
-        @inject(EnvironmentSettings) private readonly environmentSettings: EnvironmentSettings,
-    ) {}
+    constructor(@inject(iocTypeNames.AzureKeyVaultClientProvider) private readonly keyVaultClientProvider: AzureKeyVaultClientProvider) {}
 
     public async getSecret(name: string): Promise<string> {
-        const client = await this.keyVaultClientProvider();
-        const keyVaultUrl = this.environmentSettings.getValue('KEY_VAULT_URL');
-        const result = await client.getSecret(keyVaultUrl, name, '');
+        const client: SecretClient = await this.keyVaultClientProvider();
+        const result = await client.getSecret(name);
 
         return result.value;
     }

--- a/packages/azure-services/src/register-azure-services-to-container.spec.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.spec.ts
@@ -4,7 +4,6 @@
 import 'reflect-metadata';
 
 import { CosmosClient, CosmosClientOptions } from '@azure/cosmos';
-import { KeyVaultClient } from '@azure/keyvault';
 import * as msRestNodeAuth from '@azure/ms-rest-nodeauth';
 import { BlobServiceClient } from '@azure/storage-blob';
 import { MessageIdURL, MessagesURL, QueueURL } from '@azure/storage-queue';
@@ -12,6 +11,7 @@ import { Container, interfaces } from 'inversify';
 import * as _ from 'lodash';
 import { ContextAwareLogger, registerLoggerToContainer } from 'logger';
 import { IMock, Mock, Times } from 'typemoq';
+import { SecretClient } from '@azure/keyvault-secrets';
 import { CosmosClientWrapper } from './azure-cosmos/cosmos-client-wrapper';
 import { Queue } from './azure-queue/queue';
 import { StorageConfig } from './azure-queue/storage-config';
@@ -216,28 +216,15 @@ describe(registerAzureServicesToContainer, () => {
     });
 
     describe('AzureKeyVaultClientProvider', () => {
-        let credentialsStub: msRestNodeAuth.ApplicationTokenCredentials;
-        let credentialsProviderMock: IMock<CredentialsProvider>;
-
         beforeEach(() => {
-            credentialsStub = new msRestNodeAuth.ApplicationTokenCredentials('clientId', 'domain', 'secret');
-            credentialsProviderMock = Mock.ofType(CredentialsProvider);
             registerAzureServicesToContainer(container);
-
-            stubBinding(container, CredentialsProvider, credentialsProviderMock.object);
-
-            credentialsProviderMock
-                .setup(async (c) => c.getCredentialsForKeyVault())
-                .returns(async () => Promise.resolve(credentialsStub))
-                .verifiable(Times.once());
         });
 
         it('gets KeyVaultClient', async () => {
             const keyVaultClientProvider = container.get<AzureKeyVaultClientProvider>(iocTypeNames.AzureKeyVaultClientProvider);
             const keyVaultClient = await keyVaultClientProvider();
 
-            expect(keyVaultClient).toBeInstanceOf(KeyVaultClient);
-            credentialsProviderMock.verifyAll();
+            expect(keyVaultClient).toBeInstanceOf(SecretClient);
         });
 
         it('gets singleton KeyVaultClient', async () => {
@@ -248,7 +235,6 @@ describe(registerAzureServicesToContainer, () => {
             const keyVaultClient2Promise = keyVaultClientProvider2();
 
             expect(await keyVaultClient1Promise).toBe(await keyVaultClient2Promise);
-            credentialsProviderMock.verifyAll();
         });
     });
 

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { BatchServiceClient } from '@azure/batch';
 import { CosmosClient, CosmosClientOptions } from '@azure/cosmos';
-import { KeyVaultClient } from '@azure/keyvault';
 import * as msRestNodeAuth from '@azure/ms-rest-nodeauth';
 import { BlobServiceClient } from '@azure/storage-blob';
 import { MessageIdURL, MessagesURL, QueueURL, ServiceURL, SharedKeyCredential, StorageURL } from '@azure/storage-queue';
@@ -10,6 +9,7 @@ import { IoC } from 'common';
 import { Container, interfaces } from 'inversify';
 import { ContextAwareLogger } from 'logger';
 import { DefaultAzureCredential } from '@azure/identity';
+import { SecretClient } from '@azure/keyvault-secrets';
 import { Batch } from './azure-batch/batch';
 import { BatchConfig } from './azure-batch/batch-config';
 import { StorageContainerSASUrlProvider } from './azure-blob/storage-container-sas-url-provider';
@@ -133,11 +133,10 @@ function setupAuthenticationMethod(container: interfaces.Container): void {
 }
 
 function setupSingletonAzureKeyVaultClientProvider(container: interfaces.Container): void {
-    IoC.setupSingletonProvider<KeyVaultClient>(iocTypeNames.AzureKeyVaultClientProvider, container, async (context) => {
-        const credentialsProvider = context.container.get(CredentialsProvider);
-        const credentials = await credentialsProvider.getCredentialsForKeyVault();
+    IoC.setupSingletonProvider<SecretClient>(iocTypeNames.AzureKeyVaultClientProvider, container, async (context) => {
+        const credentials = new DefaultAzureCredential();
 
-        return new KeyVaultClient(credentials);
+        return new SecretClient(process.env.KEY_VAULT_URL, credentials);
     });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,14 +157,19 @@
   optionalDependencies:
     keytar "^5.4.0"
 
-"@azure/keyvault@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@azure/keyvault/-/keyvault-0.1.0.tgz#7cff48eaf3b933b01967148b634da6661de2ab04"
-  integrity sha512-CUuXCIR8GVVVxBC0NojeTrxAxTWMGKQHaQICIW4Yc51rqAoOd5AwTgnCNxacU2sjrINZo4MSZ3xbE5gn+hQWUQ==
+"@azure/keyvault-secrets@^0.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@azure/keyvault-secrets/-/keyvault-secrets-4.1.0.tgz#47f30639344eefe6ac9e5b558347ea1f626163ef"
+  integrity sha512-26ARU97svPkv8q6QbIdwdky8ntn+Q5mxTTCjpp9FUIyA2LTXmEL0wZDPBeM3mxZLHKnMEXQxEo+KYutrJW5xPQ==
   dependencies:
-    "@azure/ms-rest-azure-js" "^1.1.0"
-    "@azure/ms-rest-js" "^1.1.0"
-    tslib "^1.9.3"
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-http" "^1.1.6"
+    "@azure/core-lro" "^1.0.2"
+    "@azure/core-paging" "^1.1.1"
+    "@azure/core-tracing" "1.0.0-preview.9"
+    "@azure/logger" "^1.0.0"
+    "@opentelemetry/api" "^0.10.2"
+    tslib "^2.0.0"
 
 "@azure/logger@^1.0.0":
   version "1.0.0"
@@ -178,7 +183,7 @@
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-1.1.2.tgz#8505873afd4a1227ec040894a64fdd736b4a101f"
   integrity sha512-l7z0DPCi2Hp88w12JhDTtx5d0Y3+vhfE7JKJb9O7sEz71Cwp053N8piTtTnnk/tUor9oZHgEKi/p3tQQmLPjvA==
 
-"@azure/ms-rest-azure-js@^1.1.0", "@azure/ms-rest-azure-js@^1.3.4":
+"@azure/ms-rest-azure-js@^1.3.4":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-js/-/ms-rest-azure-js-1.3.8.tgz#96b518223d3baa2496b2981bc07288b3d887486e"
   integrity sha512-AHLfDTCyIH6wBK6+CpImI6sc9mLZ17ZgUrTx3Rhwv+3Mb3Z73BxormkarfR6Stb6scrBYitxJ27FXyndXlGAYg==
@@ -186,7 +191,7 @@
     "@azure/ms-rest-js" "^1.8.10"
     tslib "^1.9.3"
 
-"@azure/ms-rest-js@^1.1.0", "@azure/ms-rest-js@^1.8.10", "@azure/ms-rest-js@^1.8.6", "@azure/ms-rest-js@^1.8.7":
+"@azure/ms-rest-js@^1.8.10", "@azure/ms-rest-js@^1.8.6", "@azure/ms-rest-js@^1.8.7":
   version "1.8.15"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-1.8.15.tgz#4267b6b8c00d85301791fe0cf347e0455a807338"
   integrity sha512-kIB71V3DcrA4iysBbOsYcxd4WWlOE7OFtCUYNfflPODM0lbIR23A236QeTn5iAeYwcHmMjR/TAKp5KQQh/WqoQ==


### PR DESCRIPTION
#### Description of changes

Replace the deprecated @azure/keyvault package with @azure/keyvault-secrets. This will partially unblock #1122. 

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
