### PR TITLE
Update storage queue SDK and use MSI to access queue

### DIFF
--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -49,7 +49,7 @@
         "@azure/keyvault-secrets": "^4.1.0",
         "@azure/ms-rest-nodeauth": "^3.0.6",
         "@azure/storage-blob": "12.2.1",
-        "@azure/storage-queue": "^10.1.0",
+        "@azure/storage-queue": "^12.2.0",
         "common": "1.0.0",
         "dotenv": "^8.2.0",
         "got": "^11.8.0",

--- a/packages/azure-services/src/azure-queue/queue.ts
+++ b/packages/azure-services/src/azure-queue/queue.ts
@@ -1,21 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as util from 'util';
-import { Aborter, MessageIdURL, MessagesURL, Models, QueueURL } from '@azure/storage-queue';
 import { QueueRuntimeConfig, RetryHelper, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import * as _ from 'lodash';
 import { ContextAwareLogger } from 'logger';
-import { iocTypeNames, MessageIdURLProvider, MessagesURLProvider, QueueServiceURLProvider, QueueURLProvider } from '../ioc-types';
+import { DequeuedMessageItem, MessagesDequeueOptionalParams, QueueClient } from '@azure/storage-queue';
+import { iocTypeNames, QueueServiceClientProvider } from '../ioc-types';
 import { Message } from './message';
 
 @injectable()
 export class Queue {
     constructor(
-        @inject(iocTypeNames.QueueServiceURLProvider) private readonly queueServiceURLProvider: QueueServiceURLProvider,
-        @inject(iocTypeNames.QueueURLProvider) private readonly queueURLProvider: QueueURLProvider,
-        @inject(iocTypeNames.MessagesURLProvider) private readonly messagesURLProvider: MessagesURLProvider,
-        @inject(iocTypeNames.MessageIdURLProvider) private readonly messageIdURLProvider: MessageIdURLProvider,
+        @inject(iocTypeNames.QueueServiceClientProvider) private readonly queueServiceClientProvider: QueueServiceClientProvider,
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(ContextAwareLogger) private readonly logger: ContextAwareLogger,
         @inject(RetryHelper) private readonly retryHelper: RetryHelper<void>,
@@ -29,16 +26,16 @@ export class Queue {
     public async getMessages(queue: string, numberOfMessages: number = 32): Promise<Message[]> {
         const maxDequeueCount = (await this.getQueueConfig()).maxDequeueCount;
         const messages: Message[] = [];
-        const queueURL = await this.getQueueURL(queue);
-        const deadQueueURL = await this.getQueueURL(`${queue}-dead`);
+        const queueClient = await this.getQueueClient(queue);
+        const deadQueueURL = await this.getQueueClient(`${queue}-dead`);
 
-        await this.ensureQueueExists(queueURL);
+        await this.ensureQueueExists(queueClient);
         await this.ensureQueueExists(deadQueueURL);
 
-        const serverMessages = await this.getQueueMessages(queueURL, numberOfMessages);
+        const serverMessages = await this.getQueueMessages(queueClient, numberOfMessages);
         for (const serverMessage of serverMessages) {
             if (serverMessage.dequeueCount > maxDequeueCount) {
-                await this.moveToDeadQueue(queueURL, deadQueueURL, serverMessage);
+                await this.moveToDeadQueue(queueClient, deadQueueURL, serverMessage);
 
                 this.logger.logWarn(
                     `Storage queue message ${serverMessage.messageId} exceeded dequeue threshold of ${maxDequeueCount} and moved to the ${queue}-dead queue.`,
@@ -68,7 +65,7 @@ export class Queue {
     }
 
     public async deleteMessage(queue: string, message: Message): Promise<void> {
-        const queueURL = await this.getQueueURL(queue);
+        const queueURL = await this.getQueueClient(queue);
 
         return this.deleteQueueMessage(queueURL, message.messageId, message.popReceipt);
     }
@@ -86,16 +83,14 @@ export class Queue {
     }
 
     public async getMessageCount(queue: string): Promise<number> {
-        const queueURL = await this.getQueueURL(queue);
-        const queueProperties = await queueURL.getProperties(Aborter.none);
+        const queueClient = await this.getQueueClient(queue);
+        const queueProperties = await queueClient.getProperties();
 
         return queueProperties.approximateMessagesCount;
     }
 
-    public async createQueueMessage(queueURL: QueueURL, message: unknown): Promise<unknown> {
-        const messagesURL = this.getMessagesURL(queueURL);
-
-        const response = await messagesURL.enqueue(Aborter.none, JSON.stringify(message));
+    public async createQueueMessage(queueClient: QueueClient, message: unknown): Promise<unknown> {
+        const response = await queueClient.sendMessage(JSON.stringify(message));
         if (_.isNil(response) || _.isNil(response.messageId)) {
             throw new Error(`Enqueue failed with response: ${util.inspect(response)}`);
         }
@@ -106,7 +101,7 @@ export class Queue {
     private async tryCreateMessage(queue: string, message: unknown): Promise<void> {
         return this.retryHelper.executeWithRetries(
             async () => {
-                const queueURL = await this.getQueueURL(queue);
+                const queueURL = await this.getQueueClient(queue);
                 await this.ensureQueueExists(queueURL);
                 await this.createQueueMessage(queueURL, message);
             },
@@ -118,58 +113,39 @@ export class Queue {
         );
     }
 
-    private async ensureQueueExists(queueURL: QueueURL): Promise<void> {
-        try {
-            await queueURL.getProperties(Aborter.none);
-        } catch {
-            await queueURL.create(Aborter.none);
-        }
+    private async ensureQueueExists(queueClient: QueueClient): Promise<void> {
+        await queueClient.createIfNotExists();
     }
 
-    private async deleteQueueMessage(queueURL: QueueURL, messageId: string, popReceipt: string): Promise<void> {
-        const messagesURL = this.getMessagesURL(queueURL);
-        const messageIdURL = this.getMessageIdURL(messagesURL, messageId);
-
-        await messageIdURL.delete(Aborter.none, popReceipt);
+    private async deleteQueueMessage(queueClient: QueueClient, messageId: string, popReceipt: string): Promise<void> {
+        await queueClient.deleteMessage(messageId, popReceipt);
     }
 
-    private async getQueueMessages(queueURL: QueueURL, numberOfMessages: number): Promise<Models.DequeuedMessageItem[]> {
+    private async getQueueMessages(queueClient: QueueClient, numberOfMessages: number): Promise<DequeuedMessageItem[]> {
         const messageVisibilityTimeoutInSeconds = (await this.getQueueConfig()).messageVisibilityTimeoutInSeconds;
-        const requestOptions: Models.MessagesDequeueOptionalParams = {
+        const requestOptions: MessagesDequeueOptionalParams = {
             numberOfMessages,
             visibilitytimeout: messageVisibilityTimeoutInSeconds,
         };
 
-        await this.ensureQueueExists(queueURL);
+        // await this.ensureQueueExists(queueClient);
 
-        const messagesURL = this.getMessagesURL(queueURL);
+        const response = await queueClient.receiveMessages(requestOptions);
 
-        const response = await messagesURL.dequeue(Aborter.none, requestOptions);
-
-        return response.dequeuedMessageItems;
+        return response.receivedMessageItems;
     }
 
     private async moveToDeadQueue(
-        originQueueURL: QueueURL,
-        deadQueueURL: QueueURL,
-        queueMessage: Models.DequeuedMessageItem,
+        originQueueClient: QueueClient,
+        deadQueueClient: QueueClient,
+        queueMessage: DequeuedMessageItem,
     ): Promise<void> {
-        await this.createQueueMessage(deadQueueURL, queueMessage.messageText);
-        await this.deleteQueueMessage(originQueueURL, queueMessage.messageId, queueMessage.popReceipt);
+        await this.createQueueMessage(deadQueueClient, queueMessage.messageText);
+        await this.deleteQueueMessage(originQueueClient, queueMessage.messageId, queueMessage.popReceipt);
     }
 
-    private getMessagesURL(queueURL: QueueURL): MessagesURL {
-        return this.messagesURLProvider(queueURL);
-    }
-
-    private getMessageIdURL(messageURL: MessagesURL, messageId: string): MessageIdURL {
-        return this.messageIdURLProvider(messageURL, messageId);
-    }
-
-    private async getQueueURL(queueName: string): Promise<QueueURL> {
-        const serviceURL = await this.queueServiceURLProvider();
-
-        return this.queueURLProvider(serviceURL, queueName);
+    private async getQueueClient(queueName: string): Promise<QueueClient> {
+        return (await this.queueServiceClientProvider()).getQueueClient(queueName);
     }
 
     private async getQueueConfig(): Promise<QueueRuntimeConfig> {

--- a/packages/azure-services/src/ioc-types.ts
+++ b/packages/azure-services/src/ioc-types.ts
@@ -4,17 +4,14 @@ import { BatchServiceClient } from '@azure/batch';
 import { CosmosClient } from '@azure/cosmos';
 import { SecretClient } from '@azure/keyvault-secrets';
 import { BlobServiceClient } from '@azure/storage-blob';
-import { MessageIdURL, MessagesURL, QueueURL, ServiceURL } from '@azure/storage-queue';
+import { QueueServiceClient } from '@azure/storage-queue';
 
 export const iocTypeNames = {
     AzureKeyVaultClientProvider: 'AzureKeyVaultClientProvider',
     BlobServiceClientProvider: 'BlobServiceClientProvider',
-    QueueURLProvider: 'QueueURLProvider',
-    MessagesURLProvider: 'MessagesURLProvider',
-    MessageIdURLProvider: 'MessageIdURLProvider',
     CosmosClientProvider: 'CosmosClientProvider',
     msRestAzure: 'msRestAzure',
-    QueueServiceURLProvider: 'QueueServiceURLProvider',
+    QueueServiceClientProvider: 'QueueServiceClientProvider',
     AuthenticationMethod: 'AuthenticationMethod',
     CredentialType: 'CredentialType',
     BatchServiceClientProvider: 'BatchServiceClientProvider',
@@ -23,10 +20,7 @@ export const iocTypeNames = {
 export type AzureKeyVaultClientProvider = () => Promise<SecretClient>;
 export type BlobServiceClientProvider = () => Promise<BlobServiceClient>;
 export type CosmosClientProvider = () => Promise<CosmosClient>;
-export type QueueURLProvider = typeof QueueURL.fromServiceURL;
-export type MessagesURLProvider = typeof MessagesURL.fromQueueURL;
-export type MessageIdURLProvider = typeof MessageIdURL.fromMessagesURL;
-export type QueueServiceURLProvider = () => Promise<ServiceURL>;
+export type QueueServiceClientProvider = () => Promise<QueueServiceClient>;
 export type BatchServiceClientProvider = () => Promise<BatchServiceClient>;
 
 export const cosmosContainerClientTypes = {

--- a/packages/resource-deployment/scripts/enable-system-identity-for-batch-vmss.sh
+++ b/packages/resource-deployment/scripts/enable-system-identity-for-batch-vmss.sh
@@ -25,8 +25,12 @@ enableResourceGroupAccess() {
 }
 
 enableStorageAccess() {
-    role="Storage Blob Data Contributor"
     scope="--scope /subscriptions/$subscription/resourceGroups/$resourceGroupName/providers/Microsoft.Storage/storageAccounts/$storageAccountName"
+
+    role="Storage Blob Data Contributor"
+    . "${0%/*}/role-assign-for-sp.sh"
+
+    role="Storage Queue Data Contributor"
     . "${0%/*}/role-assign-for-sp.sh"
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,10 +62,10 @@
     "@opentelemetry/api" "^0.6.1"
     tslib "^2.0.0"
 
-"@azure/core-http@^1.1.1", "@azure/core-http@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-1.1.6.tgz#9d76bc569c9907e3224bd09c09b4ac08bde9faf8"
-  integrity sha512-/C+qNzhwlLKt0F6SjaBEyY2pwZvwL2LviyS5PHlCh77qWuTF1sETmYAINM88BCN+kke+UlECK4YOQaAjJwyHvQ==
+"@azure/core-http@^1.1.1", "@azure/core-http@^1.1.6", "@azure/core-http@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-1.2.0.tgz#eb2a1da9bdba8407a09d78450af5f13f8cc43d63"
+  integrity sha512-SQmyI1tpstWKePNmTseEUp8PMq1uNBslvGBrYF2zNM/fEfLD1q64XCatoH8nDQtSmDydEPsqlyyLSjjnuXrlOQ==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     "@azure/core-auth" "^1.1.3"
@@ -80,7 +80,7 @@
     tough-cookie "^4.0.0"
     tslib "^2.0.0"
     tunnel "^0.0.6"
-    uuid "^8.1.0"
+    uuid "^8.3.0"
     xml2js "^0.4.19"
 
 "@azure/core-lro@^1.0.2":
@@ -192,7 +192,7 @@
     "@azure/ms-rest-js" "^2.0.4"
     tslib "^1.10.0"
 
-"@azure/ms-rest-js@^2.0.0", "@azure/ms-rest-js@^2.0.4":
+"@azure/ms-rest-js@^2.0.4":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.1.0.tgz#41bc541984983b5242dfbcf699ea281acd045946"
   integrity sha512-4BXLVImYRt+jcUmEJ5LUWglI8RBNVQndY6IcyvQ4U8O4kIXdmlRz3cJdA/RpXf5rKT38KOoTO2T6Z1f6Z1HDBg==
@@ -232,13 +232,18 @@
     events "^3.0.0"
     tslib "^2.0.0"
 
-"@azure/storage-queue@^10.1.0":
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/@azure/storage-queue/-/storage-queue-10.3.0.tgz#b4466838e967b49e14601180d1c2e2d04987b29f"
-  integrity sha512-9njyI/63Wvfnsm4eaP0QIdw7CAWjsServb+P0twMnGaG17guEND32IgU0YtzkYhczxoSnDNZM9UNGThAPskvWA==
+"@azure/storage-queue@^12.2.0":
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/storage-queue/-/storage-queue-12.2.0.tgz#0c82a0531d82358ee57754c21e1a1fce4ae5e408"
+  integrity sha512-HxFMLs6f0VQ4q1pyj4BKpdgH2amwvSwcNh+SFFcOmVuu6PpjTgP1HLiVPAf982iZlLEAEwNjzwnw2XrLbDumMA==
   dependencies:
-    "@azure/ms-rest-js" "^2.0.0"
-    tslib "^1.9.3"
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-http" "^1.2.0"
+    "@azure/core-paging" "^1.1.1"
+    "@azure/core-tracing" "1.0.0-preview.9"
+    "@azure/logger" "^1.0.0"
+    "@opentelemetry/api" "^0.10.2"
+    tslib "^2.0.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.8.3":
   version "7.10.4"


### PR DESCRIPTION
#### Description of changes

This started as a package update in #1125, and became a larger overhaul of our storage queue client wrapper
- Update @azure/storage-queue from 10.3.0 to 12.2.0
- Refactor Queue class to use the new SDK interface
- Use MSI instead of storage key and shared key credential to authenticate to storage queue

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
