### PR TITLE
feat: integrate axe result reducer into cli file scan

### DIFF
--- a/packages/cli/src/runner/file-command-runner.spec.ts
+++ b/packages/cli/src/runner/file-command-runner.spec.ts
@@ -229,9 +229,7 @@ describe(FileCommandRunner, () => {
     }
 
     function setupResultsReducerCalls(result: AxeScanResults): void {
-        axeResultsReducerMock
-            .setup((a) => a.reduce(It.isValue(combinedAxeResults), It.isValue(result.results)))
-            .verifiable(Times.once());
+        axeResultsReducerMock.setup((a) => a.reduce(It.isValue(combinedAxeResults), It.isValue(result.results))).verifiable(Times.once());
     }
 
     function setupReportCreationCalls(url: string, result: AxeScanResults): void {

--- a/packages/cli/src/runner/file-command-runner.spec.ts
+++ b/packages/cli/src/runner/file-command-runner.spec.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 import * as fs from 'fs';
 import { AxeScanResults } from 'scanner-global-library';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { AxeCoreResults, AxeResultsReducer } from 'axe-result-converter';
 import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ReportGenerator } from '../report/report-generator';
 import { ReportNameGenerator } from '../report/report-name-generator';
@@ -16,11 +17,13 @@ import { FileCommandRunner } from './file-command-runner';
 
 describe(FileCommandRunner, () => {
     let scannerMock: IMock<AIScanner>;
+    let axeResultsReducerMock: IMock<AxeResultsReducer>;
     let reportGeneratorMock: IMock<ReportGenerator>;
     let reportDiskWriterMock: IMock<ReportDiskWriter>;
     let fsMock: IMock<typeof fs>;
     let reportNameGeneratorMock: IMock<ReportNameGenerator>;
     let testSubject: FileCommandRunner;
+    let combinedAxeResults: AxeCoreResults;
     const testInputFile = 'input file';
     const testInput: ScanArguments = { inputFile: testInputFile, output: '/users/xyz' };
 
@@ -28,14 +31,16 @@ describe(FileCommandRunner, () => {
         reportGeneratorMock = Mock.ofType<ReportGenerator>();
         reportDiskWriterMock = Mock.ofType<ReportDiskWriter>();
         reportNameGeneratorMock = Mock.ofType<ReportNameGenerator>();
+        axeResultsReducerMock = Mock.ofType<AxeResultsReducer>();
         scannerMock = Mock.ofType<AIScanner>();
         fsMock = Mock.ofInstance(fs, MockBehavior.Strict);
 
         testSubject = new FileCommandRunner(
             scannerMock.object,
+            axeResultsReducerMock.object,
             reportGeneratorMock.object,
-            reportDiskWriterMock.object,
             reportNameGeneratorMock.object,
+            reportDiskWriterMock.object,
             fsMock.object,
         );
     });
@@ -48,6 +53,8 @@ describe(FileCommandRunner, () => {
                 .setup((f) => f.readFileSync(testInput.inputFile, 'utf-8'))
                 .returns(() => fileContent)
                 .verifiable(Times.once());
+
+            combinedAxeResults = { violations: [], passes: [], incomplete: [], inapplicable: [] } as AxeCoreResults;
 
             setupScanAndReportWriteCalls();
         });
@@ -114,6 +121,7 @@ describe(FileCommandRunner, () => {
     afterEach(() => {
         fsMock.verifyAll();
         scannerMock.verifyAll();
+        axeResultsReducerMock.verifyAll();
         reportGeneratorMock.verifyAll();
         reportDiskWriterMock.verifyAll();
         reportNameGeneratorMock.verifyAll();
@@ -136,6 +144,7 @@ describe(FileCommandRunner, () => {
                 } as AxeScanResults;
 
                 setupReportCreationCalls(url, result);
+                setupResultsReducerCalls(result);
 
                 return result;
             })
@@ -170,6 +179,7 @@ describe(FileCommandRunner, () => {
                 } as AxeScanResults;
 
                 setupReportCreationCalls(url, result);
+                setupResultsReducerCalls(result);
 
                 return result;
             })
@@ -216,6 +226,12 @@ describe(FileCommandRunner, () => {
             .setup((s) => s.getUserAgent())
             .returns(() => 'user agent')
             .verifiable(Times.atLeast(0));
+    }
+
+    function setupResultsReducerCalls(result: AxeScanResults): void {
+        axeResultsReducerMock
+            .setup((a) => a.reduce(It.isValue(combinedAxeResults), It.isValue(result.results)))
+            .verifiable(Times.once());
     }
 
     function setupReportCreationCalls(url: string, result: AxeScanResults): void {

--- a/packages/cli/src/runner/file-command-runner.ts
+++ b/packages/cli/src/runner/file-command-runner.ts
@@ -33,7 +33,6 @@ export class FileCommandRunner implements CommandRunner {
     constructor(
         @inject(AIScanner) private readonly scanner: AIScanner,
         @inject(AxeResultsReducer) private readonly axeResultsReducer: AxeResultsReducer,
-        // @inject(ConsolidatedReportGenerator) private readonly consolidatedReportGenerator: ConsolidatedReportGenerator,
         @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
         @inject(ReportNameGenerator) private readonly reportNameGenerator: ReportNameGenerator,
         @inject(ReportDiskWriter) private readonly reportDiskWriter: ReportDiskWriter,
@@ -61,16 +60,7 @@ export class FileCommandRunner implements CommandRunner {
 
         const endDate = new Date();
         this.reportDiskWriter.copyToDirectory(scanArguments.inputFile, scanArguments.output);
-        await this.generateConsolidatedReport(scanArguments, startDate, endDate);
         await this.generateSummaryReports(scanArguments, startDate, endDate);
-    }
-
-    private async generateConsolidatedReport(scanArguments: ScanArguments, startDate: Date, endDate: Date): Promise<void> {
-        // console.log('Generating summary scan report...');
-        // const reportContent = await this.consolidatedReportGenerator.generateReport(this.combinedAxeResults.url, startDate, endDate);
-        // console.log(reportContent);
-        // const reportLocation = this.reportDiskWriter.writeToDirectory(scanArguments.output, 'index', 'html', reportContent);
-        // console.log(`Summary report was saved as ${reportLocation}`);
     }
 
     private async generateSummaryReports(scanArguments: ScanArguments, startDate: Date, endDate: Date): Promise<void> {


### PR DESCRIPTION
#### Description of changes

<!-- (Give an overview. Add a technical description describing your changes.) --->
- Use AxeResultReducer to combine results after scans in a CLI file scan

#### Pull request checklist

- [x] Addresses an existing issue: WI # 1790211
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
