### PR TITLE
fix: combined report failure sorting

### DIFF
--- a/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
+++ b/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
@@ -183,4 +183,28 @@ describe(CombinedReportDataConverter, () => {
 
         expect(combinedReportData).toMatchSnapshot();
     });
+
+    it('sorts failed rules by number of failure instances', () => {
+        const ruleId1 = 'rule-id-1';
+        const ruleId2 = 'rule-id-2';
+        const violations = addAxeResult(
+            new AxeResults(),
+            getAccumulatedResult(ruleId1, { urls: ['url-1', 'url-2', 'url-3'], nodeId: 'node-1' }),
+            getAccumulatedResult(ruleId1, { urls: ['url-4'], nodeId: 'node-2' }),
+            getAccumulatedResult(ruleId2, { urls: ['url-5'], nodeId: 'node-3' }),
+        );
+        const axeCoreResults = {
+            violations,
+            passes: new AxeResults(),
+            inapplicable: new AxeResults(),
+            incomplete: new AxeResults(),
+        } as AxeCoreResults;
+
+        const combinedReportData = combinedReportDataConverter.convert(axeCoreResults, scanResultData);
+        const failedRules = combinedReportData.results.resultsByRule.failed;
+
+        expect(failedRules.length).toBe(2);
+        expect(failedRules[0].failed[0].rule.ruleId).toBe(ruleId1);
+        expect(failedRules[1].failed[0].rule.ruleId).toBe(ruleId2);
+    });
 });


### PR DESCRIPTION
#### Description of changes

currently, the combined report failures are sorted by the number of cards, not by the number of failure instances (sum of #urls for each card). Since we display the number of failure instances, in the report, the failed rules appear to be unsorted or sorted badly:

![Current "failed" section in combined report, with numbers out of order](https://user-images.githubusercontent.com/55459788/100033362-e84f4280-2dae-11eb-81b8-83c006b375d2.png)

This PR will make sure we sort by number of failure instances instead.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
