### PR TITLE
Fixed puppeteer obsolete API `waitFor` warning message

### DIFF
--- a/packages/scanner-global-library/src/page-handler.spec.ts
+++ b/packages/scanner-global-library/src/page-handler.spec.ts
@@ -32,7 +32,8 @@ describe(PageHandler, () => {
             .returns(() => Promise.resolve(1024))
             .verifiable(Times.exactly(minCheckBreakCount + 1));
         pageMock
-            .setup(async (o) => o.waitFor(checkIntervalMsecs))
+            // @ts-ignore
+            .setup(async (o) => o.waitForTimeout(checkIntervalMsecs))
             .returns(() => Promise.resolve())
             .verifiable(Times.exactly(minCheckBreakCount));
 

--- a/packages/scanner-global-library/src/page-handler.spec.ts
+++ b/packages/scanner-global-library/src/page-handler.spec.ts
@@ -51,7 +51,8 @@ describe(PageHandler, () => {
             .returns(() => Promise.resolve(contentSize))
             .verifiable(Times.exactly(validationCallCount));
         pageMock
-            .setup(async (o) => o.waitFor(checkIntervalMsecs))
+            // @ts-ignore
+            .setup(async (o) => o.waitForTimeout(checkIntervalMsecs))
             .returns(() => Promise.resolve())
             .verifiable(Times.exactly(validationCallCount));
 

--- a/packages/scanner-global-library/src/page-handler.ts
+++ b/packages/scanner-global-library/src/page-handler.ts
@@ -40,7 +40,8 @@ export class PageHandler {
                 break;
             }
 
-            await page.waitFor(checkIntervalMsecs);
+            // @ts-ignore
+            await page.waitForTimeout(checkIntervalMsecs);
             checkCount += 1;
         }
 

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -26,7 +26,6 @@
         "@types/jest": "^26.0.14",
         "@types/lodash": "^4.14.161",
         "@types/node": "^12.12.54",
-        "@types/puppeteer": "^3.0.0",
         "@types/sha.js": "^2.4.0",
         "@types/verror": "^1.10.4",
         "@types/yargs": "^15.0.5",


### PR DESCRIPTION
#### Description of changes

Fixed puppeteer obsolete API `waitFor` warning message. See https://github.com/puppeteer/puppeteer/issues/6214

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
