### PR TITLE
Fix: Increase max calls per minute for API calls

### DIFF
--- a/packages/resource-deployment/templates/model-accessibility-insight-service-scan-api-api.template.json
+++ b/packages/resource-deployment/templates/model-accessibility-insight-service-scan-api-api.template.json
@@ -10,7 +10,7 @@
         },
         "maxCallsPerMinute": {
             "type": "int",
-            "defaultValue": 1000
+            "defaultValue": 3000
         }
     },
     "resources": [


### PR DESCRIPTION
#### Description of changes

Increase max calls per minute for API calls to be 3000 request per minute instead of 1000.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
