### PR TITLE
Add empty combined results to WebsiteScanResults

### DIFF
--- a/packages/axe-result-converter/src/index.ts
+++ b/packages/axe-result-converter/src/index.ts
@@ -4,3 +4,4 @@ export * from './axe-result-types';
 export * from './scan-result-data';
 export { AxeResultsReducer } from './axe-results-reducer';
 export { CombinedReportDataConverter } from './combined-report-data-converter';
+export { AxeCoreResults, AxeResults } from './axe-result-types';

--- a/packages/storage-documents/package.json
+++ b/packages/storage-documents/package.json
@@ -34,6 +34,7 @@
     },
     "dependencies": {
         "inversify": "^5.0.1",
-        "reflect-metadata": "^0.1.13"
+        "reflect-metadata": "^0.1.13",
+        "axe-result-converter": "1.0.0"
     }
 }

--- a/packages/storage-documents/src/website-scan-result.ts
+++ b/packages/storage-documents/src/website-scan-result.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AxeCoreResults, UrlCount } from 'axe-result-converter';
 import { StorageDocument } from './storage-document';
 import { ItemType } from './item-type';
 import { ReportFormat } from './on-demand-page-scan-result';
@@ -10,6 +11,7 @@ export interface WebsiteScanResult extends StorageDocument {
     baseUrl: string;
     pageScans?: PageScan[];
     reports?: WebsiteScanReport[];
+    websiteScanResults?: CombinedScanResult;
 }
 
 export interface WebsiteScanReport {
@@ -22,4 +24,9 @@ export interface PageScan {
     scanId: string;
     url: string;
     timestamp: string;
+}
+
+interface CombinedScanResult {
+    urlCount: UrlCount;
+    combinedAxeResults: AxeCoreResults;
 }

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -54,6 +54,7 @@
         "accessibility-insights-report": "3.0.1",
         "applicationinsights": "^1.8.8",
         "axe-core": "4.0.2",
+        "axe-result-converter": "^1.0.0",
         "axe-sarif-converter": "^2.6.0",
         "azure-services": "^1.0.0",
         "common": "1.0.0",


### PR DESCRIPTION
#### Description of changes

Add empty combined results object to WebsiteScanResults when a report group id is provided

#### Pull request checklist

- [x] Addresses an existing issue: #1798133
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
