### PR TITLE
chore: fix windows compat with report-disk-writer.spec.ts

### DIFF
--- a/packages/cli/src/report/report-disk-writer.spec.ts
+++ b/packages/cli/src/report/report-disk-writer.spec.ts
@@ -88,21 +88,22 @@ describe('ReportDiskWriter', () => {
     });
 
     it('output directory is empty', () => {
-        const directory = __dirname;
+        const platformSpecificDirectory = __dirname;
+        const normalizedDirectory = platformSpecificDirectory.replace(/\\/g, '/');
         const fileName = 'http://www.bing.com';
         const format = 'html';
         const content = 'content';
 
         const reportFileName = `${filenamifyUrl(fileName, { replacement: '_' })}.${format}`;
-        const reportFilePath = `${directory}/${reportFileName}`;
+        const reportFilePath = `${normalizedDirectory}/${reportFileName}`;
 
         pathMock
-            .setup((fsm) => fsm.resolve(directory, reportFileName))
+            .setup((fsm) => fsm.resolve(normalizedDirectory, reportFileName))
             .returns(() => reportFilePath)
             .verifiable(Times.once());
 
         fsMock
-            .setup((fsm) => fsm.existsSync(directory))
+            .setup((fsm) => fsm.existsSync(normalizedDirectory))
             .returns(() => false)
             .verifiable(Times.once());
         fsMock
@@ -110,7 +111,7 @@ describe('ReportDiskWriter', () => {
             .returns(() => {})
             .verifiable(Times.once());
         fsMock
-            .setup((fsm) => fsm.mkdirSync(directory, { recursive: true }))
+            .setup((fsm) => fsm.mkdirSync(normalizedDirectory, { recursive: true }))
             .returns(() => {})
             .verifiable(Times.once());
 


### PR DESCRIPTION
#### Description of changes

When running `yarn precheckin` for #1168, I noticed that there was a test case failing locally that didn't seem related to the change. It looks like there was a pre-existing case that only worked on `/`-path-separator-based filesystems; this corrects the test to match the production filepath normalization behavior.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
