### PR TITLE
Improvements and fixes to CombinedScanResultProvider

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,6 +41,7 @@
         "got": "^11.8.0",
         "inversify": "^5.0.1",
         "lodash": "^4.17.20",
+        "raw-body": "^2.4.1",
         "reflect-metadata": "^0.1.13",
         "serialize-error": "^7.0.1",
         "sha.js": "^2.4.11",

--- a/packages/common/src/body-parser.ts
+++ b/packages/common/src/body-parser.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 import { Readable } from 'stream';
 import getRawBody from 'raw-body';
+import { injectable } from 'inversify';
 
+@injectable()
 export class BodyParser {
     public async getRawBody(stream: Readable, options?: getRawBody.Options): Promise<Buffer> {
         return getRawBody(stream, options);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -16,3 +16,4 @@ export { getForeverAgents } from './web-requests/forever-agents';
 export { ResponseWithBodyType } from './web-requests/response-with-body-type';
 export { SerializableResponse, ResponseSerializer, getSerializableResponse } from './web-requests/serializable-response';
 export { HashSet, SerializedHashSet } from './hash-set';
+export { BodyParser } from './body-parser';

--- a/packages/service-library/src/data-providers/combined-scan-results-provider.spec.ts
+++ b/packages/service-library/src/data-providers/combined-scan-results-provider.spec.ts
@@ -59,7 +59,7 @@ describe(CombinedScanResultsProvider, () => {
     describe('saveCombinedResults', () => {
         it('without etag', async () => {
             setupSave(resultsString, 200);
-            const expectedResult = { filePath };
+            const expectedResult = { etag };
 
             const result = await testSubject.saveCombinedResults(fileId, combinedResults);
 
@@ -68,7 +68,7 @@ describe(CombinedScanResultsProvider, () => {
 
         it('with etag', async () => {
             setupSave(resultsString, 200, { ifMatchEtag: etag });
-            const expectedResult = { filePath };
+            const expectedResult = { etag };
 
             const result = await testSubject.saveCombinedResults(fileId, combinedResults, etag);
 
@@ -108,6 +108,7 @@ describe(CombinedScanResultsProvider, () => {
             setupRead(resultsString);
             const expectedResults = {
                 results: combinedResults,
+                etag: etag,
             };
 
             const actualResults = await testSubject.readCombinedResults(fileId);
@@ -144,7 +145,7 @@ describe(CombinedScanResultsProvider, () => {
         });
     });
 
-    describe('readOrCreateCombinedResults', () => {
+    describe('createCombinedResults', () => {
         it('returns error if results exist', async () => {
             setupRead(resultsString);
             const expectedResults = {
@@ -163,6 +164,7 @@ describe(CombinedScanResultsProvider, () => {
             setupSave(emptyResultsString, 200);
             const expectedResults = {
                 results: emptyResults,
+                etag: etag,
             };
 
             const actualResults = await testSubject.createCombinedResults(fileId);
@@ -181,6 +183,7 @@ describe(CombinedScanResultsProvider, () => {
         const response = {
             notFound: false,
             content: stubReadableStream(content),
+            etag: etag,
         } as BlobContentDownloadResponse;
         blobStorageClientMock
             .setup((bc) => bc.getBlobContent(DataProvidersCommon.combinedResultsBlobContainerName, filePath))
@@ -200,7 +203,7 @@ describe(CombinedScanResultsProvider, () => {
     }
 
     function setupSave(content: string, statusCode: number, condition?: BlobSaveCondition): void {
-        const response = { statusCode } as BlobContentUploadResponse;
+        const response = { statusCode, etag } as BlobContentUploadResponse;
         blobStorageClientMock
             .setup((bc) => bc.uploadBlobContent(DataProvidersCommon.combinedResultsBlobContainerName, filePath, content, condition))
             .returns(() => Promise.resolve(response))

--- a/packages/service-library/src/data-providers/combined-scan-results-provider.spec.ts
+++ b/packages/service-library/src/data-providers/combined-scan-results-provider.spec.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
+import { Readable } from 'stream';
 import { BlobContentDownloadResponse, BlobSaveCondition, BlobStorageClient, BlobContentUploadResponse } from 'azure-services';
 import { CombinedAxeResults, CombinedScanResults } from 'storage-documents';
 import { IMock, Mock } from 'typemoq';
 import { AxeResults } from 'axe-result-converter';
+import { BodyParser } from 'common';
 import { CombinedScanResultsProvider } from './combined-scan-results-provider';
 import { DataProvidersCommon } from './data-providers-common';
 
@@ -38,18 +40,23 @@ describe(CombinedScanResultsProvider, () => {
     };
     const emptyResultsString = JSON.stringify(emptyResults);
     const etag = 'etag';
+    const readableStream = {
+        readable: true,
+    } as NodeJS.ReadableStream;
 
     let blobStorageClientMock: IMock<BlobStorageClient>;
     let dataProvidersCommonMock: IMock<DataProvidersCommon>;
+    let bodyParserMock: IMock<BodyParser>;
 
     let testSubject: CombinedScanResultsProvider;
 
     beforeEach(() => {
         blobStorageClientMock = Mock.ofType<BlobStorageClient>();
         dataProvidersCommonMock = Mock.ofType<DataProvidersCommon>();
+        bodyParserMock = Mock.ofType<BodyParser>();
         dataProvidersCommonMock.setup((dp) => dp.getBlobName(fileId)).returns(() => filePath);
 
-        testSubject = new CombinedScanResultsProvider(blobStorageClientMock.object, dataProvidersCommonMock.object);
+        testSubject = new CombinedScanResultsProvider(blobStorageClientMock.object, dataProvidersCommonMock.object, bodyParserMock.object);
     });
 
     afterEach(() => {
@@ -105,7 +112,8 @@ describe(CombinedScanResultsProvider, () => {
 
     describe('readCombinedResults', () => {
         it('Read combined results', async () => {
-            setupRead(resultsString);
+            setupReadBlob();
+            setupReadStream(resultsString);
             const expectedResults = {
                 results: combinedResults,
                 etag: etag,
@@ -129,12 +137,29 @@ describe(CombinedScanResultsProvider, () => {
             expect(actualResults).toEqual(expectedResults);
         });
 
-        it('handles unparsable string', async () => {
-            const unparsableString = '{ unparsable content string';
-            setupRead(unparsableString);
+        it('handles stream read failure', async () => {
+            setupReadBlob();
+            const error = new Error('error');
+            bodyParserMock.setup((bp) => bp.getRawBody(readableStream as Readable)).throws(error);
             const expectedResults = {
                 error: {
-                    errorCode: 'parseError',
+                    errorCode: 'streamError',
+                    data: JSON.stringify(error),
+                },
+            };
+
+            const actualResults = await testSubject.readCombinedResults(fileId);
+
+            expect(actualResults).toEqual(expectedResults);
+        });
+
+        it('handles unparsable string', async () => {
+            const unparsableString = '{ unparsable content string';
+            setupReadBlob();
+            setupReadStream(unparsableString);
+            const expectedResults = {
+                error: {
+                    errorCode: 'JSONParseError',
                     data: unparsableString,
                 },
             };
@@ -146,8 +171,9 @@ describe(CombinedScanResultsProvider, () => {
     });
 
     describe('createCombinedResults', () => {
-        it('returns error if results exist', async () => {
-            setupRead(resultsString);
+        it('returns error if results already exist', async () => {
+            setupReadBlob();
+            setupReadStream(resultsString);
             const expectedResults = {
                 error: {
                     errorCode: 'documentAlreadyExists',
@@ -173,16 +199,14 @@ describe(CombinedScanResultsProvider, () => {
         });
     });
 
-    function stubReadableStream(content: string): NodeJS.ReadableStream {
-        return ({
-            read: () => content,
-        } as unknown) as NodeJS.ReadableStream;
+    function setupReadStream(content: string): void {
+        bodyParserMock.setup((bp) => bp.getRawBody(readableStream as Readable)).returns(() => Promise.resolve(Buffer.from(content)));
     }
 
-    function setupRead(content: string): void {
+    function setupReadBlob(): void {
         const response = {
             notFound: false,
-            content: stubReadableStream(content),
+            content: readableStream,
             etag: etag,
         } as BlobContentDownloadResponse;
         blobStorageClientMock

--- a/packages/service-library/src/data-providers/combined-scan-results-provider.ts
+++ b/packages/service-library/src/data-providers/combined-scan-results-provider.ts
@@ -6,7 +6,7 @@ import { inject, injectable } from 'inversify';
 import { CombinedAxeResults, CombinedScanResults } from 'storage-documents';
 import { DataProvidersCommon } from './data-providers-common';
 
-export type ReadErrorCode = 'documentNotFound' | 'parseError' | 'documentAlreadyExists';
+export type ReadErrorCode = 'documentNotFound' | 'parseError';
 export type CreateErrorCode = 'documentAlreadyExists' | WriteErrorCode;
 export type WriteErrorCode = 'etagMismatch' | 'httpStatusError';
 
@@ -18,16 +18,18 @@ export type CombinedScanResultsError<ErrorCodeType> = {
 export type CombinedScanResultsReadResponse = {
     error?: CombinedScanResultsError<ReadErrorCode>;
     results?: CombinedScanResults;
+    etag?: string;
 };
 
 export type CombinedScanResultsWriteResponse = {
     error?: CombinedScanResultsError<WriteErrorCode>;
-    filePath?: string;
+    etag?: string;
 };
 
 export type CombinedScanResultsCreateResponse = {
     error?: CombinedScanResultsError<CreateErrorCode>;
     results?: CombinedScanResults;
+    etag?: string;
 };
 
 @injectable()
@@ -55,7 +57,7 @@ export class CombinedScanResultsProvider {
         );
 
         if (this.statusSuccessful(response.statusCode)) {
-            return { filePath };
+            return { etag: response.etag };
         }
         if (response.statusCode === CombinedScanResultsProvider.preconditionFailedStatusCode) {
             return {
@@ -105,6 +107,7 @@ export class CombinedScanResultsProvider {
 
         return {
             results: emptyCombinedResults,
+            etag: saveResponse.etag,
         };
     }
 
@@ -123,6 +126,7 @@ export class CombinedScanResultsProvider {
 
             return {
                 results: content,
+                etag: downloadResponse.etag,
             };
         } catch (error) {
             return {

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -39,7 +39,6 @@
         "jest-junit": "^12.0.0",
         "node-loader": "^1.0.2",
         "npm-run-all": "^4.1.5",
-        "raw-body": "^2.4.1",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.3.0",
         "ts-loader": "^8.0.11",

--- a/packages/web-api/src/controllers/scan-report-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-report-controller.spec.ts
@@ -5,12 +5,11 @@ import 'reflect-metadata';
 import { Readable } from 'stream';
 import { Context } from '@azure/functions';
 import { BlobContentDownloadResponse } from 'azure-services';
-import { GuidGenerator, ServiceConfiguration } from 'common';
+import { GuidGenerator, ServiceConfiguration, BodyParser } from 'common';
 import { HttpResponse, PageScanRunReportProvider, WebApiErrorCodes } from 'service-library';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 
-import { BodyParser } from './../utils/body-parser';
 import { ScanReportController } from './scan-report-controller';
 
 describe(ScanReportController, () => {

--- a/packages/web-api/src/controllers/scan-report-controller.ts
+++ b/packages/web-api/src/controllers/scan-report-controller.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Readable } from 'stream';
-import { GuidGenerator, ServiceConfiguration } from 'common';
+import { GuidGenerator, ServiceConfiguration, BodyParser } from 'common';
 import { inject, injectable } from 'inversify';
 import { ContextAwareLogger } from 'logger';
 import { ApiController, HttpResponse, PageScanRunReportProvider, WebApiErrorCodes } from 'service-library';
-import { BodyParser } from './../utils/body-parser';
 
 @injectable()
 export class ScanReportController extends ApiController {
@@ -17,7 +16,7 @@ export class ScanReportController extends ApiController {
         @inject(GuidGenerator) protected readonly guidGenerator: GuidGenerator,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
         @inject(ContextAwareLogger) logger: ContextAwareLogger,
-        private readonly bodyParser: BodyParser = new BodyParser(),
+        @inject(BodyParser) private readonly bodyParser: BodyParser,
     ) {
         super(logger);
     }


### PR DESCRIPTION
#### Description of changes

- Add etags to response object for all CombinedScanResultProvider operations
- Fix a bug reading the combined results blob

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
