### PR TITLE
chore: upgrade to yargs 16.1.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,7 +75,7 @@
         "puppeteer": "^5.5.0",
         "reflect-metadata": "^0.1.13",
         "serialize-error": "^7.0.1",
-        "yargs": "^15.3.1"
+        "yargs": "^16.1.1"
     },
     "bin": {
         "ai-scan": "dist/ai-scan-cli.js"

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -62,6 +62,6 @@
         "reflect-metadata": "^0.1.13",
         "scanner-global-library": "1.0.0",
         "sha.js": "^2.4.11",
-        "yargs": "^15.3.1"
+        "yargs": "^16.1.1"
     }
 }

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -43,7 +43,7 @@
         "web-api-client": "1.0.0",
         "storage-documents": "1.0.0",
         "chai": "^4.2.0",
-        "yargs": "^15.3.1",
+        "yargs": "^16.1.1",
         "@azure/cosmos": "^3.9.3",
         "dotenv": "^8.2.0"
     }

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -41,6 +41,6 @@
         "functional-tests": "1.0.0",
         "logger": "1.0.0",
         "chai": "^4.2.0",
-        "yargs": "^15.3.1"
+        "yargs": "^16.1.1"
     }
 }

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -53,6 +53,6 @@
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
         "storage-documents": "1.0.0",
-        "yargs": "^15.3.1"
+        "yargs": "^16.1.1"
     }
 }

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -56,7 +56,7 @@
         "service-library": "1.0.0",
         "verror": "^1.10.0",
         "storage-documents": "1.0.0",
-        "yargs": "^15.3.1",
+        "yargs": "^16.1.1",
         "applicationinsights": "^1.8.8"
     }
 }

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -49,6 +49,6 @@
         "storage-documents": "1.0.0",
         "lodash": "^4.17.20",
         "why-is-node-running": "^2.2.0",
-        "yargs": "^15.3.1"
+        "yargs": "^16.1.1"
     }
 }

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -68,7 +68,7 @@
         "sha.js": "^2.4.11",
         "storage-documents": "1.0.0",
         "verror": "^1.10.0",
-        "yargs": "^15.3.1"
+        "yargs": "^16.1.1"
     },
     "resolutions": {
         "axe-core": "4.0.2"

--- a/packages/web-api-scan-runner/src/scan-metadata-config.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-metadata-config.spec.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 import { IMock, Mock, Times } from 'typemoq';
 import { Argv } from 'yargs';
 import { ScanMetadataConfig } from './scan-metadata-config';
+import { ScanMetadata } from './types/scan-metadata';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -29,5 +30,31 @@ describe(ScanMetadataConfig, () => {
     it('getConfig', () => {
         expect(testSubject.getConfig()).toBe(argvVal);
         argvMock.verify((a) => a.demandOption(['id', 'url']), Times.once());
+    });
+
+    describe('yargs integration', () => {
+        const args: ScanMetadata = {
+            id: 'scan id',
+            url: 'url',
+        };
+
+        beforeEach(() => {
+            testSubject = new ScanMetadataConfig();
+            Object.keys(args).forEach((varName: keyof ScanMetadata) => {
+                process.env[varName] = args[varName];
+            });
+        });
+
+        afterEach(() => {
+            Object.keys(args).forEach((varName: keyof ScanMetadata) => {
+                process.env[varName] = undefined;
+            });
+        });
+
+        it('Gets correct config', () => {
+            const config = testSubject.getConfig();
+
+            expect(config).toMatchObject(args);
+        });
     });
 });

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -55,7 +55,7 @@
         "service-library": "1.0.0",
         "storage-documents": "1.0.0",
         "verror": "^1.10.0",
-        "yargs": "^15.3.1",
+        "yargs": "^16.1.1",
         "applicationinsights": "^1.8.8"
     }
 }

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -60,7 +60,7 @@
         "sha.js": "^2.4.11",
         "storage-documents": "1.0.0",
         "verror": "^1.10.0",
-        "yargs": "^15.3.1",
+        "yargs": "^16.1.1",
         "applicationinsights": "^1.8.8"
     }
 }

--- a/packages/web-api-send-notification-runner/src/notification-sender-config.spec.ts
+++ b/packages/web-api-send-notification-runner/src/notification-sender-config.spec.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 import { IMock, Mock, Times } from 'typemoq';
 import { Argv } from 'yargs';
 import { NotificationSenderConfig } from './notification-sender-config';
+import { NotificationSenderMetadata } from './types/notification-sender-metadata';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -29,5 +30,32 @@ describe(NotificationSenderConfig, () => {
     it('getConfig', () => {
         expect(testSubject.getConfig()).toBe(argvVal);
         argvMock.verify((a) => a.demandOption(['scanId', 'scanNotifyUrl', 'runStatus']), Times.once());
+    });
+
+    describe('yargs integration', () => {
+        const args: NotificationSenderMetadata = {
+            scanId: 'scan id',
+            scanNotifyUrl: 'scan notify url',
+            runStatus: 'completed',
+        };
+
+        beforeEach(() => {
+            testSubject = new NotificationSenderConfig();
+            Object.keys(args).forEach((varName: keyof NotificationSenderMetadata) => {
+                process.env[varName] = args[varName];
+            });
+        });
+
+        afterEach(() => {
+            Object.keys(args).forEach((varName: keyof NotificationSenderMetadata) => {
+                process.env[varName] = undefined;
+            });
+        });
+
+        it('Gets correct config', () => {
+            const config = testSubject.getConfig();
+
+            expect(config).toMatchObject(args);
+        });
     });
 });

--- a/packages/web-api-send-notification-runner/src/notification-sender-config.ts
+++ b/packages/web-api-send-notification-runner/src/notification-sender-config.ts
@@ -6,7 +6,14 @@ import { NotificationSenderMetadata } from './types/notification-sender-metadata
 
 @injectable()
 export class NotificationSenderConfig {
-    constructor(private readonly argvObj: Argv = yargs) {}
+    constructor(private readonly argvObj: Argv = yargs) {
+        // Temporary workaround for yargs v16 changing all env variables to lowercase
+        argvObj.alias({
+            scanid: 'scanId',
+            scannotifyurl: 'scanNotifyUrl',
+            runstatus: 'runStatus',
+        });
+    }
 
     public getConfig(): NotificationSenderMetadata {
         this.argvObj.env().demandOption(['scanId', 'scanNotifyUrl', 'runStatus']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6010,12 +6010,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escalade@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
-  integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
-
-escalade@^3.1.1:
+escalade@^3.0.2, escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
@@ -13826,7 +13821,7 @@ yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.0.3:
+yargs@^16.0.3, yargs@^16.1.1:
   version "16.1.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.1.1.tgz#5a4a095bd1ca806b0a50d0c03611d38034d219a1"
   integrity sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==


### PR DESCRIPTION
#### Description of changes

- Undo the revert of #1147 (in #1176) so that we use the more recent version of yargs (16.1.1)
- Add workaround for the bug that appeared after the yargs commit (#1832) (workaround may be removed if a future release of yargs fixes the issue)
- Add unit tests to verify yargs behavior for batch task arguments and prevent similar issues in the future

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
