### PR TITLE
feat(ai-service-dedupe-e2e): added e2e tests for consolidated scan report

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`ServiceConfiguration verifies custom config 1`] = `
 Object {
   "availabilityTestConfig": Object {
     "consolidatedReportId": Object {
-      "default": "somerandomid",
+      "default": "e2e-consolidated-report-id",
       "doc": "The id for the consolidated report",
       "format": "String",
     },
@@ -175,7 +175,7 @@ exports[`ServiceConfiguration verifies dev config 1`] = `
 Object {
   "availabilityTestConfig": Object {
     "consolidatedReportId": Object {
-      "default": "somerandomid",
+      "default": "e2e-consolidated-report-id",
       "doc": "The id for the consolidated report",
       "format": "String",
     },

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -3,6 +3,11 @@
 exports[`ServiceConfiguration verifies custom config 1`] = `
 Object {
   "availabilityTestConfig": Object {
+    "consolidatedReportId": Object {
+      "default": "somerandomid",
+      "doc": "The id for the consolidated report",
+      "format": "String",
+    },
     "environmentDefinition": Object {
       "default": "canary",
       "doc": "The environment definition used to select tests to run",
@@ -169,6 +174,11 @@ Object {
 exports[`ServiceConfiguration verifies dev config 1`] = `
 Object {
   "availabilityTestConfig": Object {
+    "consolidatedReportId": Object {
+      "default": "somerandomid",
+      "doc": "The id for the consolidated report",
+      "format": "String",
+    },
     "environmentDefinition": Object {
       "default": "canary",
       "doc": "The environment definition used to select tests to run",

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -67,6 +67,7 @@ export interface AvailabilityTestConfig {
     maxScanWaitTimeInSeconds: number;
     logQueryTimeRange: string;
     environmentDefinition: string;
+    consolidatedReportId: string;
 }
 
 export declare type ResourceType = 'batch' | 'registry';
@@ -265,6 +266,11 @@ export class ServiceConfiguration {
                     format: 'String',
                     default: 'https://www.washington.edu/accesscomputing/AU/before.html',
                     doc: 'Url to scan for availability testing',
+                },
+                consolidatedReportId: {
+                    format: 'String',
+                    default: 'somerandomid',
+                    doc: 'The id for the consolidated report',
                 },
                 maxScanWaitTimeInSeconds: {
                     format: 'int',

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -269,7 +269,7 @@ export class ServiceConfiguration {
                 },
                 consolidatedReportId: {
                     format: 'String',
-                    default: 'somerandomid',
+                    default: 'e2e-consolidated-report-id',
                     doc: 'The id for the consolidated report',
                 },
                 maxScanWaitTimeInSeconds: {

--- a/packages/functional-tests/src/test-group-data.ts
+++ b/packages/functional-tests/src/test-group-data.ts
@@ -10,4 +10,6 @@ export interface TestContextData {
     scanUrl: string;
     scanId?: string;
     reportId?: string;
+    consolidatedScanId?: string;
+    consolidatedReportId?: string;
 }

--- a/packages/functional-tests/src/test-groups/functional-test-group.ts
+++ b/packages/functional-tests/src/test-groups/functional-test-group.ts
@@ -12,7 +12,6 @@ import { TestContextData } from '../test-group-data';
 
 export abstract class FunctionalTestGroup {
     public testContextData: TestContextData;
-    protected logger: Logger;
 
     constructor(
         @inject(A11yServiceClient) protected readonly a11yServiceClient: A11yServiceClient,
@@ -22,10 +21,6 @@ export abstract class FunctionalTestGroup {
 
     public setTestContext(testContextData: TestContextData): void {
         this.testContextData = testContextData;
-    }
-
-    public setLogger(logger: Logger) {
-        this.logger = logger;
     }
 
     public ensureResponseSuccessStatusCode(response: ResponseWithBodyType<unknown>, message?: string): void {

--- a/packages/functional-tests/src/test-groups/functional-test-group.ts
+++ b/packages/functional-tests/src/test-groups/functional-test-group.ts
@@ -3,6 +3,7 @@
 import { expect } from 'chai';
 import { getSerializableResponse, GuidGenerator, ResponseWithBodyType } from 'common';
 import { inject } from 'inversify';
+import { Logger } from 'logger';
 import { OnDemandPageScanRunResultProvider, WebApiErrorCode } from 'service-library';
 import { A11yServiceClient } from 'web-api-client';
 import { TestContextData } from '../test-group-data';
@@ -11,6 +12,7 @@ import { TestContextData } from '../test-group-data';
 
 export abstract class FunctionalTestGroup {
     public testContextData: TestContextData;
+    protected logger: Logger;
 
     constructor(
         @inject(A11yServiceClient) protected readonly a11yServiceClient: A11yServiceClient,
@@ -20,6 +22,10 @@ export abstract class FunctionalTestGroup {
 
     public setTestContext(testContextData: TestContextData): void {
         this.testContextData = testContextData;
+    }
+
+    public setLogger(logger: Logger) {
+        this.logger = logger;
     }
 
     public ensureResponseSuccessStatusCode(response: ResponseWithBodyType<unknown>, message?: string): void {

--- a/packages/functional-tests/src/test-groups/functional-test-group.ts
+++ b/packages/functional-tests/src/test-groups/functional-test-group.ts
@@ -3,7 +3,6 @@
 import { expect } from 'chai';
 import { getSerializableResponse, GuidGenerator, ResponseWithBodyType } from 'common';
 import { inject } from 'inversify';
-import { Logger } from 'logger';
 import { OnDemandPageScanRunResultProvider, WebApiErrorCode } from 'service-library';
 import { A11yServiceClient } from 'web-api-client';
 import { TestContextData } from '../test-group-data';

--- a/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
@@ -38,7 +38,10 @@ export class ScanReportTestGroup extends FunctionalTestGroup {
         const reportsInfo = (<ScanRunResultResponse>response.body).reports;
         await Promise.all(
             reportsInfo.map(async (reportData: ScanReport) => {
-                const reportResponse = await this.a11yServiceClient.getScanReport(this.testContextData.consolidatedScanId, this.testContextData.consolidatedReportId);
+                const reportResponse = await this.a11yServiceClient.getScanReport(
+                    this.testContextData.consolidatedScanId,
+                    this.testContextData.consolidatedReportId,
+                );
 
                 console.log(`reportData report id is: ${reportData.reportId}`);
                 console.log(`testContextData report id is: ${this.testContextData.consolidatedReportId}`);

--- a/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
@@ -9,6 +9,8 @@ import { FunctionalTestGroup } from './functional-test-group';
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 export class ScanReportTestGroup extends FunctionalTestGroup {
+    private static TAG: string = "ScanReportTestGroup: ";
+
     @test(TestEnvironment.all)
     public async testReportGenerated(): Promise<void> {
         const response = await this.a11yServiceClient.getScanStatus(this.testContextData.scanId);
@@ -43,8 +45,8 @@ export class ScanReportTestGroup extends FunctionalTestGroup {
                     this.testContextData.consolidatedReportId,
                 );
 
-                console.log(`reportData report id is: ${reportData.reportId}`);
-                console.log(`testContextData report id is: ${this.testContextData.consolidatedReportId}`);
+                console.log(ScanReportTestGroup.TAG + `reportData report id is: ${reportData.reportId}`);
+                console.log(ScanReportTestGroup.TAG + `testContextData report id is: ${this.testContextData.consolidatedReportId}`);
                 this.ensureResponseSuccessStatusCode(response);
                 expect(reportResponse.statusCode, 'Get Scan Report API should return response with 200 status code').to.not.be.undefined;
             }),

--- a/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
@@ -33,6 +33,22 @@ export class ScanReportTestGroup extends FunctionalTestGroup {
     }
 
     @test(TestEnvironment.all)
+    public async testGetConsolidatedReport(): Promise<void> {
+        const response = await this.a11yServiceClient.getScanStatus(this.testContextData.consolidatedScanId);
+        const reportsInfo = (<ScanRunResultResponse>response.body).reports;
+        await Promise.all(
+            reportsInfo.map(async (reportData: ScanReport) => {
+                const reportResponse = await this.a11yServiceClient.getScanReport(this.testContextData.consolidatedScanId, this.testContextData.consolidatedReportId);
+
+                console.log(`reportData report id is: ${reportData.reportId}`);
+                console.log(`testContextData report id is: ${this.testContextData.consolidatedReportId}`);
+                this.ensureResponseSuccessStatusCode(response);
+                expect(reportResponse.statusCode, 'Get Scan Report API should return response with 200 status code').to.not.be.undefined;
+            }),
+        );
+    }
+
+    @test(TestEnvironment.all)
     public async testGetScanReportWithInvalidGuid(): Promise<void> {
         const invalidGuid = 'invalid guid';
         const response = await this.a11yServiceClient.getScanReport(this.testContextData.scanId, invalidGuid);

--- a/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-reports-test-group.ts
@@ -9,8 +9,6 @@ import { FunctionalTestGroup } from './functional-test-group';
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 export class ScanReportTestGroup extends FunctionalTestGroup {
-    private static TAG: string = "ScanReportTestGroup: ";
-
     @test(TestEnvironment.all)
     public async testReportGenerated(): Promise<void> {
         const response = await this.a11yServiceClient.getScanStatus(this.testContextData.scanId);
@@ -38,6 +36,9 @@ export class ScanReportTestGroup extends FunctionalTestGroup {
     public async testGetConsolidatedReport(): Promise<void> {
         const response = await this.a11yServiceClient.getScanStatus(this.testContextData.consolidatedScanId);
         const reportsInfo = (<ScanRunResultResponse>response.body).reports;
+
+        expect((<ScanRunResultResponse>response.body).reports, 'Expected three reports to be returned').to.have.lengthOf(3);
+
         await Promise.all(
             reportsInfo.map(async (reportData: ScanReport) => {
                 const reportResponse = await this.a11yServiceClient.getScanReport(
@@ -45,10 +46,8 @@ export class ScanReportTestGroup extends FunctionalTestGroup {
                     this.testContextData.consolidatedReportId,
                 );
 
-                console.log(ScanReportTestGroup.TAG + `reportData report id is: ${reportData.reportId}`);
-                console.log(ScanReportTestGroup.TAG + `testContextData report id is: ${this.testContextData.consolidatedReportId}`);
                 this.ensureResponseSuccessStatusCode(response);
-                expect(reportResponse.statusCode, 'Get Scan Report API should return response with 200 status code').to.not.be.undefined;
+                expect(reportResponse.body, 'Get Scan Report API should return response with defined body').to.not.be.undefined;
             }),
         );
     }

--- a/packages/web-api-client/src/a11y-service-client.spec.ts
+++ b/packages/web-api-client/src/a11y-service-client.spec.ts
@@ -29,15 +29,11 @@ describe(A11yServiceClient, () => {
     const scanUrl = 'url';
     const priority = 3;
     let response: unknown;
-    let requestBody: unknown;
-    let requestOptions: unknown;
     const agentsStub = {};
 
     beforeEach(() => {
         error = new Error('HTTP 500 Server Error');
         response = { statusCode: 200 };
-        requestBody = [{ url: scanUrl, priority }];
-        requestOptions = { json: requestBody };
 
         getMock = Mock.ofInstance(() => {
             return null;
@@ -143,6 +139,8 @@ describe(A11yServiceClient, () => {
     });
 
     it('postScanUrl', async () => {
+        const requestBody = [{ url: scanUrl, priority }];
+        const requestOptions = { json: requestBody };
         setupVerifiableSignRequestCall();
         setupRetryHelperMock(false);
         postMock
@@ -156,6 +154,8 @@ describe(A11yServiceClient, () => {
     });
 
     it('postScanUrl with retry', async () => {
+        const requestBody = [{ url: scanUrl, priority }];
+        const requestOptions = { json: requestBody };
         setupVerifiableSignRequestCall();
         setupRetryHelperMock(true);
         setupLoggerMock();
@@ -168,8 +168,8 @@ describe(A11yServiceClient, () => {
     });
 
     it('postScanUrl, priority not set', async () => {
-        requestBody = [{ url: scanUrl, priority: 0 }];
-        requestOptions = { json: requestBody };
+        const requestBody = [{ url: scanUrl, priority: 0 }];
+        const requestOptions = { json: requestBody };
         setupVerifiableSignRequestCall();
         setupRetryHelperMock(false);
         postMock
@@ -178,6 +178,23 @@ describe(A11yServiceClient, () => {
             .verifiable(Times.once());
 
         const actualResponse = await testSubject.postScanUrl(scanUrl);
+
+        expect(actualResponse).toEqual(response);
+    });
+
+    it('postConsolidatedScan', async () => {
+        const reportId = 'some-report-id';
+        const requestBody = [{ url: scanUrl, site: { baseUrl: scanUrl }, reportGroups: [{ consolidatedId: reportId }], priority }];
+        const requestOptions = { json: requestBody };
+
+        setupVerifiableSignRequestCall();
+        setupRetryHelperMock(false);
+        postMock
+            .setup((req) => req(`${baseUrl}/scans`, requestOptions))
+            .returns(async () => Promise.resolve(response))
+            .verifiable(Times.once());
+
+        const actualResponse = await testSubject.postConsolidatedScan(scanUrl, reportId, priority);
 
         expect(actualResponse).toEqual(response);
     });

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -59,8 +59,19 @@ export class A11yServiceClient {
         )) as ResponseWithBodyType<ScanRunResponse[]>;
     }
 
-    public async postConsolidatedScan(scanUrl: string, reportId: string, priority?: number): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
-        const requestBody: ScanRunRequest[] = [{ url: scanUrl, site: { baseUrl: scanUrl }, reportGroups: [{consolidatedId: reportId}],  priority: priority === undefined ? 0 : priority }];
+    public async postConsolidatedScan(
+        scanUrl: string,
+        reportId: string,
+        priority?: number,
+    ): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
+        const requestBody: ScanRunRequest[] = [
+            {
+                url: scanUrl,
+                site: { baseUrl: scanUrl },
+                reportGroups: [{ consolidatedId: reportId }],
+                priority: priority === undefined ? 0 : priority,
+            },
+        ];
         const requestUrl: string = `${this.requestBaseUrl}/scans`;
         const options: Options = { json: requestBody };
 

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -43,9 +43,9 @@ export class A11yServiceClient {
     }
 
     public async postScanUrl(scanUrl: string, priority?: number): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
-        const requestBody: ScanRunRequest = { url: scanUrl };
+        const scanRequestData: ScanRunRequest = { url: scanUrl };
 
-        return this.postScanUrlWithRequest(requestBody, priority);
+        return this.postScanUrlWithRequest(scanRequestData, priority);
     }
 
     public async postConsolidatedScan(
@@ -53,19 +53,19 @@ export class A11yServiceClient {
         reportId: string,
         priority?: number,
     ): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
-        const requestBody: ScanRunRequest = {
+        const scanRequestData: ScanRunRequest = {
             url: scanUrl,
             site: { baseUrl: scanUrl },
             reportGroups: [{ consolidatedId: reportId }],
         };
 
-        return this.postScanUrlWithRequest(requestBody, priority);
+        return this.postScanUrlWithRequest(scanRequestData, priority);
     }
 
-    private async postScanUrlWithRequest(requestBody: ScanRunRequest, priority: number): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
-        requestBody.priority = priority || 0;
+    private async postScanUrlWithRequest(scanRequestData: ScanRunRequest, priority: number): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
+        scanRequestData.priority = priority || 0;
         const requestUrl: string = `${this.requestBaseUrl}/scans`;
-        const options: Options = { json: [requestBody] };
+        const options: Options = { json: [scanRequestData] };
 
         return (await this.retryHelper.executeWithRetries(
             async () => (await this.signRequest()).post(requestUrl, options),

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -62,7 +62,10 @@ export class A11yServiceClient {
         return this.postScanUrlWithRequest(scanRequestData, priority);
     }
 
-    private async postScanUrlWithRequest(scanRequestData: ScanRunRequest, priority: number): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
+    private async postScanUrlWithRequest(
+        scanRequestData: ScanRunRequest,
+        priority: number,
+    ): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
         scanRequestData.priority = priority || 0;
         const requestUrl: string = `${this.requestBaseUrl}/scans`;
         const options: Options = { json: [scanRequestData] };

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -59,6 +59,23 @@ export class A11yServiceClient {
         )) as ResponseWithBodyType<ScanRunResponse[]>;
     }
 
+    public async postConsolidatedScan(scanUrl: string, reportId: string, priority?: number): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
+        const requestBody: ScanRunRequest[] = [{ url: scanUrl, site: { baseUrl: scanUrl }, reportGroups: [{consolidatedId: reportId}],  priority: priority === undefined ? 0 : priority }];
+        const requestUrl: string = `${this.requestBaseUrl}/scans`;
+        const options: Options = { json: requestBody };
+
+        return (await this.retryHelper.executeWithRetries(
+            async () => (await this.signRequest()).post(requestUrl, options),
+            async (e) =>
+                this.logger.logError('POST scans REST API request fail. Retrying on error.', {
+                    url: requestUrl,
+                    error: System.serializeError(e),
+                }),
+            this.maxRetryCount,
+            this.msecBetweenRetries,
+        )) as ResponseWithBodyType<ScanRunResponse[]>;
+    }
+
     public async getScanStatus(scanId: string): Promise<ResponseWithBodyType<ScanResultResponse>> {
         const requestUrl: string = `${this.requestBaseUrl}/scans/${scanId}`;
 

--- a/packages/web-api/src/controllers/health-check-controller.spec.ts
+++ b/packages/web-api/src/controllers/health-check-controller.spec.ts
@@ -40,6 +40,7 @@ describe(HealthCheckController, () => {
             urlToScan: 'https://www.bing.com',
             logQueryTimeRange: 'P1D',
             environmentDefinition: 'canary',
+            consolidatedReportId: 'somereportid',
         };
 
         serviceConfigurationMock = Mock.ofType<ServiceConfiguration>();

--- a/packages/web-workers/src/contracts/activity-actions.ts
+++ b/packages/web-workers/src/contracts/activity-actions.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 export enum ActivityAction {
     createScanRequest = 'createScanRequest',
+    createConsolidatedScanRequest = 'createConsolidatedScanRequest',
     getScanResult = 'getScanResult',
     getScanResultBatch = 'getScanResultBatch',
     getScanReport = 'getScanReport',

--- a/packages/web-workers/src/controllers/activity-request-data.ts
+++ b/packages/web-workers/src/controllers/activity-request-data.ts
@@ -13,6 +13,10 @@ export interface CreateScanRequestData {
     priority: number;
 }
 
+export interface CreateConsolidatedScanRequestData extends CreateScanRequestData {
+    reportId: string;
+}
+
 export interface GetScanResultData {
     scanId: string;
 }

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.spec.ts
@@ -85,8 +85,9 @@ describe(HealthMonitorClientController, () => {
     describe('invoke', () => {
         it('handles createScanRequest', async () => {
             const scanUrl = 'scan-url';
+            const priority = 1;
             webApiClientMock
-                .setup(async (w) => w.postScanUrl(scanUrl, 1))
+                .setup(async (w) => w.postScanUrl(scanUrl, priority))
                 .returns(async () => Promise.resolve(expectedResponse))
                 .verifiable(Times.once());
 
@@ -94,7 +95,28 @@ describe(HealthMonitorClientController, () => {
                 activityName: ActivityAction.createScanRequest,
                 data: {
                     scanUrl: scanUrl,
-                    priority: 1,
+                    priority: priority,
+                },
+            };
+            const result = await testSubject.invoke(context, args);
+            expect(result).toEqual(jsonResponse);
+        });
+
+        it('handles createConsolidatedScanRequest', async () => {
+            const scanUrl = 'scan-url';
+            const reportIdStub = 'some-report-id';
+            const priority = 1;
+            webApiClientMock
+                .setup(async (w) => w.postConsolidatedScan(scanUrl, reportIdStub, priority))
+                .returns(async () => Promise.resolve(expectedResponse))
+                .verifiable(Times.once());
+
+            const args: ActivityRequestData = {
+                activityName: ActivityAction.createConsolidatedScanRequest,
+                data: {
+                    scanUrl: scanUrl,
+                    priority: priority,
+                    reportId: reportIdStub,
                 },
             };
             const result = await testSubject.invoke(context, args);

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.ts
@@ -116,7 +116,6 @@ export class HealthMonitorClientController extends WebController {
         const functionalTestGroupCtor = this.testGroupTypes[data.testGroupName];
         const functionalTestGroup = new functionalTestGroupCtor(webApiClient, this.onDemandPageScanRunResultProvider, this.guidGenerator);
         functionalTestGroup.setTestContext(data.testContextData);
-        functionalTestGroup.setLogger(this.logger);
 
         await this.testRunner.run(functionalTestGroup, data.environment, this.releaseId, data.runId);
     };

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.ts
@@ -76,7 +76,9 @@ export class HealthMonitorClientController extends WebController {
         return this.serializeResponse(response);
     };
 
-    private readonly createConsolidatedScanRequest = async (data: CreateConsolidatedScanRequestData): Promise<SerializableResponse<ScanRunResponse[]>> => {
+    private readonly createConsolidatedScanRequest = async (
+        data: CreateConsolidatedScanRequestData,
+    ): Promise<SerializableResponse<ScanRunResponse[]>> => {
         const webApiClient = await this.webApiClientProvider();
         const response = await webApiClient.postConsolidatedScan(data.scanUrl, data.reportId, data.priority);
 

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.ts
@@ -14,6 +14,7 @@ import {
     GetScanResultData,
     RunFunctionalTestGroupData,
     TrackAvailabilityData,
+    CreateConsolidatedScanRequestData,
 } from './activity-request-data';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
@@ -41,6 +42,7 @@ export class HealthMonitorClientController extends WebController {
 
         this.activityCallbacks = {
             [ActivityAction.createScanRequest]: this.createScanRequest,
+            [ActivityAction.createConsolidatedScanRequest]: this.createConsolidatedScanRequest,
             [ActivityAction.getScanResult]: this.getScanResult,
             [ActivityAction.getScanReport]: this.getScanReport,
             [ActivityAction.getHealthStatus]: this.getHealthStatus,
@@ -70,6 +72,13 @@ export class HealthMonitorClientController extends WebController {
     private readonly createScanRequest = async (data: CreateScanRequestData): Promise<SerializableResponse<ScanRunResponse[]>> => {
         const webApiClient = await this.webApiClientProvider();
         const response = await webApiClient.postScanUrl(data.scanUrl, data.priority);
+
+        return this.serializeResponse(response);
+    };
+
+    private readonly createConsolidatedScanRequest = async (data: CreateConsolidatedScanRequestData): Promise<SerializableResponse<ScanRunResponse[]>> => {
+        const webApiClient = await this.webApiClientProvider();
+        const response = await webApiClient.postConsolidatedScan(data.scanUrl, data.reportId, data.priority);
 
         return this.serializeResponse(response);
     };

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.ts
@@ -116,6 +116,7 @@ export class HealthMonitorClientController extends WebController {
         const functionalTestGroupCtor = this.testGroupTypes[data.testGroupName];
         const functionalTestGroup = new functionalTestGroupCtor(webApiClient, this.onDemandPageScanRunResultProvider, this.guidGenerator);
         functionalTestGroup.setTestContext(data.testContextData);
+        functionalTestGroup.setLogger(this.logger);
 
         await this.testRunner.run(functionalTestGroup, data.environment, this.releaseId, data.runId);
     };

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
@@ -324,7 +324,7 @@ describe('HealthMonitorOrchestrationController', () => {
             orchestratorIterator.next();
             expectedStepsCallCount.getScanReportCount += 1;
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
-            
+
             orchestratorIterator.next();
             expectedStepsCallCount.getScanReportCount += 1;
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
@@ -129,6 +129,15 @@ class OrchestrationStepsStub implements OrchestrationSteps {
         return yield this.scanId;
     }
 
+    public *invokeSubmitConsolidatedScanRequestRestApi(url: string, reportId: string): Generator<any, string, any> {
+        this.orchestratorStepsCallCount.callSubmitScanRequest += 1;
+        this.throwExceptionIfExpected();
+        expect(url).toBe(this.availabilityTestConfig.urlToScan);
+        expect(reportId).toBe(this.availabilityTestConfig.consolidatedReportId);
+
+        return yield this.scanId;
+    }
+
     public *runFunctionalTestGroups(
         testContextData: TestContextData,
         testGroupNames: TestGroupName[],
@@ -170,6 +179,7 @@ describe('HealthMonitorOrchestrationController', () => {
             maxScanWaitTimeInSeconds: 20,
             logQueryTimeRange: 'P1D',
             environmentDefinition: TestEnvironment[TestEnvironment.canary],
+            consolidatedReportId: 'somereportid',
         };
 
         serviceConfigurationMock = Mock.ofType(ServiceConfiguration);
@@ -280,6 +290,10 @@ describe('HealthMonitorOrchestrationController', () => {
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
 
             orchestratorIterator.next();
+            expectedStepsCallCount.callSubmitScanRequest += 1;
+            expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
+
+            orchestratorIterator.next();
             expectedTests.push('PostScan', 'ScanStatus');
             expectedStepsCallCount.runFunctionalTestsCount += 1;
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
@@ -287,6 +301,14 @@ describe('HealthMonitorOrchestrationController', () => {
 
             orchestratorIterator.next();
             expectedStepsCallCount.verifyScanSubmittedCount += 1;
+            expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
+
+            orchestratorIterator.next();
+            expectedStepsCallCount.verifyScanSubmittedCount += 1;
+            expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
+
+            orchestratorIterator.next();
+            expectedStepsCallCount.waitForScanCompletionCount += 1;
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
 
             orchestratorIterator.next();
@@ -299,6 +321,10 @@ describe('HealthMonitorOrchestrationController', () => {
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
             expect(orchestratorStepsStub.functionalTestsRun).toEqual(expectedTests);
 
+            orchestratorIterator.next();
+            expectedStepsCallCount.getScanReportCount += 1;
+            expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
+            
             orchestratorIterator.next();
             expectedStepsCallCount.getScanReportCount += 1;
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
@@ -70,16 +70,23 @@ export class HealthMonitorOrchestrationController extends WebController {
             yield* orchestrationSteps.invokeHealthCheckRestApi();
 
             const scanId = yield* orchestrationSteps.invokeSubmitScanRequestRestApi(availabilityTestConfig.urlToScan);
+            const consolidatedScanId = yield* orchestrationSteps.invokeSubmitConsolidatedScanRequestRestApi(availabilityTestConfig.urlToScan, availabilityTestConfig.consolidatedReportId)
             testContextData.scanId = scanId;
+            testContextData.consolidatedScanId = consolidatedScanId;
             yield* orchestrationSteps.runFunctionalTestGroups(testContextData, e2eTestGroupNames.postScanSubmissionTests);
 
             yield* orchestrationSteps.validateScanRequestSubmissionState(scanId);
+            yield* orchestrationSteps.validateScanRequestSubmissionState(consolidatedScanId);
             const scanRunStatus = yield* orchestrationSteps.waitForScanRequestCompletion(scanId);
+            const consolidatedScanRunStatus = yield* orchestrationSteps.waitForScanRequestCompletion(consolidatedScanId);
             yield* orchestrationSteps.runFunctionalTestGroups(testContextData, e2eTestGroupNames.postScanCompletionTests);
 
             const reportId = scanRunStatus.reports[0].reportId;
+            const consolidatedReportId = consolidatedScanRunStatus.reports[0].reportId;
             testContextData.reportId = reportId;
+            testContextData.consolidatedReportId = consolidatedReportId;
             yield* orchestrationSteps.invokeGetScanReportRestApi(scanId, reportId);
+            yield* orchestrationSteps.invokeGetScanReportRestApi(consolidatedScanId, consolidatedReportId);
             yield* orchestrationSteps.runFunctionalTestGroups(testContextData, e2eTestGroupNames.scanReportTests);
 
             // The last test group in a functional test suite to indicated a suite run completion

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
@@ -70,7 +70,10 @@ export class HealthMonitorOrchestrationController extends WebController {
             yield* orchestrationSteps.invokeHealthCheckRestApi();
 
             const scanId = yield* orchestrationSteps.invokeSubmitScanRequestRestApi(availabilityTestConfig.urlToScan);
-            const consolidatedScanId = yield* orchestrationSteps.invokeSubmitConsolidatedScanRequestRestApi(availabilityTestConfig.urlToScan, availabilityTestConfig.consolidatedReportId)
+            const consolidatedScanId = yield* orchestrationSteps.invokeSubmitConsolidatedScanRequestRestApi(
+                availabilityTestConfig.urlToScan,
+                availabilityTestConfig.consolidatedReportId,
+            );
             testContextData.scanId = scanId;
             testContextData.consolidatedScanId = consolidatedScanId;
             yield* orchestrationSteps.runFunctionalTestGroups(testContextData, e2eTestGroupNames.postScanSubmissionTests);

--- a/packages/web-workers/src/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration-steps.spec.ts
@@ -16,6 +16,7 @@ import {
     CreateScanRequestData,
     RunFunctionalTestGroupData,
     TrackAvailabilityData,
+    CreateConsolidatedScanRequestData,
 } from './controllers/activity-request-data';
 import { OrchestrationStepsImpl, OrchestrationTelemetryProperties } from './orchestration-steps';
 import { GeneratorExecutor } from './test-utilities/generator-executor';
@@ -188,6 +189,84 @@ describe(OrchestrationStepsImpl, () => {
             setupVerifyTrackActivityCall(false, {
                 requestResponse: JSON.stringify(response),
                 activityName: ActivityAction.createScanRequest,
+            });
+
+            expect(() => generatorExecutor.runTillEnd()).toThrowError();
+        });
+    });
+
+    describe('invokeSubmitConsolidatedScanRequestRestApi', () => {
+        let generatorExecutor: GeneratorExecutor<string>;
+        let activityRequestData: ActivityRequestData;
+        let reportIdStub: string;
+
+        beforeEach(() => {
+            reportIdStub = 'some-report-id';
+            generatorExecutor = new GeneratorExecutor<string>(
+                testSubject.invokeSubmitConsolidatedScanRequestRestApi(scanUrl, reportIdStub),
+            );
+            activityRequestData = {
+                activityName: ActivityAction.createConsolidatedScanRequest,
+                data: {
+                    scanUrl: scanUrl,
+                    priority: 1000,
+                    reportId: reportIdStub,
+                } as CreateConsolidatedScanRequestData,
+            };
+        });
+
+        test.each([200, 299])('triggers submitScanRequest with status code %o', async (statusCode) => {
+            const response: SerializableResponse<ScanRunResponse[]> = createSerializableResponse<ScanRunResponse[]>(statusCode, [
+                { scanId: scanId } as ScanRunResponse,
+            ]);
+
+            orchestrationContext
+                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
+                .returns(() => {
+                    return response as any;
+                })
+                .verifiable(Times.once());
+            setupTrackActivityNeverCalled();
+
+            const scanIdResult = generatorExecutor.runTillEnd();
+            expect(scanIdResult).toEqual(scanId);
+        });
+
+        test.each([199, 300])('submitScanRequest throws error on status code %o', async (statusCode) => {
+            const response: SerializableResponse<ScanRunResponse[]> = createSerializableResponse<ScanRunResponse[]>(statusCode);
+
+            orchestrationContext
+                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
+                .returns(() => response as any)
+                .verifiable(Times.once());
+
+            setupVerifyTrackActivityCall(false, {
+                requestResponse: JSON.stringify(response),
+                activityName: ActivityAction.createConsolidatedScanRequest,
+            });
+
+            expect(() => generatorExecutor.runTillEnd()).toThrowError();
+        });
+
+        it('submitScanRequest throws error on scan submitted failure', async () => {
+            const error: WebApiError = {
+                code: 'InternalError',
+                codeId: 2000,
+                message: 'test error message',
+            };
+
+            const response: SerializableResponse<ScanRunResponse[]> = createSerializableResponse<ScanRunResponse[]>(200, [
+                { error: error } as ScanRunResponse,
+            ]);
+
+            orchestrationContext
+                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
+                .returns(() => response as any)
+                .verifiable(Times.once());
+
+            setupVerifyTrackActivityCall(false, {
+                requestResponse: JSON.stringify(response),
+                activityName: ActivityAction.createConsolidatedScanRequest,
             });
 
             expect(() => generatorExecutor.runTillEnd()).toThrowError();

--- a/packages/web-workers/src/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration-steps.spec.ts
@@ -56,6 +56,7 @@ describe(OrchestrationStepsImpl, () => {
             urlToScan: 'https://www.bing.com',
             logQueryTimeRange: 'P1D',
             environmentDefinition: 'canary',
+            consolidatedReportId: 'somereportid',
         };
 
         loggerMock = Mock.ofType(MockableLogger);

--- a/packages/web-workers/src/orchestration-steps.ts
+++ b/packages/web-workers/src/orchestration-steps.ts
@@ -172,7 +172,7 @@ export class OrchestrationStepsImpl implements OrchestrationSteps {
 
         const response = yield* this.callWebRequestActivity(ActivityAction.createConsolidatedScanRequest, requestData);
         const scanId = yield* this.getScanIdFromResponse(response, ActivityAction.createConsolidatedScanRequest);
-        this.logOrchestrationStep(`Orchestrator submitted scan with scan Id: ${scanId}`);
+        this.logOrchestrationStep(`Orchestrator submitted consolidated scan request with scan Id: ${scanId}`);
 
         return scanId;
     }

--- a/packages/web-workers/src/orchestration-steps.ts
+++ b/packages/web-workers/src/orchestration-steps.ts
@@ -16,6 +16,7 @@ import {
     GetScanResultData,
     RunFunctionalTestGroupData,
     TrackAvailabilityData,
+    CreateConsolidatedScanRequestData,
 } from './controllers/activity-request-data';
 import { getAllTestGroupClassNames } from './e2e-test-group-names';
 
@@ -34,6 +35,7 @@ export interface OrchestrationTelemetryProperties {
 export interface OrchestrationSteps {
     invokeHealthCheckRestApi(): Generator<Task, void, SerializableResponse>;
     invokeSubmitScanRequestRestApi(url: string): Generator<Task, string, SerializableResponse>;
+    invokeSubmitConsolidatedScanRequestRestApi(url: string, reportId: string): Generator<Task, string, SerializableResponse>;
     validateScanRequestSubmissionState(scanId: string): Generator<Task, void, SerializableResponse & void>;
     waitForScanRequestCompletion(scanId: string): Generator<Task, ScanRunResultResponse, SerializableResponse & void>;
     invokeGetScanReportRestApi(scanId: string, reportId: string): Generator<Task, void, SerializableResponse & void>;
@@ -153,6 +155,20 @@ export class OrchestrationStepsImpl implements OrchestrationSteps {
 
         const response = yield* this.callWebRequestActivity(ActivityAction.createScanRequest, requestData);
         const scanId = yield* this.getScanIdFromResponse(response, ActivityAction.createScanRequest);
+        this.logOrchestrationStep(`Orchestrator submitted scan with scan Id: ${scanId}`);
+
+        return scanId;
+    }
+
+    public *invokeSubmitConsolidatedScanRequestRestApi(url: string, reportId: string): Generator<Task, string, SerializableResponse & void> {
+        const requestData: CreateConsolidatedScanRequestData = {
+            scanUrl: url,
+            reportId: reportId,
+            priority: 1000,
+        };
+
+        const response = yield* this.callWebRequestActivity(ActivityAction.createConsolidatedScanRequest, requestData);
+        const scanId = yield* this.getScanIdFromResponse(response, ActivityAction.createConsolidatedScanRequest);
         this.logOrchestrationStep(`Orchestrator submitted scan with scan Id: ${scanId}`);
 
         return scanId;

--- a/packages/web-workers/src/orchestration-steps.ts
+++ b/packages/web-workers/src/orchestration-steps.ts
@@ -160,7 +160,10 @@ export class OrchestrationStepsImpl implements OrchestrationSteps {
         return scanId;
     }
 
-    public *invokeSubmitConsolidatedScanRequestRestApi(url: string, reportId: string): Generator<Task, string, SerializableResponse & void> {
+    public *invokeSubmitConsolidatedScanRequestRestApi(
+        url: string,
+        reportId: string,
+    ): Generator<Task, string, SerializableResponse & void> {
         const requestData: CreateConsolidatedScanRequestData = {
             scanUrl: url,
             reportId: reportId,


### PR DESCRIPTION
#### Description of changes

This adds an additional test to validate the consolidated report api. Specifically, we're checking to see that we're returned 3 reports as a result.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
