### PR TITLE
chore: prepare installation scripts for mandatory keyvault soft-delete

### DIFF
--- a/packages/resource-deployment/scripts/delete-resource-group.sh
+++ b/packages/resource-deployment/scripts/delete-resource-group.sh
@@ -9,7 +9,7 @@ export resourceGroupName
 
 exitWithUsageInfo() {
     echo "
-        Usage: $0 -r <resource group name>
+        Usage: $0 -r <resource group name> [-p <purge key vault if set to true>]
     "
     exit 1
 }
@@ -23,6 +23,8 @@ deleteResourceGroup() {
     if [[ "$response" == true ]]; then
         echo "Resource group $resourceGroupName exists."
 
+        . "${0%/*}/get-resource-names.sh"
+
         deleteApimIfExists
 
         echo "Triggering delete operation on resource group $resourceGroupName"
@@ -34,26 +36,40 @@ deleteResourceGroup() {
             echo "Unable to delete resource group $resourceGroupName. Response - $response"
             exit 1
         fi
+
+        if [[ "$purgeKeyVault" == true ]]; then
+            purgeKeyvaultIfSoftDeleted
+        else
+            echo "Keyvault $keyVault was not purged and will be recoverable for 90 days."
+        fi
     else
         echo "$resourceGroupName - Does not exist."
     fi
 }
 
 deleteApimIfExists() {
-    . "${0%/*}/get-resource-names.sh"
-
-    response=$(az apim show --name $apiManagementName --resource-group $resourceGroupName -o tsv)
+    response=$(az apim show --name $keyVault --resource-group $resourceGroupName -o tsv)
 
     if [[ -n "$response" ]]; then
-        echo "Deleting API Management $apiManagementName"
+        echo "Deleting API Management $apiManagementName..."
         az apim delete --name $apiManagementName --resource-group $resourceGroupName --yes || true
     fi
 }
 
+purgeKeyvaultIfSoftDeleted() {
+    response=$(az keyvault list-deleted --resource-type vault --query "[?name=='$keyVault'].id" -o tsv)
+
+    if [[ -n "$response" ]]; then
+        echo "Purging keyvault $keyVault..."
+        az keyvault purge --name "$keyVault" || true
+    fi
+}
+
 # Read script arguments
-while getopts ":r:" option; do
+while getopts ":r:p:" option; do
     case $option in
     r) resourceGroupName=${OPTARG} ;;
+    p) purgeKeyVault=${OPTARG} ;;
     *) exitWithUsageInfo ;;
     esac
 done


### PR DESCRIPTION
At the end of this year, soft-delete will be enabled for all existing keyvaults and the option to opt out of soft delete will be deprecated ([more info on soft delete here](https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-change)). Soft delete is currently disabled for our dev testing and selftest pipelines. Since our dev and selftest resources are more frequently deleted and recreated, enabling soft-delete will likely cause name collisions which would break our deployment pipelines. This PR will prepare those pipelines to handle name collisions for soft-deleted keyvaults.

#### Description of changes
- When we attempt to deploy a keyvault, if a deleted keyvault is found with the same name, restore the deleted one instead of attempting to redeploy (the deleted keyvault can be manually purged if it's important to redeploy a fresh keyvault)
- Add an option in delete-resource-group to purge the deleted keyvault, which will allow a fresh redeployment in selftest without naming collisions.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
