### PR TITLE
fix: wait for APIM instance to finish deleting before deleting resource group

### DIFF
--- a/packages/resource-deployment/scripts/delete-resource-group.sh
+++ b/packages/resource-deployment/scripts/delete-resource-group.sh
@@ -48,11 +48,34 @@ deleteResourceGroup() {
 }
 
 deleteApimIfExists() {
-    response=$(az apim list --resource-group $resourceGroupName --query "[?name=='$apiManagementName']" -o tsv)
+    apimExistsCommand="az apim list --resource-group $resourceGroupName --query \"[?name=='$apiManagementName']\" -o tsv"
+    apimExists=$(eval "$apimExistsCommand")
 
-    if [[ -n "$response" ]]; then
+    if [[ -n "$apimExists" ]]; then
         echo "Deleting API Management $apiManagementName..."
         az apim delete --name $apiManagementName --resource-group $resourceGroupName --yes || true
+
+        # Wait for APIM to delete
+        local waiting=false
+        local deleteTimeout=1200
+        local end=$((SECONDS + $deleteTimeout))
+        apimExists=$(eval "$apimExistsCommand")
+        while [ -n "$apimExists"] && [ $SECONDS -le $end ]; do
+            if [[ $waiting != true ]]; then
+                waiting=true
+                echo "Waiting for $apiManagementName to delete"
+                printf " - Running .."
+            fi
+
+            sleep 5
+            printf "."
+            apimExists=$(eval "$apimExistsCommand")
+        done
+
+        if [[ -n $apimExists ]]; then
+            echo "Unable to delete API Management instance $apiManagementName within $deleteTimeout seconds"
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
#### Description of changes

This will prevent status conflict errors when deleting resource groups (i.e. APIM is in deleting state when we try to delete the resource group)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
