### PR TITLE
fix: handle empty resource group

### DIFF
--- a/packages/resource-deployment/scripts/delete-resource-group.sh
+++ b/packages/resource-deployment/scripts/delete-resource-group.sh
@@ -48,6 +48,10 @@ deleteResourceGroup() {
 }
 
 deleteApimIfExists() {
+    if [[ -z "$apiManagementName" ]]; then
+        return
+    fi
+
     apimExistsCommand="az apim list --resource-group $resourceGroupName --query \"[?name=='$apiManagementName']\" -o tsv"
     apimExists=$(eval "$apimExistsCommand")
 

--- a/packages/resource-deployment/scripts/get-resource-names.sh
+++ b/packages/resource-deployment/scripts/get-resource-names.sh
@@ -17,7 +17,7 @@ storageAccountName=$(
 
 if [[ -z $storageAccountName ]]; then
     echo "Unable to get storage account for resource group $resourceGroupName"
-    exit 1
+    return
 fi
 
 resourceGroupSuffix=${storageAccountName:11}


### PR DESCRIPTION
#### Description of changes

Fixes a case when running delete-resource-group where the resource group exists, but is empty, so the script errors when trying to get resource names

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
