### PR TITLE
feat(ai-service-dedupe-e2e): added fail scan notification e2e test

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -30,7 +30,12 @@ Object {
     },
     "scanNotifyApiEndpoint": Object {
       "default": "/scan-notification-url",
-      "doc": "The end-point to hit when a scan is completed.",
+      "doc": "The end-point to hit when a scan is completed and will respond successfully",
+      "format": "String",
+    },
+    "scanNotifyFailApiEndpoint": Object {
+      "default": "/scan-notification-url-fail",
+      "doc": "The end-point to hit when a scan is completed and will respond unsuccessfully",
       "format": "String",
     },
     "scanWaitIntervalInSeconds": Object {
@@ -211,7 +216,12 @@ Object {
     },
     "scanNotifyApiEndpoint": Object {
       "default": "/scan-notification-url",
-      "doc": "The end-point to hit when a scan is completed.",
+      "doc": "The end-point to hit when a scan is completed and will respond successfully",
+      "format": "String",
+    },
+    "scanNotifyFailApiEndpoint": Object {
+      "default": "/scan-notification-url-fail",
+      "doc": "The end-point to hit when a scan is completed and will respond unsuccessfully",
       "format": "String",
     },
     "scanWaitIntervalInSeconds": Object {

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -69,6 +69,7 @@ export interface AvailabilityTestConfig {
     environmentDefinition: string;
     consolidatedReportId: string;
     scanNotifyApiEndpoint: string;
+    scanNotifyFailApiEndpoint: string;
     maxScanCompletionNotificationWaitTimeInSeconds: number;
 }
 
@@ -302,7 +303,12 @@ export class ServiceConfiguration {
                 scanNotifyApiEndpoint: {
                     format: 'String',
                     default: '/scan-notification-url',
-                    doc: 'The end-point to hit when a scan is completed.',
+                    doc: 'The end-point to hit when a scan is completed and will respond successfully',
+                },
+                scanNotifyFailApiEndpoint: {
+                    format: 'String',
+                    default: '/scan-notification-url-fail',
+                    doc: 'The end-point to hit when a scan is completed and will respond unsuccessfully',
                 },
             },
         };

--- a/packages/e2e-web-apis/scan-notification-client-func-fail/function.json
+++ b/packages/e2e-web-apis/scan-notification-client-func-fail/function.json
@@ -1,0 +1,18 @@
+{
+    "bindings": [
+        {
+            "authLevel": "anonymous",
+            "name": "request",
+            "type": "httpTrigger",
+            "direction": "in",
+            "methods": ["post"],
+            "route": "scan-notification-url-fail"
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "response"
+        }
+    ],
+    "scriptFile": "../scan-notification-client-func-fail/index.js"
+}

--- a/packages/e2e-web-apis/scan-notification-client-func-fail/index.ts
+++ b/packages/e2e-web-apis/scan-notification-client-func-fail/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Context } from '@azure/functions';
+
+export async function run(context: Context): Promise<void> {
+    context.res = {
+        status: 500,
+    };
+    context.done();
+}

--- a/packages/e2e-web-apis/webpack.config.js
+++ b/packages/e2e-web-apis/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = (env) => {
         externals: ['@azure/functions'],
         entry: {
             ['scan-notification-client-func']: path.resolve('./scan-notification-client-func/index.ts'),
+            ['scan-notification-client-func-fail']: path.resolve('./scan-notification-client-func-fail/index.ts'),
         },
         mode: 'development',
         module: {

--- a/packages/functional-tests/src/test-groups/scan-completion-notification-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-completion-notification-test-group.ts
@@ -16,4 +16,12 @@ export class ScanCompletionNotificationTestGroup extends FunctionalTestGroup {
 
         expect(notification.state).to.equal('sent');
     }
+
+    @test(TestEnvironment.all)
+    public async testScanNotificatioFail(): Promise<void> {
+        const response = await this.a11yServiceClient.getScanStatus(this.testContextData.consolidatedScanId);
+        const notification = (<ScanRunResultResponse>response.body).notification;
+
+        expect(notification.state).to.equal('sendFailed');
+    }
 }

--- a/packages/functional-tests/src/test-groups/scan-completion-notification-test-group.ts
+++ b/packages/functional-tests/src/test-groups/scan-completion-notification-test-group.ts
@@ -22,6 +22,7 @@ export class ScanCompletionNotificationTestGroup extends FunctionalTestGroup {
         const response = await this.a11yServiceClient.getScanStatus(this.testContextData.consolidatedScanId);
         const notification = (<ScanRunResultResponse>response.body).notification;
 
+        // Consolidated scan request submitted with the scan notification url endpoint that would always fail.
         expect(notification.state).to.equal('sendFailed');
     }
 }

--- a/packages/resource-deployment/scripts/deploy-rest-api.sh
+++ b/packages/resource-deployment/scripts/deploy-rest-api.sh
@@ -9,7 +9,7 @@ set -eo pipefail
 deployRestApi() {
     local templateName="$templatesFolder/model-accessibility-insight-service-scan-api-api.template.json"
     echo "Deploying REST API template with resource parameters: Resource = $resourceGroupName, API Instance = $apiManagementName"
-    az deployment group create --resource-group "$resourceGroupName" --template-file "$templateName" --parameters functionName="$webApiFuncAppName" apimServiceName="$apiManagementName" 1>/dev/null
+    az deployment group create --resource-group "$resourceGroupName" --template-file "$templateName" --parameters functionName="$webApiFuncAppName" e2eFunctionName="$e2eWebApisFuncAppName" apimServiceName="$apiManagementName" 1>/dev/null
     echo "  Completed"
 }
 

--- a/packages/resource-deployment/templates/model-accessibility-insight-service-scan-api-api.template.json
+++ b/packages/resource-deployment/templates/model-accessibility-insight-service-scan-api-api.template.json
@@ -8,6 +8,9 @@
         "functionName": {
             "type": "string"
         },
+        "e2eFunctionName": {
+            "type": "string"
+        },
         "maxCallsPerMinute": {
             "type": "int",
             "defaultValue": 3000
@@ -40,6 +43,20 @@
             "type": "Microsoft.ApiManagement/service/backends",
             "apiVersion": "2019-01-01",
             "dependsOn": []
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/backends",
+            "apiVersion": "2019-01-01",
+            "name": "[concat(parameters('apimServiceName'), '/', parameters('e2eFunctionName'))]",
+            "dependsOn": [],
+            "properties": {
+                "url": "[concat('https://', parameters('e2eFunctionName'), '.azurewebsites.net/api')]",
+                "protocol": "http",
+                "resourceId": "[concat('https://management.azure.com/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/',parameters('e2eFunctionName'))]",
+                "credentials": {
+                    "header": {}
+                }
+            }
         },
         {
             "properties": {
@@ -447,6 +464,38 @@
             ]
         },
         {
+            "type": "Microsoft.ApiManagement/service/apis/operations",
+            "apiVersion": "2019-01-01",
+            "name": "[concat(parameters('apimServiceName'), '/accessibility-insight-service-scan-api/ping-scan-notification-url')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apimServiceName'), 'accessibility-insight-service-scan-api')]"
+            ],
+            "properties": {
+                "displayName": "Ping scan notification url",
+                "method": "POST",
+                "urlTemplate": "/scan-notification-url",
+                "templateParameters": [],
+                "description": "Hits the scan notification url api for successful notification",
+                "responses": []
+            }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis/operations",
+            "apiVersion": "2019-01-01",
+            "name": "[concat(parameters('apimServiceName'), '/accessibility-insight-service-scan-api/ping-scan-notification-url-fail')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apimServiceName'), 'accessibility-insight-service-scan-api')]"
+            ],
+            "properties": {
+                "displayName": "Ping scan notification url (fail)",
+                "method": "POST",
+                "urlTemplate": "/scan-notification-url-fail",
+                "templateParameters": [],
+                "description": "Hits the scan notification url api for unsuccessful notification",
+                "responses": []
+            }
+        },
+        {
             "properties": {
                 "value": "[concat('<policies>\r\n\t<inbound>\r\n\t\t<base />\r\n\t\t<set-backend-service id=\"apim-generated-policy\" backend-id=\"', parameters('functionName'), '\" />\r\n\t</inbound>\r\n\t<backend>\r\n\t\t<base />\r\n\t</backend>\r\n\t<outbound>\r\n\t\t<base />\r\n\t\t<redirect-content-urls />\r\n\t</outbound>\r\n\t<on-error>\r\n\t\t<base />\r\n\t</on-error>\r\n</policies>')]",
                 "format": "xml"
@@ -457,6 +506,30 @@
             "dependsOn": [
                 "[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('apimServiceName'), 'accessibility-insight-service-scan-api','health')]"
             ]
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis/operations/policies",
+            "apiVersion": "2019-01-01",
+            "name": "[concat(parameters('apimServiceName'), '/accessibility-insight-service-scan-api/ping-scan-notification-url/policy')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('apimServiceName'), 'accessibility-insight-service-scan-api','ping-scan-notification-url')]"
+            ],
+            "properties": {
+                "value": "[concat('<policies>\r\n\t<inbound>\r\n\t\t<base />\r\n\t\t<set-backend-service id=\"apim-generated-policy\" backend-id=\"', parameters('e2eFunctionName'), '\" />\r\n\t</inbound>\r\n\t<backend>\r\n\t\t<base />\r\n\t</backend>\r\n\t<outbound>\r\n\t\t<base />\r\n\t\t<redirect-content-urls />\r\n\t</outbound>\r\n\t<on-error>\r\n\t\t<base />\r\n\t</on-error>\r\n</policies>')]",
+                "format": "xml"
+            }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis/operations/policies",
+            "apiVersion": "2019-01-01",
+            "name": "[concat(parameters('apimServiceName'), '/accessibility-insight-service-scan-api/ping-scan-notification-url-fail/policy')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('apimServiceName'), 'accessibility-insight-service-scan-api','ping-scan-notification-url-fail')]"
+            ],
+            "properties": {
+                "value": "[concat('<policies>\r\n\t<inbound>\r\n\t\t<base />\r\n\t\t<set-backend-service id=\"apim-generated-policy\" backend-id=\"', parameters('e2eFunctionName'), '\" />\r\n\t</inbound>\r\n\t<backend>\r\n\t\t<base />\r\n\t</backend>\r\n\t<outbound>\r\n\t\t<base />\r\n\t\t<redirect-content-urls />\r\n\t</outbound>\r\n\t<on-error>\r\n\t\t<base />\r\n\t</on-error>\r\n</policies>')]",
+                "format": "xml"
+            }
         },
         {
             "type": "Microsoft.ApiManagement/service/apis/policies",

--- a/packages/web-api-client/src/a11y-service-client.spec.ts
+++ b/packages/web-api-client/src/a11y-service-client.spec.ts
@@ -200,7 +200,15 @@ describe(A11yServiceClient, () => {
 
     it('postConsolidatedScan', async () => {
         const reportId = 'some-report-id';
-        const requestBody = [{ url: scanUrl, site: { baseUrl: scanUrl }, reportGroups: [{ consolidatedId: reportId }], priority }];
+        const requestBody = [
+            {
+                url: scanUrl,
+                site: { baseUrl: scanUrl },
+                scanNotifyUrl: scanNotifyUrlStub,
+                reportGroups: [{ consolidatedId: reportId }],
+                priority,
+            },
+        ];
         const requestOptions = { json: requestBody };
 
         setupVerifiableSignRequestCall();
@@ -210,7 +218,7 @@ describe(A11yServiceClient, () => {
             .returns(async () => Promise.resolve(response))
             .verifiable(Times.once());
 
-        const actualResponse = await testSubject.postConsolidatedScan(scanUrl, reportId, priority);
+        const actualResponse = await testSubject.postConsolidatedScan(scanUrl, reportId, scanNotifyUrlStub, priority);
 
         expect(actualResponse).toEqual(response);
     });

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -61,12 +61,14 @@ export class A11yServiceClient {
     public async postConsolidatedScan(
         scanUrl: string,
         reportId: string,
+        scanNotificationUrl: string,
         priority?: number,
     ): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
         const scanRequestData: ScanRunRequest = {
             url: scanUrl,
             site: { baseUrl: scanUrl },
             reportGroups: [{ consolidatedId: reportId }],
+            scanNotifyUrl: scanNotificationUrl,
         };
 
         return this.postScanUrlWithRequest(scanRequestData, priority);

--- a/packages/web-api/src/controllers/health-check-controller.spec.ts
+++ b/packages/web-api/src/controllers/health-check-controller.spec.ts
@@ -43,6 +43,7 @@ describe(HealthCheckController, () => {
             consolidatedReportId: 'somereportid',
             scanNotifyApiEndpoint: '/some-endpoint',
             maxScanCompletionNotificationWaitTimeInSeconds: 30,
+            scanNotifyFailApiEndpoint: '/some-fail-endpoint',
         };
 
         serviceConfigurationMock = Mock.ofType<ServiceConfiguration>();

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.spec.ts
@@ -108,8 +108,10 @@ describe(HealthMonitorClientController, () => {
             const scanUrl = 'scan-url';
             const reportIdStub = 'some-report-id';
             const priority = 1;
+            const notifyScanUrl = 'some-notify-url';
+
             webApiClientMock
-                .setup(async (w) => w.postConsolidatedScan(scanUrl, reportIdStub, priority))
+                .setup(async (w) => w.postConsolidatedScan(scanUrl, reportIdStub, notifyScanUrl, priority))
                 .returns(async () => Promise.resolve(expectedResponse))
                 .verifiable(Times.once());
 
@@ -119,6 +121,7 @@ describe(HealthMonitorClientController, () => {
                     scanUrl: scanUrl,
                     priority: priority,
                     reportId: reportIdStub,
+                    notifyScanUrl: notifyScanUrl,
                 },
             };
             const result = await testSubject.invoke(context, args);

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.ts
@@ -80,7 +80,7 @@ export class HealthMonitorClientController extends WebController {
         data: CreateConsolidatedScanRequestData,
     ): Promise<SerializableResponse<ScanRunResponse[]>> => {
         const webApiClient = await this.webApiClientProvider();
-        const response = await webApiClient.postConsolidatedScan(data.scanUrl, data.reportId, data.priority);
+        const response = await webApiClient.postConsolidatedScan(data.scanUrl, data.reportId, data.notifyScanUrl, data.priority);
 
         return this.serializeResponse(response);
     };

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
@@ -146,11 +146,12 @@ class OrchestrationStepsStub implements OrchestrationSteps {
         return yield this.scanId;
     }
 
-    public *invokeSubmitConsolidatedScanRequestRestApi(url: string, reportId: string): Generator<any, string, any> {
+    public *invokeSubmitConsolidatedScanRequestRestApi(url: string, reportId: string, scanNotifyUrl: string): Generator<any, string, any> {
         this.orchestratorStepsCallCount.callSubmitScanRequest += 1;
         this.throwExceptionIfExpected();
         expect(url).toBe(this.availabilityTestConfig.urlToScan);
         expect(reportId).toBe(this.availabilityTestConfig.consolidatedReportId);
+        expect(scanNotifyUrl).toEqual(`${baseWebApiUrl}${this.availabilityTestConfig.scanNotifyFailApiEndpoint}`);
 
         return yield this.scanId;
     }
@@ -200,6 +201,7 @@ describe('HealthMonitorOrchestrationController', () => {
             consolidatedReportId: 'somereportid',
             scanNotifyApiEndpoint: '/some-endpoint',
             maxScanCompletionNotificationWaitTimeInSeconds: 30,
+            scanNotifyFailApiEndpoint: '/some-fail-endpoint',
         };
 
         serviceConfigurationMock = Mock.ofType(ServiceConfiguration);
@@ -360,6 +362,10 @@ describe('HealthMonitorOrchestrationController', () => {
             expectedStepsCallCount.runFunctionalTestsCount += 1;
             expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
             expect(orchestratorStepsStub.functionalTestsRun).toEqual(expectedTests);
+
+            orchestratorIterator.next();
+            expectedStepsCallCount.waitForScanCompletionNotificationCount += 1;
+            expect(actualStepsCallCount).toEqual(expectedStepsCallCount);
 
             orchestratorIterator.next();
             expectedStepsCallCount.waitForScanCompletionNotificationCount += 1;

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
@@ -63,6 +63,7 @@ export class HealthMonitorOrchestrationController extends WebController {
             const thisObj = context.bindingData.controller as HealthMonitorOrchestrationController;
             const availabilityTestConfig = context.bindingData.availabilityTestConfig as AvailabilityTestConfig;
             const scanNotificationUrl = `${thisObj.webApiConfig.baseUrl}${availabilityTestConfig.scanNotifyApiEndpoint}`;
+            const failScanNotificationUrl = `${thisObj.webApiConfig.baseUrl}${availabilityTestConfig.scanNotifyFailApiEndpoint}`;
             const orchestrationSteps = thisObj.createOrchestrationSteps(context, availabilityTestConfig);
             const testContextData: TestContextData = {
                 scanUrl: availabilityTestConfig.urlToScan,
@@ -76,6 +77,7 @@ export class HealthMonitorOrchestrationController extends WebController {
             const consolidatedScanId = yield* orchestrationSteps.invokeSubmitConsolidatedScanRequestRestApi(
                 availabilityTestConfig.urlToScan,
                 availabilityTestConfig.consolidatedReportId,
+                failScanNotificationUrl,
             );
             testContextData.scanId = scanId;
             testContextData.consolidatedScanId = consolidatedScanId;
@@ -96,6 +98,7 @@ export class HealthMonitorOrchestrationController extends WebController {
             yield* orchestrationSteps.runFunctionalTestGroups(testContextData, e2eTestGroupNames.scanReportTests);
 
             yield* orchestrationSteps.waitForScanCompletionNotification(scanId);
+            yield* orchestrationSteps.waitForScanCompletionNotification(consolidatedScanId);
             yield* orchestrationSteps.runFunctionalTestGroups(testContextData, e2eTestGroupNames.postScanCompletionNotificationTests);
 
             // The last test group in a functional test suite to indicated a suite run completion

--- a/packages/web-workers/src/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration-steps.spec.ts
@@ -61,6 +61,7 @@ describe(OrchestrationStepsImpl, () => {
             consolidatedReportId: 'somereportid',
             maxScanCompletionNotificationWaitTimeInSeconds: 30,
             scanNotifyApiEndpoint: '/scan-notify-api',
+            scanNotifyFailApiEndpoint: '/some-fail-endpoint',
         };
 
         loggerMock = Mock.ofType(MockableLogger);
@@ -207,7 +208,7 @@ describe(OrchestrationStepsImpl, () => {
         beforeEach(() => {
             reportIdStub = 'some-report-id';
             generatorExecutor = new GeneratorExecutor<string>(
-                testSubject.invokeSubmitConsolidatedScanRequestRestApi(scanUrl, reportIdStub),
+                testSubject.invokeSubmitConsolidatedScanRequestRestApi(scanUrl, reportIdStub, notifyScanUrl),
             );
             activityRequestData = {
                 activityName: ActivityAction.createConsolidatedScanRequest,
@@ -215,6 +216,7 @@ describe(OrchestrationStepsImpl, () => {
                     scanUrl: scanUrl,
                     priority: 1000,
                     reportId: reportIdStub,
+                    notifyScanUrl: notifyScanUrl,
                 } as CreateConsolidatedScanRequestData,
             };
         });

--- a/packages/web-workers/src/orchestration-steps.ts
+++ b/packages/web-workers/src/orchestration-steps.ts
@@ -42,7 +42,11 @@ export interface OrchestrationTelemetryProperties {
 export interface OrchestrationSteps {
     invokeHealthCheckRestApi(): Generator<Task, void, SerializableResponse>;
     invokeSubmitScanRequestRestApi(url: string, notifyScanUrl: string): Generator<Task, string, SerializableResponse>;
-    invokeSubmitConsolidatedScanRequestRestApi(url: string, reportId: string): Generator<Task, string, SerializableResponse>;
+    invokeSubmitConsolidatedScanRequestRestApi(
+        url: string,
+        reportId: string,
+        notifyScanUrl: string,
+    ): Generator<Task, string, SerializableResponse>;
     validateScanRequestSubmissionState(scanId: string): Generator<Task, void, SerializableResponse & void>;
     waitForScanRequestCompletion(scanId: string): Generator<Task, ScanRunResultResponse, SerializableResponse & void>;
     waitForScanCompletionNotification(scanId: string): Generator<Task, ScanCompletedNotification, SerializableResponse & void>;
@@ -240,11 +244,13 @@ export class OrchestrationStepsImpl implements OrchestrationSteps {
     public *invokeSubmitConsolidatedScanRequestRestApi(
         url: string,
         reportId: string,
+        notifyScanUrl: string,
     ): Generator<Task, string, SerializableResponse & void> {
         const requestData: CreateConsolidatedScanRequestData = {
             scanUrl: url,
             reportId: reportId,
             priority: 1000,
+            notifyScanUrl,
         };
 
         const response = yield* this.callWebRequestActivity(ActivityAction.createConsolidatedScanRequest, requestData);

--- a/packages/web-workers/src/orchestration-steps.ts
+++ b/packages/web-workers/src/orchestration-steps.ts
@@ -187,7 +187,7 @@ export class OrchestrationStepsImpl implements OrchestrationSteps {
         this.logOrchestrationStep('Starting wait for scan completion notification');
 
         while (
-            completedNotificationStates.indexOf(notificationState) === -1 &&
+            !completedNotificationStates.includes(notificationState) &&
             moment.utc(this.context.df.currentUtcDateTime).isBefore(waitEndTime)
         ) {
             this.logOrchestrationStep(`Starting timer with wait time ${scanWaitIntervalInSeconds}`, LogLevel.info, {
@@ -213,7 +213,7 @@ export class OrchestrationStepsImpl implements OrchestrationSteps {
 
         const totalWaitTimeInSeconds = moment.utc(this.context.df.currentUtcDateTime).diff(moment.utc(waitStartTime), 'seconds');
 
-        if (completedNotificationStates.indexOf(notificationState) !== -1) {
+        if (completedNotificationStates.includes(notificationState)) {
             this.logOrchestrationStep('Wait for scan completition notification succeeded', LogLevel.info, {
                 totalWaitTimeInSeconds: totalWaitTimeInSeconds.toString(),
                 waitStartTime: waitStartTime.toJSON(),


### PR DESCRIPTION
#### Description of changes

Creates another function in e2e-web-apis to send a non-200 response for scan notification fail case. This api/url is passed for the consolidated scan.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
