### PR TITLE
feat (Hackathon -- AI-Action): Get the crawler package ready to be consumed by external users

### DIFF
--- a/packages/axe-result-converter/src/axe-result-types.ts
+++ b/packages/axe-result-converter/src/axe-result-types.ts
@@ -7,13 +7,13 @@ export declare type SelectorType = 'xpath' | 'css';
 
 export interface AxeCoreResults extends Omit<axe.AxeResults, 'passes' | 'violations' | 'incomplete' | 'inapplicable'> {
     urls: string[];
-    passes: AxeResults;
-    violations: AxeResults;
-    incomplete: AxeResults;
-    inapplicable: AxeResults;
+    passes: AxeResultsList;
+    violations: AxeResultsList;
+    incomplete: AxeResultsList;
+    inapplicable: AxeResultsList;
 }
 
-export class AxeResults extends HashSet<AxeResult> {}
+export class AxeResultsList extends HashSet<AxeResult> {}
 
 export interface AxeResult extends axe.Result {
     urls: string[];

--- a/packages/axe-result-converter/src/axe-results-reducer.spec.ts
+++ b/packages/axe-result-converter/src/axe-results-reducer.spec.ts
@@ -6,7 +6,7 @@ import { IMock, Mock, It, Times } from 'typemoq';
 import { HashGenerator } from 'common';
 import axe from 'axe-core';
 import { AxeResultsReducer } from './axe-results-reducer';
-import { AxeResult, AxeNodeResult, AxeCoreResults, AxeResults } from './axe-result-types';
+import { AxeResult, AxeNodeResult, AxeCoreResults, AxeResultsList } from './axe-result-types';
 
 let hashGeneratorMock: IMock<HashGenerator>;
 let axeResultsReducer: AxeResultsReducer;
@@ -27,7 +27,7 @@ const getAccumulatedResult = (ruleId: string, data: { urls: string[]; nodeId?: s
         fingerprint: data.nodeId ? `id-${ruleId}|snippet-${data.nodeId}|selector-${data.nodeId}` : `id-${ruleId}`,
     } as AxeResult;
 };
-const addAxeResult = (axeResults: AxeResults, ...axeResultList: AxeResult[]): AxeResults => {
+const addAxeResult = (axeResults: AxeResultsList, ...axeResultList: AxeResult[]): AxeResultsList => {
     axeResultList.forEach((axeResult) => axeResults.add(axeResult.fingerprint, axeResult));
 
     return axeResults;
@@ -65,10 +65,10 @@ describe(AxeResultsReducer, () => {
     it('reduce axe result', () => {
         const url = 'url-1';
         const accumulatedResults = {
-            violations: new AxeResults(),
-            passes: new AxeResults(),
-            incomplete: new AxeResults(),
-            inapplicable: new AxeResults(),
+            violations: new AxeResultsList(),
+            passes: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
         } as AxeCoreResults;
         const violations = getCurrentResults('rule-1', 'node-11');
         const passes = getCurrentResults('rule-2', 'node-21');
@@ -90,7 +90,7 @@ describe(AxeResultsReducer, () => {
 
     it('reduce result without nodes', () => {
         const currentUrl = 'url-2';
-        const accumulatedResults = addAxeResult(new AxeResults(), getAccumulatedResult('rule-1', { urls: ['url-1'] }));
+        const accumulatedResults = addAxeResult(new AxeResultsList(), getAccumulatedResult('rule-1', { urls: ['url-1'] }));
         const currentResults = getCurrentResults('rule-1');
         const expectedResults = [getAccumulatedResult('rule-1', { urls: ['url-1', currentUrl] })];
 
@@ -104,10 +104,10 @@ describe(AxeResultsReducer, () => {
 
     it('skip same rule node', () => {
         const currentUrl = 'url-2';
-        const accumulatedResults = addAxeResult(new AxeResults(), getAccumulatedResult('rule-1', { urls: ['url-1'], nodeId: 'node-1' }));
+        const accumulatedResults = addAxeResult(new AxeResultsList(), getAccumulatedResult('rule-1', { urls: ['url-1'], nodeId: 'node-1' }));
         const currentResults = getCurrentResults('rule-1', 'node-1', 'node-2', 'node-3');
         const expectedResults = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult('rule-1', { urls: ['url-1', currentUrl], nodeId: 'node-1' }),
             getAccumulatedResult('rule-1', { urls: [currentUrl], nodeId: 'node-2' }),
             getAccumulatedResult('rule-1', { urls: [currentUrl], nodeId: 'node-3' }),
@@ -123,10 +123,10 @@ describe(AxeResultsReducer, () => {
 
     it('split multiple nodes from a single result', () => {
         const currentUrl = 'url-1';
-        const accumulatedResults = new AxeResults();
+        const accumulatedResults = new AxeResultsList();
         const currentResults = getCurrentResults('rule-1', 'node-1', 'node-2', 'node-3');
         const expectedResults = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult('rule-1', { urls: [currentUrl], nodeId: 'node-1' }),
             getAccumulatedResult('rule-1', { urls: [currentUrl], nodeId: 'node-2' }),
             getAccumulatedResult('rule-1', { urls: [currentUrl], nodeId: 'node-3' }),

--- a/packages/axe-result-converter/src/axe-results-reducer.spec.ts
+++ b/packages/axe-result-converter/src/axe-results-reducer.spec.ts
@@ -104,7 +104,10 @@ describe(AxeResultsReducer, () => {
 
     it('skip same rule node', () => {
         const currentUrl = 'url-2';
-        const accumulatedResults = addAxeResult(new AxeResultsList(), getAccumulatedResult('rule-1', { urls: ['url-1'], nodeId: 'node-1' }));
+        const accumulatedResults = addAxeResult(
+            new AxeResultsList(),
+            getAccumulatedResult('rule-1', { urls: ['url-1'], nodeId: 'node-1' }),
+        );
         const currentResults = getCurrentResults('rule-1', 'node-1', 'node-2', 'node-3');
         const expectedResults = addAxeResult(
             new AxeResultsList(),

--- a/packages/axe-result-converter/src/axe-results-reducer.ts
+++ b/packages/axe-result-converter/src/axe-results-reducer.ts
@@ -3,7 +3,7 @@
 import { injectable, inject } from 'inversify';
 import axe from 'axe-core';
 import { HashGenerator } from 'common';
-import { Selector, AxeCoreResults, AxeResults, AxeResult } from './axe-result-types';
+import { Selector, AxeCoreResults, AxeResultsList, AxeResult } from './axe-result-types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -19,7 +19,7 @@ export class AxeResultsReducer {
         this.reduceResultsWithoutNodes(currentAxeResults.url, accumulatedAxeResults.inapplicable, currentAxeResults.inapplicable);
     }
 
-    private reduceResults(url: string, accumulatedResults: AxeResults, currentResults: axe.Result[]): void {
+    private reduceResults(url: string, accumulatedResults: AxeResultsList, currentResults: axe.Result[]): void {
         if (currentResults) {
             for (const currentResult of currentResults) {
                 if (currentResult) {
@@ -52,7 +52,7 @@ export class AxeResultsReducer {
         }
     }
 
-    private reduceResultsWithoutNodes(url: string, accumulatedResults: AxeResults, currentResults: axe.Result[]): void {
+    private reduceResultsWithoutNodes(url: string, accumulatedResults: AxeResultsList, currentResults: axe.Result[]): void {
         if (currentResults) {
             for (const currentResult of currentResults) {
                 if (currentResult) {

--- a/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
+++ b/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { CombinedReportDataConverter } from './combined-report-data-converter';
-import { AxeResult, AxeNodeResult, AxeCoreResults, AxeResults } from './axe-result-types';
+import { AxeResult, AxeNodeResult, AxeCoreResults, AxeResultsList } from './axe-result-types';
 import { ScanResultData } from './scan-result-data';
 
 let combinedReportDataConverter: CombinedReportDataConverter;
@@ -55,7 +55,7 @@ const getAccumulatedResult = (ruleId: string, data: { urls: string[]; nodeId?: s
     } as AxeResult;
 };
 
-const addAxeResult = (axeResults: AxeResults, ...axeResultList: AxeResult[]): AxeResults => {
+const addAxeResult = (axeResults: AxeResultsList, ...axeResultList: AxeResult[]): AxeResultsList => {
     axeResultList.forEach((axeResult) => axeResults.add(axeResult.fingerprint, axeResult));
 
     return axeResults;
@@ -68,7 +68,7 @@ describe(CombinedReportDataConverter, () => {
 
     it('convert axe results to combined report data', () => {
         const violations = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult('rule-1', { urls: ['url-11'], nodeId: 'node-11' }),
             getAccumulatedResult('rule-2', { urls: ['url-21', 'url-22'], nodeId: 'node-12' }),
             getAccumulatedResult('rule-2', { urls: ['url-21'], nodeId: 'node-22' }),
@@ -77,17 +77,17 @@ describe(CombinedReportDataConverter, () => {
             getAccumulatedResult('rule-3', { urls: ['url-31'], nodeId: 'node-33' }),
         );
         const passes = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult('rule-21', { urls: ['url-21'], nodeId: 'node-21' }),
             getAccumulatedResult('rule-22', { urls: ['url-22'], nodeId: 'node-22' }),
         );
         const incomplete = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult('rule-31', { urls: ['url-31'], nodeId: 'node-31' }),
             getAccumulatedResult('rule-32', { urls: ['url-32'], nodeId: 'node-32' }),
         );
         const inapplicable = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult('rule-41', { urls: ['url-41'] }),
             getAccumulatedResult('rule-42', { urls: ['url-42'] }),
         );
@@ -105,14 +105,14 @@ describe(CombinedReportDataConverter, () => {
 
     it('Does not repeat failed rules in passed or not applicable sections', () => {
         const failedRuleId = 'failed-rule';
-        const violations = addAxeResult(new AxeResults(), getAccumulatedResult(failedRuleId, { urls: ['url-11'], nodeId: 'node-11' }));
+        const violations = addAxeResult(new AxeResultsList(), getAccumulatedResult(failedRuleId, { urls: ['url-11'], nodeId: 'node-11' }));
         const passes = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult(failedRuleId, { urls: ['url-21'], nodeId: 'node-21' }),
             getAccumulatedResult('passed-rule', { urls: ['url-22'], nodeId: 'node-22' }),
         );
         const inapplicable = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult(failedRuleId, { urls: ['url-31'], nodeId: 'node-31' }),
             getAccumulatedResult('not-applicable-rule', { urls: ['url-32'], nodeId: 'node-32' }),
         );
@@ -120,7 +120,7 @@ describe(CombinedReportDataConverter, () => {
         const axeCoreResults = {
             violations,
             passes,
-            incomplete: new AxeResults(),
+            incomplete: new AxeResultsList(),
             inapplicable,
         } as AxeCoreResults;
 
@@ -139,17 +139,17 @@ describe(CombinedReportDataConverter, () => {
 
     it('Does not repeat passed rule in not applicable section', () => {
         const passedRuleId = 'passed-rule';
-        const passes = addAxeResult(new AxeResults(), getAccumulatedResult(passedRuleId, { urls: ['url-21'], nodeId: 'node-21' }));
+        const passes = addAxeResult(new AxeResultsList(), getAccumulatedResult(passedRuleId, { urls: ['url-21'], nodeId: 'node-21' }));
         const inapplicable = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult(passedRuleId, { urls: ['url-31'], nodeId: 'node-31' }),
             getAccumulatedResult('not-applicable-rule', { urls: ['url-32'], nodeId: 'node-32' }),
         );
 
         const axeCoreResults = {
-            violations: new AxeResults(),
+            violations: new AxeResultsList(),
             passes,
-            incomplete: new AxeResults(),
+            incomplete: new AxeResultsList(),
             inapplicable,
         } as AxeCoreResults;
 
@@ -166,7 +166,7 @@ describe(CombinedReportDataConverter, () => {
     it('sorts failure cards by url count, then alphabetically by url', () => {
         const ruleId = 'rule-id';
         const violations = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             // failure cards should be sorted in the reverse of this order
             getAccumulatedResult(ruleId, { urls: ['url-a'], nodeId: 'node-4' }),
             getAccumulatedResult(ruleId, { urls: ['url-c', 'url-d'], nodeId: 'node-3' }),
@@ -175,9 +175,9 @@ describe(CombinedReportDataConverter, () => {
         );
         const axeCoreResults = {
             violations,
-            passes: new AxeResults(),
-            inapplicable: new AxeResults(),
-            incomplete: new AxeResults(),
+            passes: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
         } as AxeCoreResults;
 
         const combinedReportData = combinedReportDataConverter.convert(axeCoreResults, scanResultData);
@@ -189,16 +189,16 @@ describe(CombinedReportDataConverter, () => {
         const ruleId1 = 'rule-id-1';
         const ruleId2 = 'rule-id-2';
         const violations = addAxeResult(
-            new AxeResults(),
+            new AxeResultsList(),
             getAccumulatedResult(ruleId1, { urls: ['url-1', 'url-2', 'url-3'], nodeId: 'node-1' }),
             getAccumulatedResult(ruleId1, { urls: ['url-4'], nodeId: 'node-2' }),
             getAccumulatedResult(ruleId2, { urls: ['url-5'], nodeId: 'node-3' }),
         );
         const axeCoreResults = {
             violations,
-            passes: new AxeResults(),
-            inapplicable: new AxeResults(),
-            incomplete: new AxeResults(),
+            passes: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
         } as AxeCoreResults;
 
         const combinedReportData = combinedReportDataConverter.convert(axeCoreResults, scanResultData);

--- a/packages/axe-result-converter/src/combined-report-data-converter.ts
+++ b/packages/axe-result-converter/src/combined-report-data-converter.ts
@@ -13,7 +13,7 @@ import _ from 'lodash';
 import { injectable } from 'inversify';
 import { HashSet } from 'common';
 import { ScanResultData } from './scan-result-data';
-import { AxeNodeResult, AxeCoreResults, AxeResults } from './axe-result-types';
+import { AxeNodeResult, AxeCoreResults, AxeResultsList } from './axe-result-types';
 
 type SortableFailuresGroup = {
     failuresGroup: FailuresGroup;
@@ -78,7 +78,7 @@ export class CombinedReportDataConverter {
         return this.sortFailuresGroups(failuresGroup);
     }
 
-    private getFailureData(results: AxeResults): FailureData[] {
+    private getFailureData(results: AxeResultsList): FailureData[] {
         const failureData: FailureData[] = [];
         if (!results) {
             return failureData;
@@ -99,7 +99,7 @@ export class CombinedReportDataConverter {
         return failureData;
     }
 
-    private getAxeRuleData(results: AxeResults, excludeRuleIds: HashSet<string>): AxeRuleData[] {
+    private getAxeRuleData(results: AxeResultsList, excludeRuleIds: HashSet<string>): AxeRuleData[] {
         const axeRuleData = new HashSet<AxeRuleData>();
         if (results) {
             for (const result of results) {

--- a/packages/cli/src/converter/ai-data-converter.spec.ts
+++ b/packages/cli/src/converter/ai-data-converter.spec.ts
@@ -4,8 +4,8 @@ import 'reflect-metadata';
 
 import { IMock, Mock, It } from 'typemoq';
 import { CombinedReportDataConverter } from 'axe-result-converter';
-import { AICombinedReportDataConverter } from './ai-data-converter';
 import { CombinedReportParameters } from 'accessibility-insights-report';
+import { AICombinedReportDataConverter } from './ai-data-converter';
 
 let combinedReportDataConverterMock: IMock<CombinedReportDataConverter>;
 let testSubject: AICombinedReportDataConverter;
@@ -22,6 +22,7 @@ describe(AICombinedReportDataConverter, () => {
     });
 
     it('convert', () => {
+        /* eslint-disable @typescript-eslint/no-shadow */
         const CombinedReportParameters = {} as CombinedReportParameters;
         combinedReportDataConverterMock
             .setup((o) => o.convert(It.isAny(), It.isAny()))

--- a/packages/cli/src/converter/ai-data-converter.spec.ts
+++ b/packages/cli/src/converter/ai-data-converter.spec.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { IMock, Mock, It } from 'typemoq';
+import { CombinedReportDataConverter } from 'axe-result-converter';
+import { AICombinedReportDataConverter } from './ai-data-converter';
+import { CombinedReportParameters } from 'accessibility-insights-report';
+
+let combinedReportDataConverterMock: IMock<CombinedReportDataConverter>;
+let testSubject: AICombinedReportDataConverter;
+
+describe(AICombinedReportDataConverter, () => {
+    beforeEach(() => {
+        combinedReportDataConverterMock = Mock.ofType<CombinedReportDataConverter>();
+
+        testSubject = new AICombinedReportDataConverter(combinedReportDataConverterMock.object);
+    });
+
+    afterEach(() => {
+        combinedReportDataConverterMock.verifyAll();
+    });
+
+    it('convert', () => {
+        const CombinedReportParameters = {} as CombinedReportParameters;
+        combinedReportDataConverterMock
+            .setup((o) => o.convert(It.isAny(), It.isAny()))
+            .returns(() => CombinedReportParameters)
+            .verifiable();
+
+        testSubject.convertCrawlingResults(null, null);
+    });
+});

--- a/packages/cli/src/converter/ai-data-converter.ts
+++ b/packages/cli/src/converter/ai-data-converter.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inject, injectable } from 'inversify';
+import { CombinedReportDataConverter, ScanResultData, AxeCoreResults } from 'axe-result-converter';
+import { CombinedReportParameters } from 'accessibility-insights-report';
+
+@injectable()
+export class AICombinedReportDataConverter {
+    constructor(@inject(CombinedReportDataConverter) private readonly combinedReportDataConverter: CombinedReportDataConverter) {}
+
+    public convertCrawlingResults(combinedAxeResults: AxeCoreResults, scanResultData: ScanResultData): CombinedReportParameters {
+        return this.combinedReportDataConverter.convert(combinedAxeResults, scanResultData);
+    }
+}

--- a/packages/cli/src/crawler-parameters-builder.spec.ts
+++ b/packages/cli/src/crawler-parameters-builder.spec.ts
@@ -41,6 +41,8 @@ describe(CrawlerParametersBuilder, () => {
             silentMode: true,
             discoveryPatterns: ['regex'],
             continue: true,
+            chromePath: 'chrome path',
+            axeSourcePath: 'axe path',
         };
         fileSystemMock
             .setup((o) => o.existsSync(scanArguments.inputFile))
@@ -63,6 +65,8 @@ describe(CrawlerParametersBuilder, () => {
             silentMode: true,
             inputUrls: [...inputUrls, ...fileUrls],
             discoveryPatterns: ['regex'],
+            chromePath: 'chrome path',
+            axeSourcePath: 'axe path',
         };
         const actualCrawlOptions = crawlerParametersBuilder.build(scanArguments);
         expect(actualCrawlOptions).toEqual(expectedCrawlOptions);

--- a/packages/cli/src/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler-parameters-builder.ts
@@ -38,6 +38,8 @@ export class CrawlerParametersBuilder {
             silentMode: scanArguments.silentMode,
             inputUrls: [...inputUrlSet],
             discoveryPatterns: scanArguments.discoveryPatterns,
+            chromePath: scanArguments.chromePath,
+            axeSourcePath: scanArguments.axeSourcePath,
         };
     }
 

--- a/packages/cli/src/crawler/ai-crawler.spec.ts
+++ b/packages/cli/src/crawler/ai-crawler.spec.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 import { IMock, Mock, It } from 'typemoq';
 import { AICrawler } from './ai-crawler';
 import { DbScanResultReader, Crawler, CrawlerRunOptions, ScanMetadata, ScanResult } from 'accessibility-insights-crawler';
-import { AxeResultsReducer, AxeCoreResults, AxeResults } from 'axe-result-converter';
+import { AxeResultsReducer, AxeCoreResults, AxeResultsList } from 'axe-result-converter';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -49,10 +49,10 @@ describe(AICrawler, () => {
             browserResolution: '1920x1080',
         } as ScanMetadata;
         const combinedAxeResults = {
-            violations: new AxeResults(),
-            passes: new AxeResults(),
-            incomplete: new AxeResults(),
-            inapplicable: new AxeResults(),
+            violations: new AxeResultsList(),
+            passes: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
         } as AxeCoreResults;
         const scanResults = [
             {

--- a/packages/cli/src/crawler/ai-crawler.spec.ts
+++ b/packages/cli/src/crawler/ai-crawler.spec.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { IMock, Mock, It } from 'typemoq';
+import { AICrawler } from './ai-crawler';
+import { DbScanResultReader, Crawler, CrawlerRunOptions, ScanMetadata, ScanResult } from 'accessibility-insights-crawler';
+import { AxeResultsReducer, AxeCoreResults, AxeResults } from 'axe-result-converter';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe(AICrawler, () => {
+    const testUrl = 'http://localhost/';
+    const testOutput = './dir';
+    let crawler: AICrawler;
+    let dbScanResultReaderMock: IMock<DbScanResultReader>;
+    let axeResultsReducerMock: IMock<AxeResultsReducer>;
+    let crawlerOption: CrawlerRunOptions;
+    let crawlerMock: IMock<Crawler>;
+
+    beforeEach(() => {
+        crawlerOption = {
+            baseUrl: testUrl,
+            localOutputDir: testOutput,
+            inputUrls: undefined,
+            discoveryPatterns: undefined,
+            simulate: undefined,
+            selectors: undefined,
+            maxRequestsPerCrawl: undefined,
+            restartCrawl: undefined,
+            snapshot: undefined,
+            memoryMBytes: undefined,
+            silentMode: undefined,
+        };
+
+        dbScanResultReaderMock = Mock.ofType<DbScanResultReader>();
+        axeResultsReducerMock = Mock.ofType<AxeResultsReducer>();
+        crawlerMock = Mock.ofType<Crawler>();
+
+        crawler = new AICrawler(crawlerMock.object, dbScanResultReaderMock.object, axeResultsReducerMock.object);
+    });
+
+    it('crawl', async () => {
+        const baseUrl = 'baseUrl-1';
+        const scanMetadata = {
+            baseUrl,
+            basePageTitle: 'basePageTitle',
+            userAgent: 'userAgent',
+            browserResolution: '1920x1080',
+        } as ScanMetadata;
+        const combinedAxeResults = {
+            violations: new AxeResults(),
+            passes: new AxeResults(),
+            incomplete: new AxeResults(),
+            inapplicable: new AxeResults(),
+        } as AxeCoreResults;
+        const scanResults = [
+            {
+                id: 'id-1',
+                scanState: 'pass',
+                axeResults: { url: 'url-1' },
+            },
+            {
+                id: 'id-2',
+                scanState: 'fail',
+                axeResults: { url: 'url-2' },
+            },
+            {
+                id: 'id-3',
+                scanState: 'pass',
+                axeResults: { url: 'url-3' },
+            },
+            {
+                id: 'id-4',
+                scanState: 'runError',
+            },
+        ] as ScanResult[];
+
+        crawlerMock
+            .setup((o) => o.crawl(crawlerOption))
+            .returns(async () => Promise.resolve())
+            .verifiable();
+
+        for (let index = 0; index <= scanResults.length; index++) {
+            const next = index === scanResults.length ? { done: true, value: undefined } : { done: false, value: scanResults[index] };
+            dbScanResultReaderMock
+                .setup(async (o) => o.next())
+                .returns(() => Promise.resolve(next))
+                .verifiable();
+            if (next.done === false && scanResults[index].axeResults !== undefined) {
+                axeResultsReducerMock
+                    .setup((o) => o.reduce(It.isValue(combinedAxeResults), It.isValue(scanResults[index].axeResults)))
+                    .verifiable();
+            }
+        }
+
+        dbScanResultReaderMock
+            .setup(async (o) => o.getScanMetadata(baseUrl))
+            .returns(() => Promise.resolve(scanMetadata))
+            .verifiable();
+        dbScanResultReaderMock.setup((o) => o[Symbol.asyncIterator]).returns(() => () => dbScanResultReaderMock.object);
+
+        await crawler.crawl(crawlerOption);
+
+        crawlerMock.verifyAll();
+        axeResultsReducerMock.verifyAll();
+    });
+
+    it('crawling fail', async () => {
+        crawlerMock
+            .setup((o) => o.crawl(crawlerOption))
+            .returns(async () => Promise.reject())
+            .verifiable();
+
+        await crawler.crawl(crawlerOption);
+
+        crawlerMock.verifyAll();
+    });
+});

--- a/packages/cli/src/crawler/ai-crawler.spec.ts
+++ b/packages/cli/src/crawler/ai-crawler.spec.ts
@@ -3,9 +3,9 @@
 import 'reflect-metadata';
 
 import { IMock, Mock, It } from 'typemoq';
-import { AICrawler } from './ai-crawler';
 import { DbScanResultReader, Crawler, CrawlerRunOptions, ScanMetadata, ScanResult } from 'accessibility-insights-crawler';
 import { AxeResultsReducer, AxeCoreResults, AxeResultsList } from 'axe-result-converter';
+import { AICrawler } from './ai-crawler';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/packages/cli/src/crawler/ai-crawler.ts
+++ b/packages/cli/src/crawler/ai-crawler.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inject, injectable } from 'inversify';
+import { System } from 'common';
+import { DbScanResultReader, CrawlerRunOptions, Crawler, ScanMetadata } from 'accessibility-insights-crawler';
+import { AxeResultsReducer, UrlCount, AxeCoreResults, AxeResults } from 'axe-result-converter';
+import { ScanResultReader } from '../scan-result-providers/scan-result-reader';
+
+export interface CombinedScanResult {
+    urlCount?: UrlCount;
+    combinedAxeResults?: AxeCoreResults;
+    scanMetadata?: ScanMetadata;
+    error?: string;
+}
+
+@injectable()
+export class AICrawler {
+    constructor(
+        @inject(Crawler) private readonly crawler: Crawler,
+        @inject(DbScanResultReader) private readonly scanResultReader: ScanResultReader,
+        @inject(AxeResultsReducer) private readonly axeResultsReducer: AxeResultsReducer,
+    ) {}
+
+    public async crawl(crawlerRunOptions: CrawlerRunOptions): Promise<CombinedScanResult> {
+        try {
+            await this.crawler.crawl(crawlerRunOptions);
+            let combinedAxeResult = await this.combineAxeResults();
+            combinedAxeResult.scanMetadata = await this.scanResultReader.getScanMetadata(crawlerRunOptions.baseUrl);
+
+            return combinedAxeResult;
+        } catch (error) {
+            console.log(error, `An error occurred while scanning/crawling website page ${crawlerRunOptions.baseUrl}`);
+
+            return { error: System.serializeError(error) };
+        } finally {
+            console.log(`Accessibility scanning/crawling of URL ${crawlerRunOptions.baseUrl} completed`);
+        }
+    }
+
+    private async combineAxeResults(): Promise<CombinedScanResult> {
+        const combinedAxeResults = {
+            violations: new AxeResults(),
+            passes: new AxeResults(),
+            incomplete: new AxeResults(),
+            inapplicable: new AxeResults(),
+        } as AxeCoreResults;
+        const urlCount = {
+            total: 0,
+            failed: 0,
+            passed: 0,
+        };
+
+        for await (const scanResult of this.scanResultReader) {
+            urlCount.total++;
+            if (scanResult.scanState === 'pass') {
+                urlCount.passed++;
+            } else if (scanResult.scanState === 'fail') {
+                urlCount.failed++;
+            }
+
+            if (scanResult.axeResults) {
+                this.axeResultsReducer.reduce(combinedAxeResults, scanResult.axeResults);
+            }
+        }
+
+        return {
+            urlCount,
+            combinedAxeResults,
+        };
+    }
+}

--- a/packages/cli/src/crawler/ai-crawler.ts
+++ b/packages/cli/src/crawler/ai-crawler.ts
@@ -3,7 +3,7 @@
 import { inject, injectable } from 'inversify';
 import { System } from 'common';
 import { DbScanResultReader, CrawlerRunOptions, Crawler, ScanMetadata } from 'accessibility-insights-crawler';
-import { AxeResultsReducer, UrlCount, AxeCoreResults, AxeResults } from 'axe-result-converter';
+import { AxeResultsReducer, UrlCount, AxeCoreResults, AxeResultsList } from 'axe-result-converter';
 import { ScanResultReader } from '../scan-result-providers/scan-result-reader';
 
 export interface CombinedScanResult {
@@ -39,10 +39,10 @@ export class AICrawler {
 
     private async combineAxeResults(): Promise<CombinedScanResult> {
         const combinedAxeResults = {
-            violations: new AxeResults(),
-            passes: new AxeResults(),
-            incomplete: new AxeResults(),
-            inapplicable: new AxeResults(),
+            violations: new AxeResultsList(),
+            passes: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
         } as AxeCoreResults;
         const urlCount = {
             total: 0,

--- a/packages/cli/src/crawler/ai-crawler.ts
+++ b/packages/cli/src/crawler/ai-crawler.ts
@@ -24,7 +24,7 @@ export class AICrawler {
     public async crawl(crawlerRunOptions: CrawlerRunOptions): Promise<CombinedScanResult> {
         try {
             await this.crawler.crawl(crawlerRunOptions);
-            let combinedAxeResult = await this.combineAxeResults();
+            const combinedAxeResult = await this.combineAxeResults();
             combinedAxeResult.scanMetadata = await this.scanResultReader.getScanMetadata(crawlerRunOptions.baseUrl);
 
             return combinedAxeResult;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,3 +3,4 @@
 export { AIScanner } from './scanner/ai-scanner';
 export { AICrawler } from './crawler/ai-crawler';
 export { setupCliContainer } from './setup-cli-container';
+export { AICombinedReportDataConverter } from './converter/ai-data-converter';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export { AIScanner } from './scanner/ai-scanner';
+export { AICrawler } from './crawler/ai-crawler';
+export { setupCliContainer } from './setup-cli-container';

--- a/packages/cli/src/report/consolidated-report-generator.spec.ts
+++ b/packages/cli/src/report/consolidated-report-generator.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { IMock, Mock } from 'typemoq';
 import { ScanResult, ScanMetadata } from 'accessibility-insights-crawler';
-import { CombinedReportDataConverter, AxeCoreResults, ScanResultData, UrlCount, AxeResults } from 'axe-result-converter';
+import { CombinedReportDataConverter, AxeCoreResults, ScanResultData, UrlCount, AxeResultsList } from 'axe-result-converter';
 import { ReporterFactory, CombinedReportParameters, Reporter, Report } from 'accessibility-insights-report';
 import { AxeInfo } from '../axe/axe-info';
 import { serviceName } from '../service-name';
@@ -66,10 +66,10 @@ describe(ConsolidatedReportGenerator, () => {
             browserResolution: '1920x1080',
         } as ScanMetadata;
         const combinedAxeResults = {
-            violations: new AxeResults(),
-            passes: new AxeResults(),
-            incomplete: new AxeResults(),
-            inapplicable: new AxeResults(),
+            violations: new AxeResultsList(),
+            passes: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
         } as AxeCoreResults;
         const scanResults = [
             {

--- a/packages/cli/src/report/consolidated-report-generator.spec.ts
+++ b/packages/cli/src/report/consolidated-report-generator.spec.ts
@@ -8,8 +8,8 @@ import { CombinedReportDataConverter, AxeCoreResults, ScanResultData, UrlCount, 
 import { ReporterFactory, CombinedReportParameters, Reporter, Report } from 'accessibility-insights-report';
 import { AxeInfo } from '../axe/axe-info';
 import { serviceName } from '../service-name';
-import { ConsolidatedReportGenerator } from './consolidated-report-generator';
 import { CombinedScanResult } from '../crawler/ai-crawler';
+import { ConsolidatedReportGenerator } from './consolidated-report-generator';
 
 const axeCoreVersion = 'axe core version';
 const htmlReportString = 'html report';

--- a/packages/cli/src/report/consolidated-report-generator.spec.ts
+++ b/packages/cli/src/report/consolidated-report-generator.spec.ts
@@ -2,21 +2,20 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { IMock, Mock, It } from 'typemoq';
-import { DbScanResultReader, ScanResult, ScanMetadata } from 'accessibility-insights-crawler';
-import { AxeResultsReducer, CombinedReportDataConverter, AxeCoreResults, ScanResultData, UrlCount, AxeResults } from 'axe-result-converter';
+import { IMock, Mock } from 'typemoq';
+import { ScanResult, ScanMetadata } from 'accessibility-insights-crawler';
+import { CombinedReportDataConverter, AxeCoreResults, ScanResultData, UrlCount, AxeResults } from 'axe-result-converter';
 import { ReporterFactory, CombinedReportParameters, Reporter, Report } from 'accessibility-insights-report';
 import { AxeInfo } from '../axe/axe-info';
 import { serviceName } from '../service-name';
 import { ConsolidatedReportGenerator } from './consolidated-report-generator';
+import { CombinedScanResult } from '../crawler/ai-crawler';
 
 const axeCoreVersion = 'axe core version';
 const htmlReportString = 'html report';
 const scanStarted = new Date(1000);
 const scanEnded = new Date(60000);
 
-let dbScanResultReaderMock: IMock<DbScanResultReader>;
-let axeResultsReducerMock: IMock<AxeResultsReducer>;
 let combinedReportDataConverterMock: IMock<CombinedReportDataConverter>;
 let reporterMock: IMock<Reporter>;
 let axeInfoMock: IMock<AxeInfo>;
@@ -26,8 +25,6 @@ let combinedReportData: CombinedReportParameters;
 
 describe(ConsolidatedReportGenerator, () => {
     beforeEach(() => {
-        dbScanResultReaderMock = Mock.ofType<DbScanResultReader>();
-        axeResultsReducerMock = Mock.ofType<AxeResultsReducer>();
         combinedReportDataConverterMock = Mock.ofType<CombinedReportDataConverter>();
         axeInfoMock = Mock.ofType<AxeInfo>();
         reporterMock = Mock.ofType<Reporter>();
@@ -48,8 +45,6 @@ describe(ConsolidatedReportGenerator, () => {
             .verifiable();
 
         consolidatedReportGenerator = new ConsolidatedReportGenerator(
-            dbScanResultReaderMock.object,
-            axeResultsReducerMock.object,
             combinedReportDataConverterMock.object,
             reporterFactoryMock,
             axeInfoMock.object,
@@ -57,7 +52,6 @@ describe(ConsolidatedReportGenerator, () => {
     });
 
     afterEach(() => {
-        axeResultsReducerMock.verifyAll();
         combinedReportDataConverterMock.verifyAll();
         reporterMock.verifyAll();
         axeInfoMock.verifyAll();
@@ -111,30 +105,18 @@ describe(ConsolidatedReportGenerator, () => {
             scanEnded,
         };
 
-        for (let index = 0; index <= scanResults.length; index++) {
-            const next = index === scanResults.length ? { done: true, value: undefined } : { done: false, value: scanResults[index] };
-            dbScanResultReaderMock
-                .setup(async (o) => o.next())
-                .returns(() => Promise.resolve(next))
-                .verifiable();
-            if (next.done === false && scanResults[index].axeResults !== undefined) {
-                axeResultsReducerMock
-                    .setup((o) => o.reduce(It.isValue(combinedAxeResults), It.isValue(scanResults[index].axeResults)))
-                    .verifiable();
-            }
-        }
-
-        dbScanResultReaderMock
-            .setup(async (o) => o.getScanMetadata(baseUrl))
-            .returns(() => Promise.resolve(scanMetadata))
-            .verifiable();
-        dbScanResultReaderMock.setup((o) => o[Symbol.asyncIterator]).returns(() => () => dbScanResultReaderMock.object);
         combinedReportDataConverterMock
             .setup((o) => o.convert(combinedAxeResults, scanResultData))
             .returns(() => combinedReportData)
             .verifiable();
 
-        await consolidatedReportGenerator.generateReport(baseUrl, scanStarted, scanEnded);
+        const combinedScanResult = {
+            urlCount: urlCount,
+            scanMetadata: scanMetadata,
+            combinedAxeResults: combinedAxeResults,
+        } as CombinedScanResult;
+
+        await consolidatedReportGenerator.generateReport(combinedScanResult, scanStarted, scanEnded);
     });
 });
 

--- a/packages/cli/src/report/consolidated-report-generator.ts
+++ b/packages/cli/src/report/consolidated-report-generator.ts
@@ -1,78 +1,37 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
-import { AxeResultsReducer, CombinedReportDataConverter, AxeCoreResults, ScanResultData, UrlCount, AxeResults } from 'axe-result-converter';
+import { CombinedReportDataConverter, ScanResultData } from 'axe-result-converter';
 import { ReporterFactory } from 'accessibility-insights-report';
-import { DbScanResultReader } from 'accessibility-insights-crawler';
 import { AxeInfo } from '../axe/axe-info';
 import { iocTypes } from '../ioc-types';
-import { ScanResultReader } from '../scan-result-providers/scan-result-reader';
 import { serviceName } from '../service-name';
+import {CombinedScanResult} from '../crawler/ai-crawler';
 
-interface CombinedScanResult {
-    urlCount: UrlCount;
-    combinedAxeResults: AxeCoreResults;
-}
 
 @injectable()
 export class ConsolidatedReportGenerator {
     constructor(
-        @inject(DbScanResultReader) private readonly scanResultReader: ScanResultReader,
-        @inject(AxeResultsReducer) private readonly axeResultsReducer: AxeResultsReducer,
         @inject(CombinedReportDataConverter) private readonly combinedReportDataConverter: CombinedReportDataConverter,
         @inject(iocTypes.ReporterFactory) private readonly reporterFactoryFunc: ReporterFactory,
         @inject(AxeInfo) private readonly axeInfo: AxeInfo,
     ) {}
 
-    public async generateReport(baseUrl: string, scanStarted: Date, scanEnded: Date): Promise<string> {
-        const combinedAxeResults = await this.combineAxeResults();
-        const scanMetadata = await this.scanResultReader.getScanMetadata(baseUrl);
+    public async generateReport(combinedScanResult: CombinedScanResult, scanStarted: Date, scanEnded: Date): Promise<string> {
         const scanResultData: ScanResultData = {
-            baseUrl: scanMetadata.baseUrl ?? 'n/a',
-            basePageTitle: scanMetadata.basePageTitle,
+            baseUrl: combinedScanResult.scanMetadata.baseUrl ?? 'n/a',
+            basePageTitle: combinedScanResult.scanMetadata.basePageTitle,
             scanEngineName: serviceName,
             axeCoreVersion: this.axeInfo.version,
-            browserUserAgent: scanMetadata.userAgent,
-            browserResolution: scanMetadata.browserResolution,
-            urlCount: combinedAxeResults.urlCount,
+            browserUserAgent: combinedScanResult.scanMetadata.userAgent,
+            browserResolution: combinedScanResult.scanMetadata.browserResolution,
+            urlCount: combinedScanResult.urlCount,
             scanStarted,
             scanEnded,
         };
-        const combinedReportData = this.combinedReportDataConverter.convert(combinedAxeResults.combinedAxeResults, scanResultData);
+        const combinedReportData = this.combinedReportDataConverter.convert(combinedScanResult.combinedAxeResults, scanResultData);
         const reporter = this.reporterFactoryFunc();
 
         return reporter.fromCombinedResults(combinedReportData).asHTML();
-    }
-
-    private async combineAxeResults(): Promise<CombinedScanResult> {
-        const combinedAxeResults = {
-            violations: new AxeResults(),
-            passes: new AxeResults(),
-            incomplete: new AxeResults(),
-            inapplicable: new AxeResults(),
-        } as AxeCoreResults;
-        const urlCount = {
-            total: 0,
-            failed: 0,
-            passed: 0,
-        };
-
-        for await (const scanResult of this.scanResultReader) {
-            urlCount.total++;
-            if (scanResult.scanState === 'pass') {
-                urlCount.passed++;
-            } else if (scanResult.scanState === 'fail') {
-                urlCount.failed++;
-            }
-
-            if (scanResult.axeResults) {
-                this.axeResultsReducer.reduce(combinedAxeResults, scanResult.axeResults);
-            }
-        }
-
-        return {
-            urlCount,
-            combinedAxeResults,
-        };
     }
 }

--- a/packages/cli/src/report/consolidated-report-generator.ts
+++ b/packages/cli/src/report/consolidated-report-generator.ts
@@ -6,8 +6,7 @@ import { ReporterFactory } from 'accessibility-insights-report';
 import { AxeInfo } from '../axe/axe-info';
 import { iocTypes } from '../ioc-types';
 import { serviceName } from '../service-name';
-import {CombinedScanResult} from '../crawler/ai-crawler';
-
+import { CombinedScanResult } from '../crawler/ai-crawler';
 
 @injectable()
 export class ConsolidatedReportGenerator {

--- a/packages/cli/src/runner/crawler-command-runner.spec.ts
+++ b/packages/cli/src/runner/crawler-command-runner.spec.ts
@@ -9,8 +9,8 @@ import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ScanArguments } from '../scan-arguments';
 import { ConsolidatedReportGenerator } from '../report/consolidated-report-generator';
 import { CrawlerParametersBuilder } from '../crawler-parameters-builder';
-import { CrawlerCommandRunner } from './crawler-command-runner';
 import { AICrawler } from '../crawler/ai-crawler';
+import { CrawlerCommandRunner } from './crawler-command-runner';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 

--- a/packages/cli/src/runner/crawler-command-runner.spec.ts
+++ b/packages/cli/src/runner/crawler-command-runner.spec.ts
@@ -3,13 +3,14 @@
 import 'reflect-metadata';
 
 import * as fs from 'fs';
-import { Crawler, CrawlerRunOptions } from 'accessibility-insights-crawler';
+import { CrawlerRunOptions } from 'accessibility-insights-crawler';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ScanArguments } from '../scan-arguments';
 import { ConsolidatedReportGenerator } from '../report/consolidated-report-generator';
 import { CrawlerParametersBuilder } from '../crawler-parameters-builder';
 import { CrawlerCommandRunner } from './crawler-command-runner';
+import { AICrawler } from '../crawler/ai-crawler';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
@@ -18,7 +19,7 @@ describe('CrawlerCommandRunner', () => {
 
     let scanArguments: ScanArguments;
     let crawlerOption: CrawlerRunOptions;
-    let crawlerMock: IMock<Crawler>;
+    let crawlerMock: IMock<AICrawler>;
     let crawlerParametersBuilderMock: IMock<CrawlerParametersBuilder>;
     let reportDiskWriterMock: IMock<ReportDiskWriter>;
     let consolidatedReportGeneratorMock: IMock<ConsolidatedReportGenerator>;
@@ -41,7 +42,7 @@ describe('CrawlerCommandRunner', () => {
             silentMode: undefined,
         };
 
-        crawlerMock = Mock.ofType<Crawler>();
+        crawlerMock = Mock.ofType<AICrawler>();
         crawlerParametersBuilderMock = Mock.ofType<CrawlerParametersBuilder>();
         reportDiskWriterMock = Mock.ofType<ReportDiskWriter>();
         consolidatedReportGeneratorMock = Mock.ofType<ConsolidatedReportGenerator>();
@@ -57,7 +58,7 @@ describe('CrawlerCommandRunner', () => {
             .verifiable();
         crawlerMock
             .setup((o) => o.crawl(crawlerOption))
-            .returns(async () => Promise.resolve())
+            .returns(async () => Promise.resolve({}))
             .verifiable();
 
         testSubject = new CrawlerCommandRunner(
@@ -102,7 +103,7 @@ describe('CrawlerCommandRunner', () => {
         crawlerMock.reset();
         crawlerMock
             .setup((o) => o.crawl(crawlerOption))
-            .returns(async () => Promise.resolve())
+            .returns(async () => Promise.resolve({}))
             .verifiable();
         await testSubject.runCommand(scanArguments);
     });
@@ -121,7 +122,7 @@ describe('CrawlerCommandRunner', () => {
 
     it('run crawler', async () => {
         consolidatedReportGeneratorMock
-            .setup(async (o) => o.generateReport(testUrl, It.isAny(), It.isAny()))
+            .setup(async (o) => o.generateReport({}, It.isAny(), It.isAny()))
             .returns(() => Promise.resolve('report'))
             .verifiable();
         reportDiskWriterMock

--- a/packages/cli/src/runner/crawler-command-runner.ts
+++ b/packages/cli/src/runner/crawler-command-runner.ts
@@ -6,8 +6,8 @@ import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ScanArguments } from '../scan-arguments';
 import { ConsolidatedReportGenerator } from '../report/consolidated-report-generator';
 import { CrawlerParametersBuilder } from '../crawler-parameters-builder';
-import { CommandRunner } from './command-runner';
 import { AICrawler } from '../crawler/ai-crawler';
+import { CommandRunner } from './command-runner';
 
 @injectable()
 export class CrawlerCommandRunner implements CommandRunner {

--- a/packages/cli/src/scan-arguments.ts
+++ b/packages/cli/src/scan-arguments.ts
@@ -16,4 +16,6 @@ export interface ScanArguments {
     discoveryPatterns?: string[];
     // eslint-disable-next-line
     continue?: boolean;
+    chromePath?: string;
+    axeSourcePath?:string;
 }

--- a/packages/cli/src/scan-arguments.ts
+++ b/packages/cli/src/scan-arguments.ts
@@ -17,5 +17,5 @@ export interface ScanArguments {
     // eslint-disable-next-line
     continue?: boolean;
     chromePath?: string;
-    axeSourcePath?:string;
+    axeSourcePath?: string;
 }

--- a/packages/cli/src/setup-cli-container.ts
+++ b/packages/cli/src/setup-cli-container.ts
@@ -3,8 +3,9 @@
 import { Crawler, setupCrawlerContainer } from 'accessibility-insights-crawler';
 import * as inversify from 'inversify';
 
-export function setupCliContainer(): inversify.Container {
-    const container = new inversify.Container({ autoBindInjectable: true });
+export function setupCliContainer(
+    container: inversify.Container = new inversify.Container({ autoBindInjectable: true }),
+): inversify.Container {
     setupCrawlerContainer(container);
     container.bind(Crawler).toConstantValue(new Crawler(container));
 

--- a/packages/common/src/ciphers/hash-generator.ts
+++ b/packages/common/src/ciphers/hash-generator.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 import fnv1a from '@sindresorhus/fnv1a';
 import { injectable } from 'inversify';
-import SHA from 'sha.js';
 import { JumpConsistentHash } from './jump-consistent-hash';
+
+const shaJS = require('sha.js');
 
 @injectable()
 export class HashGenerator {
-    public constructor(private readonly sha: typeof SHA = SHA) {}
+    public constructor(private readonly shaObj = shaJS) {}
 
     public getWebsiteScanResultDocumentId(baseUrl: string, scanGroupId: string): string {
         // Preserve parameters order below for the hash generation compatibility
@@ -31,6 +32,6 @@ export class HashGenerator {
     public generateBase64Hash(...values: string[]): string {
         const hashSeed: string = values.join('|').toLowerCase();
 
-        return this.sha('sha256').update(hashSeed).digest('hex');
+        return this.shaObj('sha256').update(hashSeed).digest('hex');
     }
 }

--- a/packages/common/src/ciphers/hash-generator.ts
+++ b/packages/common/src/ciphers/hash-generator.ts
@@ -4,6 +4,8 @@ import fnv1a from '@sindresorhus/fnv1a';
 import { injectable } from 'inversify';
 import { JumpConsistentHash } from './jump-consistent-hash';
 
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-var-requires */
 const shaJS = require('sha.js');
 
 @injectable()

--- a/packages/crawler/src/apify/apify-settings.spec.ts
+++ b/packages/crawler/src/apify/apify-settings.spec.ts
@@ -7,6 +7,7 @@ describe('Apify settings', () => {
     const defaultEnv: ApifySettings = {
         APIFY_HEADLESS: '',
         APIFY_LOCAL_STORAGE_DIR: '',
+        APIFY_CHROME_EXECUTABLE_PATH: '',
     };
 
     beforeEach(() => {

--- a/packages/crawler/src/apify/apify-settings.ts
+++ b/packages/crawler/src/apify/apify-settings.ts
@@ -5,6 +5,7 @@ export interface ApifySettings {
     APIFY_HEADLESS?: string;
     APIFY_LOCAL_STORAGE_DIR?: string;
     APIFY_MEMORY_MBYTES?: string;
+    APIFY_CHROME_EXECUTABLE_PATH?: string;
 }
 
 export interface ApifySettingsHandler {

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -130,6 +130,18 @@ describe(CrawlerConfiguration, () => {
         });
     });
 
+    describe('getAxeSourcePath', () => {
+
+        it('explicitly set axeSourcePath state', () => {
+            crawlerRunOptionsMock
+                .setup((o) => o.axeSourcePath)
+                .returns(() => 'axeSourcePath')
+                .verifiable();
+
+            expect(crawlerConfiguration.axeSourcePath()).toEqual('axeSourcePath');
+        });
+    });
+
     describe('getMaxRequestsPerCrawl', () => {
         it('with no value provided', () => {
             crawlerRunOptionsMock
@@ -169,6 +181,7 @@ describe(CrawlerConfiguration, () => {
 
         const prevApifyHeadless = 'prev apify headless value';
         const prevApifyStorageDir = 'prev apify storage dir';
+        const prevChromePath = 'chrome path';
 
         const defaultApifyHeadless = '1';
         const defaultApifyStorageDir = './ai_scan_cli_output';
@@ -177,6 +190,7 @@ describe(CrawlerConfiguration, () => {
             existingSettings = {
                 APIFY_HEADLESS: prevApifyHeadless,
                 APIFY_LOCAL_STORAGE_DIR: prevApifyStorageDir,
+                APIFY_CHROME_EXECUTABLE_PATH: prevChromePath,
             };
             apifySettingsHandlerMock.setup((ash) => ash.getApifySettings()).returns(() => existingSettings);
         });
@@ -191,7 +205,7 @@ describe(CrawlerConfiguration, () => {
             crawlerConfiguration.setDefaultApifySettings();
         });
 
-        it('setDefaultApifySettings sets APIFY_LOCAL_STORAGE_DIR and APIFY_HEADLESS', () => {
+        it('setDefaultApifySettings sets APIFY_LOCAL_STORAGE_DIR, APIFY_HEADLESS and APIFY_CHROME_EXECUTABLE_PATH', () => {
             const expectedSettings = {
                 APIFY_HEADLESS: defaultApifyHeadless,
                 APIFY_LOCAL_STORAGE_DIR: defaultApifyStorageDir,
@@ -211,6 +225,16 @@ describe(CrawlerConfiguration, () => {
             apifySettingsHandlerMock.setup((ash) => ash.setApifySettings(expectedSettings)).verifiable();
 
             crawlerConfiguration.setLocalOutputDir(localOutputDir);
+        });
+
+        it('setChromePath', () => {
+            const chromePath = 'new chrome path';
+            const expectedSettings = {
+                APIFY_CHROME_EXECUTABLE_PATH: chromePath,
+            };
+            apifySettingsHandlerMock.setup((ash) => ash.setApifySettings(expectedSettings)).verifiable();
+
+            crawlerConfiguration.setChromePath(chromePath);
         });
 
         it('setSilentMode', () => {

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -131,7 +131,6 @@ describe(CrawlerConfiguration, () => {
     });
 
     describe('getAxeSourcePath', () => {
-
         it('explicitly set axeSourcePath state', () => {
             crawlerRunOptionsMock
                 .setup((o) => o.axeSourcePath)

--- a/packages/crawler/src/crawler/crawler-configuration.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.ts
@@ -38,6 +38,14 @@ export class CrawlerConfiguration {
         return this.crawlerRunOptions.crawl ?? false;
     }
 
+    public axeSourcePath(): string {
+        return this.crawlerRunOptions.axeSourcePath;
+    }
+
+    public chromePath(): string {
+        return this.crawlerRunOptions.chromePath;
+    }
+
     public setDefaultApifySettings(): void {
         this.settingsHandler.setApifySettings(this.getDefaultApifySettings());
     }
@@ -52,6 +60,10 @@ export class CrawlerConfiguration {
 
     public setSilentMode(silentMode: boolean): void {
         this.settingsHandler.setApifySettings({ APIFY_HEADLESS: silentMode === undefined ? undefined : silentMode ? '1' : '0' });
+    }
+
+    public setChromePath(chromePath: string): void {
+        this.settingsHandler.setApifySettings({ APIFY_CHROME_EXECUTABLE_PATH: chromePath });
     }
 
     private getMaxRequestsPerCrawl(maxRequestsPerCrawl: number): number {

--- a/packages/crawler/src/crawler/crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/crawler-engine.spec.ts
@@ -75,10 +75,6 @@ describe(CrawlerEngine, () => {
         };
 
         puppeteerCrawlerMock.setup((o) => o.run()).verifiable();
-        crawlerFactoryMock
-            .setup((o) => o.createPuppeteerCrawler(baseCrawlerOptions))
-            .returns(() => puppeteerCrawlerMock.object)
-            .verifiable();
 
         requestQueueProvider = () => Promise.resolve(requestQueueStub);
         pageProcessorFactoryStub = jest.fn().mockImplementation(() => pageProcessorStub as PageProcessorBase);
@@ -91,6 +87,24 @@ describe(CrawlerEngine, () => {
     });
 
     it('Run crawler with settings validation', async () => {
+        crawlerFactoryMock
+            .setup((o) => o.createPuppeteerCrawler(baseCrawlerOptions))
+            .returns(() => puppeteerCrawlerMock.object)
+            .verifiable();
+
+        await crawlerEngine.start(crawlerRunOptions);
+    });
+
+    it('Run crawler while chrome path is set', async () => {
+        crawlerRunOptions.chromePath = 'chrome path';
+        crawlerConfigurationMock.setup((o) => o.setChromePath(crawlerRunOptions.chromePath)).verifiable();
+
+        baseCrawlerOptions.launchPuppeteerOptions.useChrome = true;
+        crawlerFactoryMock
+            .setup((o) => o.createPuppeteerCrawler(baseCrawlerOptions))
+            .returns(() => puppeteerCrawlerMock.object)
+            .verifiable();
+
         await crawlerEngine.start(crawlerRunOptions);
     });
 

--- a/packages/crawler/src/crawler/crawler-engine.ts
+++ b/packages/crawler/src/crawler/crawler-engine.ts
@@ -8,6 +8,7 @@ import { CrawlerRunOptions } from '../types/crawler-run-options';
 import { ApifyRequestQueueProvider, iocTypes, PageProcessorFactory } from '../types/ioc-types';
 import { CrawlerConfiguration } from './crawler-configuration';
 import { CrawlerFactory } from './crawler-factory';
+import { isEmpty } from 'lodash';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
@@ -44,6 +45,14 @@ export class CrawlerEngine {
                 },
             } as Apify.LaunchPuppeteerOptions,
         };
+
+        if (!isEmpty(crawlerRunOptions.chromePath)) {
+            puppeteerCrawlerOptions.launchPuppeteerOptions = {
+                ...puppeteerCrawlerOptions.launchPuppeteerOptions,
+                useChrome: true,
+            } as Apify.LaunchPuppeteerOptions;
+            this.crawlerConfiguration.setChromePath(crawlerRunOptions.chromePath);
+        }
 
         if (crawlerRunOptions.debug === true) {
             this.crawlerConfiguration.setSilentMode(false);

--- a/packages/crawler/src/crawler/crawler-engine.ts
+++ b/packages/crawler/src/crawler/crawler-engine.ts
@@ -4,11 +4,11 @@ import Apify from 'apify';
 import { inject, injectable } from 'inversify';
 // @ts-ignore
 import * as cheerio from 'cheerio';
+import { isEmpty } from 'lodash';
 import { CrawlerRunOptions } from '../types/crawler-run-options';
 import { ApifyRequestQueueProvider, iocTypes, PageProcessorFactory } from '../types/ioc-types';
 import { CrawlerConfiguration } from './crawler-configuration';
 import { CrawlerFactory } from './crawler-factory';
-import { isEmpty } from 'lodash';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 

--- a/packages/crawler/src/level-storage/storage-documents.ts
+++ b/packages/crawler/src/level-storage/storage-documents.ts
@@ -20,6 +20,7 @@ export interface ScanMetadata {
     baseUrl: string;
     basePageTitle?: string;
     userAgent?: string;
+    browserSpec?: string;
     browserResolution?: string;
 }
 

--- a/packages/crawler/src/page-operations/accessibility-scan-operation.spec.ts
+++ b/packages/crawler/src/page-operations/accessibility-scan-operation.spec.ts
@@ -76,7 +76,7 @@ describe(AccessibilityScanOperation, () => {
             .returns(async () => {})
             .verifiable(Times.once());
         scannerMock
-            .setup((s) => s.scan(It.isAny()))
+            .setup((s) => s.scan(It.isAny(), It.isAny()))
             .returns(async () => axeResult)
             .verifiable(Times.once());
         reportGeneratorMock

--- a/packages/crawler/src/page-operations/accessibility-scan-operation.ts
+++ b/packages/crawler/src/page-operations/accessibility-scan-operation.ts
@@ -16,8 +16,8 @@ export class AccessibilityScanOperation {
         @inject(LocalBlobStore) protected readonly blobStore: BlobStore,
     ) {}
 
-    public async run(page: Page, id: string): Promise<AxeResults> {
-        const axeResults = await this.scanner.scan(page);
+    public async run(page: Page, id: string, axeSourcePath?: string): Promise<AxeResults> {
+        const axeResults = await this.scanner.scan(page, axeSourcePath);
         const report = this.reportGenerator.generateReport(axeResults, page.url(), await page.title());
 
         await this.blobStore.setValue(`${id}.axe`, axeResults);

--- a/packages/crawler/src/page-processors/classic-page-processor.spec.ts
+++ b/packages/crawler/src/page-processors/classic-page-processor.spec.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 import Apify from 'apify';
 import { Page } from 'puppeteer';
 import { PageNavigator } from 'scanner-global-library';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, It } from 'typemoq';
 import { AxeResults } from 'axe-core';
 import { CrawlerConfiguration } from '../crawler/crawler-configuration';
 import { DataBase } from '../level-storage/data-base';
@@ -98,7 +98,7 @@ describe(ClassicPageProcessor, () => {
     it('pageProcessor', async () => {
         setupEnqueueLinks(pageStub);
         accessibilityScanOpMock
-            .setup((aso) => aso.run(pageStub, testId))
+            .setup((aso) => aso.run(pageStub, testId, It.isAny()))
             .returns(async () => Promise.resolve(axeResults))
             .verifiable();
         const expectedScanData = {

--- a/packages/crawler/src/page-processors/classic-page-processor.ts
+++ b/packages/crawler/src/page-processors/classic-page-processor.ts
@@ -11,7 +11,7 @@ export class ClassicPageProcessor extends PageProcessorBase {
     public processPage: Apify.PuppeteerHandlePage = async ({ page, request }) => {
         console.log(`Processing page ${page.url()}`);
         await this.enqueueLinks(page);
-        const axeResults = await this.accessibilityScanOp.run(page, request.id as string);
+        const axeResults = await this.accessibilityScanOp.run(page, request.id as string, this.crawlerConfiguration.axeSourcePath());
         const issueCount = axeResults?.violations?.length > 0 ? axeResults.violations.reduce((a, b) => a + b.nodes.length, 0) : 0;
         await this.saveSnapshot(page, request.id as string);
         await this.pushScanData({ id: request.id as string, url: request.url, succeeded: true, issueCount });

--- a/packages/crawler/src/page-processors/page-processor-base.spec.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.spec.ts
@@ -120,6 +120,7 @@ describe(PageProcessorBase, () => {
     it('gotoFunction', async () => {
         pageProcessorBase.baseUrl = testUrl;
         const userAgent = 'userAgent';
+        const browserSpec = 'browser spec';
         const browserResolution = '1920x1080';
         const inputs: Apify.PuppeteerGotoInputs = {
             page: pageStub,
@@ -129,6 +130,10 @@ describe(PageProcessorBase, () => {
         pageConfiguratorMock
             .setup((o) => o.getUserAgent())
             .returns(() => userAgent)
+            .verifiable();
+        pageConfiguratorMock
+            .setup((o) => o.getBrowserSpec())
+            .returns(() => browserSpec)
             .verifiable();
         pageConfiguratorMock
             .setup((o) => o.getBrowserResolution())
@@ -143,7 +148,7 @@ describe(PageProcessorBase, () => {
             .returns(() => Promise.resolve(response))
             .verifiable();
         dataBaseMock
-            .setup((o) => o.addScanMetadata({ baseUrl: testUrl, basePageTitle: 'title', userAgent, browserResolution }))
+            .setup((o) => o.addScanMetadata({ baseUrl: testUrl, basePageTitle: 'title', userAgent, browserSpec, browserResolution }))
             .verifiable();
 
         await pageProcessorBase.gotoFunction(inputs);

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -200,6 +200,7 @@ export abstract class PageProcessorBase implements PageProcessor {
                 baseUrl: this.baseUrl,
                 basePageTitle: this.baseUrl === url ? pageTitle : '',
                 userAgent: this.pageNavigator.pageConfigurator.getUserAgent(),
+                browserSpec: this.pageNavigator.pageConfigurator.getBrowserSpec(),
                 browserResolution: this.pageNavigator.pageConfigurator.getBrowserResolution(),
             });
             this.scanMetadataSaved = true;

--- a/packages/crawler/src/page-processors/simulator-page-processor.spec.ts
+++ b/packages/crawler/src/page-processors/simulator-page-processor.spec.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 import Apify from 'apify';
 import { Page } from 'puppeteer';
 import { PageNavigator } from 'scanner-global-library';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, It } from 'typemoq';
 import { AxeResults } from 'axe-core';
 import { CrawlerConfiguration } from '../crawler/crawler-configuration';
 import { DataBase } from '../level-storage/data-base';
@@ -111,7 +111,7 @@ describe(SimulatorPageProcessor, () => {
     it('pageProcessor, no-op', async () => {
         setupEnqueueLinks(pageStub);
         accessibilityScanOpMock
-            .setup((aso) => aso.run(pageStub, testId))
+            .setup((aso) => aso.run(pageStub, testId, It.isAny()))
             .returns(async () => Promise.resolve(axeResults))
             .verifiable();
         const expectedScanData = {
@@ -136,7 +136,7 @@ describe(SimulatorPageProcessor, () => {
         } as any;
 
         setupEnqueueLinks(pageStub);
-        accessibilityScanOpMock.setup((aso) => aso.run(pageStub, testId)).verifiable();
+        accessibilityScanOpMock.setup((aso) => aso.run(pageStub, testId, It.isAny())).verifiable();
         const expectedScanData = {
             id: testId,
             url: testUrl,

--- a/packages/crawler/src/page-processors/simulator-page-processor.ts
+++ b/packages/crawler/src/page-processors/simulator-page-processor.ts
@@ -56,7 +56,7 @@ export class SimulatorPageProcessor extends PageProcessorBase {
             console.log(`Processing page ${page.url()}`);
             await this.enqueueLinks(page);
             await this.enqueueActiveElementsOp.find(page, this.selectors, requestQueue);
-            const axeResults = await this.accessibilityScanOp.run(page, request.id as string);
+            const axeResults = await this.accessibilityScanOp.run(page, request.id as string, this.crawlerConfiguration.axeSourcePath());
             const issueCount = axeResults?.violations?.length > 0 ? axeResults.violations.reduce((a, b) => a + b.nodes.length, 0) : 0;
             await this.saveSnapshot(page, request.id as string);
             await this.pushScanData({ succeeded: true, id: request.id as string, url: request.url, issueCount: issueCount });
@@ -68,7 +68,11 @@ export class SimulatorPageProcessor extends PageProcessorBase {
             let issueCount;
             if (operationResult.clickAction === 'page-action') {
                 await this.enqueueLinks(page);
-                const axeResults = await this.accessibilityScanOp.run(page, request.id as string);
+                const axeResults = await this.accessibilityScanOp.run(
+                    page,
+                    request.id as string,
+                    this.crawlerConfiguration.axeSourcePath(),
+                );
                 issueCount = axeResults?.violations?.length > 0 ? axeResults.violations.reduce((a, b) => a + b.nodes.length, 0) : 0;
                 await this.saveSnapshot(page, request.id as string);
                 await this.saveScanResult(request, issueCount, activeElement.selector);

--- a/packages/crawler/src/scanners/page-scanner.spec.ts
+++ b/packages/crawler/src/scanners/page-scanner.spec.ts
@@ -6,7 +6,7 @@ import { AxePuppeteer } from '@axe-core/puppeteer';
 import { AxeResults } from 'axe-core';
 import { Page } from 'puppeteer';
 import { AxePuppeteerFactory } from 'scanner-global-library';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, It } from 'typemoq';
 import { getPromisableDynamicMock } from '../test-utilities/promisable-mock';
 import { PageScanner } from './page-scanner';
 
@@ -34,7 +34,7 @@ describe(PageScanner, () => {
         createAxePuppeteerMock = Mock.ofType<AxePuppeteerFactory>();
         axePuppeteerMock = getPromisableDynamicMock(Mock.ofType<AxePuppeteer>());
         createAxePuppeteerMock
-            .setup(async (cap) => cap.createAxePuppeteer(pageStub))
+            .setup(async (cap) => cap.createAxePuppeteer(pageStub, It.isAny()))
             .returns(() => Promise.resolve(axePuppeteerMock.object));
 
         pageScanner = new PageScanner(createAxePuppeteerMock.object);

--- a/packages/crawler/src/scanners/page-scanner.ts
+++ b/packages/crawler/src/scanners/page-scanner.ts
@@ -10,8 +10,8 @@ import { AxeResults } from 'axe-core';
 export class PageScanner {
     public constructor(@inject(AxePuppeteerFactory) private readonly axePuppeteerFactory: AxePuppeteerFactory) {}
 
-    public async scan(page: Page): Promise<AxeResults> {
-        const axePuppeteer: AxePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(page);
+    public async scan(page: Page, axeSourcePath?: string): Promise<AxeResults> {
+        const axePuppeteer: AxePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(page, axeSourcePath);
 
         return axePuppeteer.analyze();
     }

--- a/packages/crawler/src/types/crawler-run-options.ts
+++ b/packages/crawler/src/types/crawler-run-options.ts
@@ -15,4 +15,6 @@ export interface CrawlerRunOptions {
     memoryMBytes?: number;
     silentMode?: boolean;
     debug?: boolean;
+    chromePath?: string;
+    axeSourcePath?:string;
 }

--- a/packages/crawler/src/types/crawler-run-options.ts
+++ b/packages/crawler/src/types/crawler-run-options.ts
@@ -16,5 +16,5 @@ export interface CrawlerRunOptions {
     silentMode?: boolean;
     debug?: boolean;
     chromePath?: string;
-    axeSourcePath?:string;
+    axeSourcePath?: string;
 }

--- a/packages/scanner-global-library/src/page-configurator.spec.ts
+++ b/packages/scanner-global-library/src/page-configurator.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { Browser, Page } from 'puppeteer';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 import { PageConfigurator } from './page-configurator';
 
 describe(PageConfigurator, () => {
@@ -18,6 +18,8 @@ describe(PageConfigurator, () => {
     };
     const chromeUserAgent = 'Mozilla/5.0 Chrome/85.0';
     const headlessChromeUserAgent = 'Mozilla/5.0 HeadlessChrome/85.0';
+    const chromeSpec = 'Chrome/85.0';
+    const headlessChromeSpec = 'HeadlessChrome/85.0';
 
     beforeEach(() => {
         pageMock = Mock.ofType<Page>();
@@ -26,10 +28,14 @@ describe(PageConfigurator, () => {
             .setup(async (o) => o.userAgent())
             .returns(() => Promise.resolve(headlessChromeUserAgent))
             .verifiable();
+        browserMock
+            .setup(async (o) => o.version())
+            .returns(() => Promise.resolve(headlessChromeSpec))
+            .verifiable();
         pageMock
             .setup((o) => o.browser())
             .returns(() => browserMock.object)
-            .verifiable();
+            .verifiable(Times.exactly(2));
         pageMock
             .setup(async (o) => o.setBypassCSP(true))
             .returns(() => Promise.resolve())
@@ -54,6 +60,7 @@ describe(PageConfigurator, () => {
     it('configurePage()', async () => {
         await pageConfigurator.configurePage(pageMock.object);
         expect(pageConfigurator.getUserAgent()).toEqual(chromeUserAgent);
+        expect(pageConfigurator.getBrowserSpec()).toEqual(chromeSpec);
         expect(pageConfigurator.getBrowserResolution()).toEqual('1920x1080');
     });
 });

--- a/packages/scanner-global-library/src/page-configurator.ts
+++ b/packages/scanner-global-library/src/page-configurator.ts
@@ -6,11 +6,16 @@ import { Page } from 'puppeteer';
 @injectable()
 export class PageConfigurator {
     private userAgent: string;
+    private browserSpec: string;
     private readonly windowWidth = 1920;
     private readonly windowHeight = 1080;
 
     public getUserAgent(): string {
         return this.userAgent;
+    }
+
+    public getBrowserSpec(): string {
+        return this.browserSpec;
     }
 
     public async configurePage(page: Page): Promise<void> {
@@ -22,6 +27,7 @@ export class PageConfigurator {
         });
 
         await this.setUserAgent(page);
+        await this.setBrowserSpec(page);
     }
 
     public getBrowserResolution(): string {
@@ -32,5 +38,10 @@ export class PageConfigurator {
         const browser = page.browser();
         this.userAgent = (await browser.userAgent()).replace('HeadlessChrome', 'Chrome');
         await page.setUserAgent(this.userAgent);
+    }
+
+    private async setBrowserSpec(page: Page): Promise<void> {
+        const browser = page.browser();
+        this.browserSpec = (await browser.version()).replace('HeadlessChrome', 'Chrome');
     }
 }

--- a/packages/service-library/src/data-providers/combined-scan-results-provider.spec.ts
+++ b/packages/service-library/src/data-providers/combined-scan-results-provider.spec.ts
@@ -7,7 +7,7 @@ import { BlobContentDownloadResponse, BlobSaveCondition, BlobStorageClient, Blob
 import { CombinedScanResults } from 'storage-documents';
 import { IMock, Mock } from 'typemoq';
 import { BodyParser, System } from 'common';
-import { AxeResults, AxeResult } from 'axe-result-converter';
+import { AxeResultsList, AxeResult } from 'axe-result-converter';
 import { CombinedScanResultsProvider } from './combined-scan-results-provider';
 import { DataProvidersCommon } from './data-providers-common';
 
@@ -22,10 +22,10 @@ describe(CombinedScanResultsProvider, () => {
         },
         axeResults: {
             urls: [],
-            violations: new AxeResults(),
-            passes: new AxeResults(),
-            incomplete: new AxeResults(),
-            inapplicable: new AxeResults(),
+            violations: new AxeResultsList(),
+            passes: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
         },
     } as CombinedScanResults;
     combinedResults.axeResults.violations.add('1', { fingerprint: 'a' } as AxeResult);

--- a/packages/service-library/src/data-providers/combined-scan-results-provider.ts
+++ b/packages/service-library/src/data-providers/combined-scan-results-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Readable } from 'stream';
-import { AxeResults, AxeCoreResults } from 'axe-result-converter';
+import { AxeResultsList, AxeCoreResults } from 'axe-result-converter';
 import { BlobContentDownloadResponse, BlobStorageClient } from 'azure-services';
 import { inject, injectable } from 'inversify';
 import { CombinedScanResults } from 'storage-documents';
@@ -95,7 +95,7 @@ export class CombinedScanResultsProvider {
         try {
             const content = JSON.parse(contentString, (key, value) => {
                 if (key === 'violations' || key === 'passes' || key === 'incomplete' || key === 'inapplicable') {
-                    return new AxeResults(value);
+                    return new AxeResultsList(value);
                 }
 
                 return value;
@@ -130,10 +130,10 @@ export class CombinedScanResultsProvider {
             },
             axeResults: {
                 urls: [],
-                violations: new AxeResults(),
-                passes: new AxeResults(),
-                incomplete: new AxeResults(),
-                inapplicable: new AxeResults(),
+                violations: new AxeResultsList(),
+                passes: new AxeResultsList(),
+                incomplete: new AxeResultsList(),
+                inapplicable: new AxeResultsList(),
             } as AxeCoreResults,
         };
     }

--- a/packages/web-api-scan-runner/src/report-generator/axe-result-to-consolidated-html-converter.spec.ts
+++ b/packages/web-api-scan-runner/src/report-generator/axe-result-to-consolidated-html-converter.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { Report, Reporter, ReporterFactory, CombinedReportParameters } from 'accessibility-insights-report';
 import { IMock, Mock } from 'typemoq';
-import { AxeResults, AxeCoreResults, CombinedReportDataConverter, ScanResultData } from 'axe-result-converter';
+import { AxeResultsList, AxeCoreResults, CombinedReportDataConverter, ScanResultData } from 'axe-result-converter';
 import axe from 'axe-core';
 import { CombinedScanResults } from 'storage-documents';
 import * as MockDate from 'mockdate';
@@ -67,10 +67,10 @@ describe('AxeResultToConsolidatedHtmlConverter', () => {
         };
         const axeResults = {
             urls: [],
-            violations: new AxeResults(),
-            passes: new AxeResults(),
-            incomplete: new AxeResults(),
-            inapplicable: new AxeResults(),
+            violations: new AxeResultsList(),
+            passes: new AxeResultsList(),
+            incomplete: new AxeResultsList(),
+            inapplicable: new AxeResultsList(),
         } as AxeCoreResults;
         const combinedScanResults = { urlCount, axeResults } as CombinedScanResults;
 


### PR DESCRIPTION
#### Description of changes
This PR could be divided into 5 pieces to review (one for each commit) and the last commit is only for fixing lint and format:
- [Create AICrawler to be used later for wcp and action.](https://github.com/microsoft/accessibility-insights-service/pull/1209/commits/025bf5e5f4bdcd6e9ecb884298b6a38fc7d9cd66)
- [Export aicrawler in index to be used by external packages and fix webpack build issues.](https://github.com/microsoft/accessibility-insights-service/pull/1209/commits/35da61f1147d52de7bd1db3884ba9f5d690a9257)
- [Expose AICombinedReportDataConverter to be used by external packages.](https://github.com/microsoft/accessibility-insights-service/pull/1209/commits/92a6419d8ccba25036150167186aa01ace80636b)
- [Add axe source path and chrome executable path in crawler.](https://github.com/microsoft/accessibility-insights-service/pull/1209/commits/adee3ee5bb5e9ddb6426bf39cc0d3d8d446b137a)
- [Add browser spec to scandMetaData in Crawler.](https://github.com/microsoft/accessibility-insights-service/pull/1209/commits/c6f31a948e77123accab10ebe9cd5bb471731efd)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
