### PR TITLE
feat(deepscan-contract): fix incorrect location of deepScanResult in API contract

### DIFF
--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -179,10 +179,6 @@ components:
                     type: string
                 url:
                     type: string
-                deepScanResult:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/DeepScanResultItem'
                 error:
                     $ref: '#/components/schemas/WebApiError'
         ScanResult:
@@ -278,6 +274,10 @@ components:
                     type: string
                 scanResult:
                     $ref: '#/components/schemas/ScanResult'
+                deepScanResult:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DeepScanResultItem'
                 reports:
                     type: array
                     items:


### PR DESCRIPTION
#### Description of changes

In #1212 `deepScanResult` was incorrectly added to the response for the initial scan-request endpoint; this was meant to be on `ScanRunResultResponse` alongside the other `scanResult` info. This PR corrects the issue.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
