### PR TITLE
feat(cloud-crawler): SimpleCrawlerEngine

### DIFF
--- a/packages/cli/src/runner/crawler-command-runner.spec.ts
+++ b/packages/cli/src/runner/crawler-command-runner.spec.ts
@@ -18,7 +18,7 @@ describe('CrawlerCommandRunner', () => {
 
     let scanArguments: ScanArguments;
     let crawlerOption: CrawlerRunOptions;
-    let crawlerMock: IMock<Crawler>;
+    let crawlerMock: IMock<Crawler<void>>;
     let crawlerParametersBuilderMock: IMock<CrawlerParametersBuilder>;
     let reportDiskWriterMock: IMock<ReportDiskWriter>;
     let consolidatedReportGeneratorMock: IMock<ConsolidatedReportGenerator>;
@@ -41,7 +41,7 @@ describe('CrawlerCommandRunner', () => {
             silentMode: undefined,
         };
 
-        crawlerMock = Mock.ofType<Crawler>();
+        crawlerMock = Mock.ofType<Crawler<void>>();
         crawlerParametersBuilderMock = Mock.ofType<CrawlerParametersBuilder>();
         reportDiskWriterMock = Mock.ofType<ReportDiskWriter>();
         consolidatedReportGeneratorMock = Mock.ofType<ConsolidatedReportGenerator>();

--- a/packages/cli/src/runner/crawler-command-runner.ts
+++ b/packages/cli/src/runner/crawler-command-runner.ts
@@ -12,7 +12,7 @@ import { CommandRunner } from './command-runner';
 @injectable()
 export class CrawlerCommandRunner implements CommandRunner {
     constructor(
-        @inject(Crawler) private readonly crawler: Crawler,
+        @inject(Crawler) private readonly crawler: Crawler<void>,
         @inject(CrawlerParametersBuilder) private readonly crawlerParametersBuilder: CrawlerParametersBuilder,
         @inject(ConsolidatedReportGenerator) private readonly consolidatedReportGenerator: ConsolidatedReportGenerator,
         @inject(ReportDiskWriter) private readonly reportDiskWriter: ReportDiskWriter,

--- a/packages/cli/src/setup-cli-container.ts
+++ b/packages/cli/src/setup-cli-container.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Crawler, setupCrawlerContainer } from 'accessibility-insights-crawler';
+import { Crawler, setupLocalCrawlerContainer } from 'accessibility-insights-crawler';
 import * as inversify from 'inversify';
 
 export function setupCliContainer(): inversify.Container {
     const container = new inversify.Container({ autoBindInjectable: true });
-    setupCrawlerContainer(container);
-    container.bind(Crawler).toConstantValue(new Crawler(container));
+    setupLocalCrawlerContainer(container);
+    container.bind(Crawler).toConstantValue(new Crawler<void>(container));
 
     return container;
 }

--- a/packages/crawler/src/crawler.spec.ts
+++ b/packages/crawler/src/crawler.spec.ts
@@ -7,17 +7,17 @@ import { IMock, Mock } from 'typemoq';
 import { CrawlerRunOptions } from './types/crawler-run-options';
 import { iocTypes } from './types/ioc-types';
 import { Crawler } from './crawler';
-import { CrawlerEngine } from './crawler/crawler-engine';
+import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
 
 describe(Crawler, () => {
     let testSubject: Crawler;
     let containerMock: IMock<Container>;
-    let crawlerEngineMock: IMock<CrawlerEngine>;
+    let crawlerEngineMock: IMock<PuppeteerCrawlerEngine>;
     let containerBindMock: IMock<interfaces.BindingToSyntax<CrawlerRunOptions>>;
 
     beforeEach(() => {
         containerMock = Mock.ofType(Container);
-        crawlerEngineMock = Mock.ofType(CrawlerEngine);
+        crawlerEngineMock = Mock.ofType(PuppeteerCrawlerEngine);
         containerBindMock = Mock.ofType<interfaces.BindingToSyntax<CrawlerRunOptions>>();
 
         testSubject = new Crawler(containerMock.object);
@@ -32,7 +32,7 @@ describe(Crawler, () => {
     it('crawl', async () => {
         const testInput: CrawlerRunOptions = { baseUrl: 'url' };
         containerMock
-            .setup((c) => c.get(CrawlerEngine))
+            .setup((c) => c.get(PuppeteerCrawlerEngine))
             .returns(() => crawlerEngineMock.object)
             .verifiable();
         containerBindMock.setup((o) => o.toConstantValue(testInput)).verifiable();

--- a/packages/crawler/src/crawler.spec.ts
+++ b/packages/crawler/src/crawler.spec.ts
@@ -10,7 +10,7 @@ import { Crawler } from './crawler';
 import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
 
 describe(Crawler, () => {
-    let testSubject: Crawler;
+    let testSubject: Crawler<void>;
     let containerMock: IMock<Container>;
     let crawlerEngineMock: IMock<PuppeteerCrawlerEngine>;
     let containerBindMock: IMock<interfaces.BindingToSyntax<CrawlerRunOptions>>;
@@ -32,7 +32,7 @@ describe(Crawler, () => {
     it('crawl', async () => {
         const testInput: CrawlerRunOptions = { baseUrl: 'url' };
         containerMock
-            .setup((c) => c.get(PuppeteerCrawlerEngine))
+            .setup((c) => c.get(iocTypes.CrawlerEngine))
             .returns(() => crawlerEngineMock.object)
             .verifiable();
         containerBindMock.setup((o) => o.toConstantValue(testInput)).verifiable();

--- a/packages/crawler/src/crawler.ts
+++ b/packages/crawler/src/crawler.ts
@@ -1,15 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Container } from 'inversify';
+import { CrawlerEngine } from './crawler/crawler-engine';
 import { registerCrawlerRunOptions } from './setup-crawler-container';
 import { CrawlerRunOptions } from './types/crawler-run-options';
-import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
+import { iocTypes } from './types/ioc-types';
 
-export class Crawler {
+export class Crawler<T> {
     constructor(private readonly container: Container) {}
 
-    public async crawl(crawlerRunOptions: CrawlerRunOptions): Promise<void> {
+    public async crawl(crawlerRunOptions: CrawlerRunOptions): Promise<T> {
         registerCrawlerRunOptions(this.container, crawlerRunOptions);
-        await this.container.get(PuppeteerCrawlerEngine).start(crawlerRunOptions);
+
+        return (this.container.get(iocTypes.CrawlerEngine) as CrawlerEngine<T>).start(crawlerRunOptions);
     }
 }

--- a/packages/crawler/src/crawler.ts
+++ b/packages/crawler/src/crawler.ts
@@ -3,13 +3,13 @@
 import { Container } from 'inversify';
 import { registerCrawlerRunOptions } from './setup-crawler-container';
 import { CrawlerRunOptions } from './types/crawler-run-options';
-import { CrawlerEngine } from './crawler/crawler-engine';
+import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
 
 export class Crawler {
     constructor(private readonly container: Container) {}
 
     public async crawl(crawlerRunOptions: CrawlerRunOptions): Promise<void> {
         registerCrawlerRunOptions(this.container, crawlerRunOptions);
-        await this.container.get(CrawlerEngine).start(crawlerRunOptions);
+        await this.container.get(PuppeteerCrawlerEngine).start(crawlerRunOptions);
     }
 }

--- a/packages/crawler/src/crawler/crawler-engine.ts
+++ b/packages/crawler/src/crawler/crawler-engine.ts
@@ -1,75 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import Apify from 'apify';
-import { inject, injectable } from 'inversify';
-// @ts-ignore
-import * as cheerio from 'cheerio';
+
 import { CrawlerRunOptions } from '../types/crawler-run-options';
-import { ApifyRequestQueueProvider, iocTypes, PageProcessorFactory } from '../types/ioc-types';
-import { CrawlerConfiguration } from './crawler-configuration';
-import { CrawlerFactory } from './crawler-factory';
 
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
-@injectable()
-export class CrawlerEngine {
-    public constructor(
-        @inject(iocTypes.PageProcessorFactory) private readonly pageProcessorFactory: PageProcessorFactory,
-        @inject(iocTypes.ApifyRequestQueueProvider) protected readonly requestQueueProvider: ApifyRequestQueueProvider,
-        @inject(CrawlerFactory) private readonly crawlerFactory: CrawlerFactory,
-        @inject(CrawlerConfiguration) private readonly crawlerConfiguration: CrawlerConfiguration,
-    ) {}
-
-    public async start(crawlerRunOptions: CrawlerRunOptions): Promise<void> {
-        this.crawlerConfiguration.setDefaultApifySettings();
-        this.crawlerConfiguration.setLocalOutputDir(crawlerRunOptions.localOutputDir);
-        this.crawlerConfiguration.setMemoryMBytes(crawlerRunOptions.memoryMBytes);
-        this.crawlerConfiguration.setSilentMode(crawlerRunOptions.silentMode);
-
-        const puppeteerDefaultOptions = ['--disable-dev-shm-usage'];
-        const pageProcessor = this.pageProcessorFactory();
-        const puppeteerCrawlerOptions: Apify.PuppeteerCrawlerOptions = {
-            handlePageTimeoutSecs: 300, // timeout includes all page processing activity (navigation, rendering, accessibility scan, etc.)
-            requestQueue: await this.requestQueueProvider(),
-            handlePageFunction: pageProcessor.pageHandler,
-            gotoFunction: pageProcessor.gotoFunction,
-            handleFailedRequestFunction: pageProcessor.pageErrorProcessor,
-            maxRequestsPerCrawl: this.crawlerConfiguration.maxRequestsPerCrawl(),
-            launchPuppeteerOptions: {
-                args: puppeteerDefaultOptions,
-                defaultViewport: {
-                    width: 1920,
-                    height: 1080,
-                    deviceScaleFactor: 1,
-                },
-            } as Apify.LaunchPuppeteerOptions,
-        };
-
-        if (crawlerRunOptions.debug === true) {
-            this.crawlerConfiguration.setSilentMode(false);
-
-            puppeteerCrawlerOptions.handlePageTimeoutSecs = 3600;
-            puppeteerCrawlerOptions.gotoTimeoutSecs = 3600;
-            puppeteerCrawlerOptions.maxConcurrency = 1;
-            puppeteerCrawlerOptions.sessionPoolOptions = {
-                sessionOptions: {
-                    ...puppeteerCrawlerOptions.sessionPoolOptions?.sessionOptions,
-                    maxAgeSecs: 3600,
-                },
-            };
-            puppeteerCrawlerOptions.launchPuppeteerOptions = {
-                ...puppeteerCrawlerOptions.launchPuppeteerOptions,
-                args: ['--auto-open-devtools-for-tabs', ...puppeteerDefaultOptions],
-            } as Apify.LaunchPuppeteerOptions;
-            puppeteerCrawlerOptions.puppeteerPoolOptions = {
-                puppeteerOperationTimeoutSecs: 3600,
-                instanceKillerIntervalSecs: 3600,
-                killInstanceAfterSecs: 3600,
-                maxOpenPagesPerInstance: 1,
-            };
-        }
-
-        const crawler = this.crawlerFactory.createPuppeteerCrawler(puppeteerCrawlerOptions);
-        await crawler.run();
-    }
+export interface CrawlerEngine<T = void> {
+    start(crawlerRunOptions: CrawlerRunOptions): Promise<T>;
 }

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
@@ -8,7 +8,7 @@ import { PageProcessor, PageProcessorBase } from '../page-processors/page-proces
 import { CrawlerRunOptions } from '../types/crawler-run-options';
 import { ApifyRequestQueueProvider } from '../types/ioc-types';
 import { CrawlerConfiguration } from './crawler-configuration';
-import { CrawlerEngine } from './crawler-engine';
+import { PuppeteerCrawlerEngine } from './puppeteer-crawler-engine';
 import { CrawlerFactory } from './crawler-factory';
 
 /* eslint-disable
@@ -16,7 +16,7 @@ import { CrawlerFactory } from './crawler-factory';
    no-empty,@typescript-eslint/no-empty-function,
    @typescript-eslint/consistent-type-assertions */
 
-describe(CrawlerEngine, () => {
+describe(PuppeteerCrawlerEngine, () => {
     const puppeteerDefaultOptions = ['--disable-dev-shm-usage'];
     const maxRequestsPerCrawl: number = 100;
     const pageProcessorStub: PageProcessor = {
@@ -32,7 +32,7 @@ describe(CrawlerEngine, () => {
     let puppeteerCrawlerMock: IMock<Apify.PuppeteerCrawler>;
     let crawlerConfigurationMock: IMock<CrawlerConfiguration>;
     let baseCrawlerOptions: Apify.PuppeteerCrawlerOptions;
-    let crawlerEngine: CrawlerEngine;
+    let crawlerEngine: PuppeteerCrawlerEngine;
     let requestQueueProvider: ApifyRequestQueueProvider;
 
     beforeEach(() => {
@@ -82,7 +82,7 @@ describe(CrawlerEngine, () => {
 
         requestQueueProvider = () => Promise.resolve(requestQueueStub);
         pageProcessorFactoryStub = jest.fn().mockImplementation(() => pageProcessorStub as PageProcessorBase);
-        crawlerEngine = new CrawlerEngine(
+        crawlerEngine = new PuppeteerCrawlerEngine(
             pageProcessorFactoryStub,
             requestQueueProvider,
             crawlerFactoryMock.object,

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import Apify from 'apify';
+import { inject, injectable } from 'inversify';
+// @ts-ignore
+import * as cheerio from 'cheerio';
+import { CrawlerRunOptions } from '../types/crawler-run-options';
+import { ApifyRequestQueueProvider, iocTypes, PageProcessorFactory } from '../types/ioc-types';
+import { CrawlerConfiguration } from './crawler-configuration';
+import { CrawlerFactory } from './crawler-factory';
+
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+
+@injectable()
+export class PuppeteerCrawlerEngine {
+    public constructor(
+        @inject(iocTypes.PageProcessorFactory) private readonly pageProcessorFactory: PageProcessorFactory,
+        @inject(iocTypes.ApifyRequestQueueProvider) protected readonly requestQueueProvider: ApifyRequestQueueProvider,
+        @inject(CrawlerFactory) private readonly crawlerFactory: CrawlerFactory,
+        @inject(CrawlerConfiguration) private readonly crawlerConfiguration: CrawlerConfiguration,
+    ) {}
+
+    public async start(crawlerRunOptions: CrawlerRunOptions): Promise<void> {
+        this.crawlerConfiguration.setDefaultApifySettings();
+        this.crawlerConfiguration.setLocalOutputDir(crawlerRunOptions.localOutputDir);
+        this.crawlerConfiguration.setMemoryMBytes(crawlerRunOptions.memoryMBytes);
+        this.crawlerConfiguration.setSilentMode(crawlerRunOptions.silentMode);
+
+        const puppeteerDefaultOptions = ['--disable-dev-shm-usage'];
+        const pageProcessor = this.pageProcessorFactory();
+        const puppeteerCrawlerOptions: Apify.PuppeteerCrawlerOptions = {
+            handlePageTimeoutSecs: 300, // timeout includes all page processing activity (navigation, rendering, accessibility scan, etc.)
+            requestQueue: await this.requestQueueProvider(),
+            handlePageFunction: pageProcessor.pageHandler,
+            gotoFunction: pageProcessor.gotoFunction,
+            handleFailedRequestFunction: pageProcessor.pageErrorProcessor,
+            maxRequestsPerCrawl: this.crawlerConfiguration.maxRequestsPerCrawl(),
+            launchPuppeteerOptions: {
+                args: puppeteerDefaultOptions,
+                defaultViewport: {
+                    width: 1920,
+                    height: 1080,
+                    deviceScaleFactor: 1,
+                },
+            } as Apify.LaunchPuppeteerOptions,
+        };
+
+        if (crawlerRunOptions.debug === true) {
+            this.crawlerConfiguration.setSilentMode(false);
+
+            puppeteerCrawlerOptions.handlePageTimeoutSecs = 3600;
+            puppeteerCrawlerOptions.gotoTimeoutSecs = 3600;
+            puppeteerCrawlerOptions.maxConcurrency = 1;
+            puppeteerCrawlerOptions.sessionPoolOptions = {
+                sessionOptions: {
+                    ...puppeteerCrawlerOptions.sessionPoolOptions?.sessionOptions,
+                    maxAgeSecs: 3600,
+                },
+            };
+            puppeteerCrawlerOptions.launchPuppeteerOptions = {
+                ...puppeteerCrawlerOptions.launchPuppeteerOptions,
+                args: ['--auto-open-devtools-for-tabs', ...puppeteerDefaultOptions],
+            } as Apify.LaunchPuppeteerOptions;
+            puppeteerCrawlerOptions.puppeteerPoolOptions = {
+                puppeteerOperationTimeoutSecs: 3600,
+                instanceKillerIntervalSecs: 3600,
+                killInstanceAfterSecs: 3600,
+                maxOpenPagesPerInstance: 1,
+            };
+        }
+
+        const crawler = this.crawlerFactory.createPuppeteerCrawler(puppeteerCrawlerOptions);
+        await crawler.run();
+    }
+}

--- a/packages/crawler/src/crawler/simple-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/simple-crawler-engine.spec.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { CrawlerRunOptions } from '../types/crawler-run-options';
+import { SimpleCrawlerEngine } from './simple-crawler-engine';
+
+describe(SimpleCrawlerEngine, () => {
+    let testSubject: SimpleCrawlerEngine;
+    let crawlerRunOptions: CrawlerRunOptions;
+
+    beforeAll(() => {
+        testSubject = new SimpleCrawlerEngine();
+        crawlerRunOptions = {
+            localOutputDir: 'localOutputDir',
+            memoryMBytes: 100,
+            silentMode: true,
+            debug: false,
+        } as CrawlerRunOptions;
+    });
+
+    it('returns list of urls', async () => {
+        const expectedUrls: string[] = [];
+
+        const discoveredUrls = await testSubject.start(crawlerRunOptions);
+
+        expect(discoveredUrls).toEqual(expectedUrls);
+    });
+});

--- a/packages/crawler/src/crawler/simple-crawler-engine.ts
+++ b/packages/crawler/src/crawler/simple-crawler-engine.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { injectable } from 'inversify';
+// @ts-ignore
+import * as cheerio from 'cheerio';
+import { CrawlerRunOptions } from '../types/crawler-run-options';
+import { CrawlerEngine } from './crawler-engine';
+
+@injectable()
+export class SimpleCrawlerEngine implements CrawlerEngine<string[]> {
+    public async start(crawlerRunOptions: CrawlerRunOptions): Promise<string[]> {
+        return [];
+    }
+}

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -9,3 +9,5 @@ export { Crawler } from './crawler';
 export { setupCrawlerContainer } from './setup-crawler-container';
 export * from './level-storage/storage-documents';
 export { DbScanResultReader } from './scan-result-providers/db-scan-result-reader';
+export { CrawlerEngine } from './crawler/crawler-engine';
+export { SimpleCrawlerEngine } from './crawler/simple-crawler-engine';

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -6,8 +6,6 @@ import './global-overrides';
 
 export { CrawlerRunOptions } from './types/crawler-run-options';
 export { Crawler } from './crawler';
-export { setupCrawlerContainer } from './setup-crawler-container';
+export { setupLocalCrawlerContainer } from './setup-crawler-container';
 export * from './level-storage/storage-documents';
 export { DbScanResultReader } from './scan-result-providers/db-scan-result-reader';
-export { CrawlerEngine } from './crawler/crawler-engine';
-export { SimpleCrawlerEngine } from './crawler/simple-crawler-engine';

--- a/packages/crawler/src/main.ts
+++ b/packages/crawler/src/main.ts
@@ -9,7 +9,7 @@ import * as dotenv from 'dotenv';
 import * as yargs from 'yargs';
 import * as inversify from 'inversify';
 import { Crawler } from './crawler';
-import { setupCrawlerContainer } from './setup-crawler-container';
+import { setupLocalCrawlerContainer } from './setup-crawler-container';
 
 interface ScanArguments {
     url: string;
@@ -32,7 +32,7 @@ interface ScanArguments {
     const scanArguments = (yargs.argv as unknown) as ScanArguments;
 
     const container = new inversify.Container({ autoBindInjectable: true });
-    await new Crawler(setupCrawlerContainer(container)).crawl({
+    await new Crawler(setupLocalCrawlerContainer(container)).crawl({
         crawl: scanArguments.crawl,
         baseUrl: scanArguments.url,
         simulate: scanArguments.simulate,

--- a/packages/crawler/src/setup-crawler-container.spec.ts
+++ b/packages/crawler/src/setup-crawler-container.spec.ts
@@ -5,13 +5,13 @@ import 'reflect-metadata';
 import * as inversify from 'inversify';
 import { CrawlerConfiguration } from './crawler/crawler-configuration';
 import { DataBase } from './level-storage/data-base';
-import { setupCrawlerContainer } from './setup-crawler-container';
+import { setupLocalCrawlerContainer } from './setup-crawler-container';
 import { CrawlerRunOptions } from './types/crawler-run-options';
 import { iocTypes } from './types/ioc-types';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-describe(setupCrawlerContainer, () => {
+describe(setupLocalCrawlerContainer, () => {
     it('resolves dependencies', () => {
         const crawlerRunOptions = {
             baseUrl: 'baseUrl',
@@ -22,7 +22,7 @@ describe(setupCrawlerContainer, () => {
         } as CrawlerRunOptions;
 
         const container = new inversify.Container({ autoBindInjectable: true });
-        setupCrawlerContainer(container);
+        setupLocalCrawlerContainer(container);
         container.bind(iocTypes.CrawlerRunOptions).toConstantValue(crawlerRunOptions);
 
         expect(container.get(CrawlerConfiguration)).toBeDefined();
@@ -30,5 +30,6 @@ describe(setupCrawlerContainer, () => {
         expect(container.get(iocTypes.ReporterFactory)).toBeDefined();
         expect(container.get(iocTypes.ApifyRequestQueueProvider)).toBeDefined();
         expect(container.get(iocTypes.PageProcessorFactory)).toBeDefined();
+        expect(container.get(iocTypes.CrawlerEngine)).toBeDefined();
     });
 });

--- a/packages/crawler/src/setup-crawler-container.ts
+++ b/packages/crawler/src/setup-crawler-container.ts
@@ -3,6 +3,7 @@
 import { reporterFactory } from 'accessibility-insights-report';
 import * as inversify from 'inversify';
 import { ApifyResourceCreator } from './apify/apify-resource-creator';
+import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
 import { DataBase } from './level-storage/data-base';
 import { ClassicPageProcessor } from './page-processors/classic-page-processor';
 import { PageProcessor } from './page-processors/page-processor-base';
@@ -10,9 +11,10 @@ import { SimulatorPageProcessor } from './page-processors/simulator-page-process
 import { CrawlerRunOptions } from './types/crawler-run-options';
 import { iocTypes } from './types/ioc-types';
 
-export function setupCrawlerContainer(container: inversify.Container): inversify.Container {
+export function setupLocalCrawlerContainer(container: inversify.Container): inversify.Container {
     container.bind(DataBase).toSelf().inSingletonScope();
     container.bind(iocTypes.ReporterFactory).toConstantValue(reporterFactory);
+    container.bind(iocTypes.CrawlerEngine).to(PuppeteerCrawlerEngine);
 
     setupSingletonProvider(iocTypes.ApifyRequestQueueProvider, container, async (context: inversify.interfaces.Context) => {
         const apifyResourceCreator = context.container.get(ApifyResourceCreator);

--- a/packages/crawler/src/types/ioc-types.ts
+++ b/packages/crawler/src/types/ioc-types.ts
@@ -11,6 +11,7 @@ export const iocTypes = {
     ApifyKeyValueStore: 'ApifyKeyValueStore',
     ApifyDataset: 'ApifyDataset',
     LevelUp: 'levelup.LevelUp',
+    CrawlerEngine: 'CrawlerEngine',
 };
 
 export type PageProcessorFactory = () => PageProcessorBase;


### PR DESCRIPTION
#### Description of changes

- Create a new SimpleCrawlerEngine class to be used to crawl pages in the service
- Rename existing CrawlerEngine to PuppeteerCrawlerEngine and create a generic CrawlerEngine interface
- Make the Crawler class accept and run any arbitrary CrawlerEngine

#### Pull request checklist

- [x] Addresses an existing issue: #1807310
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
