### PR TITLE
feat(deepscan-contract): Add discoveryPatterns to scan request API

### DIFF
--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -161,6 +161,11 @@ components:
                             items:
                                 type: string
                                 description: known website page to include in a deep scan run in addition to pages discovered by crawling
+                        discoveryPatterns:
+                            type: array
+                            items:
+                                type: string
+                                description: RegEx pattern used by web crawler to specify which URLs should website include
                 reportGroups:
                     type: array
                     items:

--- a/packages/service-library/src/web-api/api-contracts/scan-run-request.ts
+++ b/packages/service-library/src/web-api/api-contracts/scan-run-request.ts
@@ -20,7 +20,7 @@ export interface ScanRunRequest {
 export interface Website {
     baseUrl: string;
     knownPages?: string[];
-    discoveryPatterns?: string[]; 
+    discoveryPatterns?: string[];
 }
 
 export interface ReportGroup {

--- a/packages/service-library/src/web-api/api-contracts/scan-run-request.ts
+++ b/packages/service-library/src/web-api/api-contracts/scan-run-request.ts
@@ -20,6 +20,7 @@ export interface ScanRunRequest {
 export interface Website {
     baseUrl: string;
     knownPages?: string[];
+    discoveryPatterns?: string[]; 
 }
 
 export interface ReportGroup {

--- a/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
@@ -14,7 +14,7 @@ export interface OnDemandPageScanBatchRequest extends StorageDocument {
 export interface WebsiteRequest {
     baseUrl: string;
     knownPages?: string[];
-    discoveryPatterns?: string[]; 
+    discoveryPatterns?: string[];
 }
 
 export interface ReportGroupRequest {

--- a/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
@@ -14,6 +14,7 @@ export interface OnDemandPageScanBatchRequest extends StorageDocument {
 export interface WebsiteRequest {
     baseUrl: string;
     knownPages?: string[];
+    discoveryPatterns?: string[]; 
 }
 
 export interface ReportGroupRequest {

--- a/packages/storage-documents/src/website-scan-result.ts
+++ b/packages/storage-documents/src/website-scan-result.ts
@@ -15,6 +15,7 @@ export interface WebsiteScanResult extends StorageDocument {
     reports?: WebsiteScanReport[];
     combinedResultsBlobId?: string;
     knownPages?: string[];
+    discoveryPatterns?: string[]; 
 }
 
 export interface WebsiteScanReport {

--- a/packages/storage-documents/src/website-scan-result.ts
+++ b/packages/storage-documents/src/website-scan-result.ts
@@ -15,7 +15,7 @@ export interface WebsiteScanResult extends StorageDocument {
     reports?: WebsiteScanReport[];
     combinedResultsBlobId?: string;
     knownPages?: string[];
-    discoveryPatterns?: string[]; 
+    discoveryPatterns?: string[];
 }
 
 export interface WebsiteScanReport {

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -183,7 +183,11 @@ describe(ScanRequestController, () => {
                     url: 'https://abs/path/',
                     priority: 1,
                     scanNotifyUrl: 'https://notify/path/',
-                    site: { baseUrl: 'https://base/path', knownPages: ['https://base/path/known1', 'https://base/path/known2'] },
+                    site: {
+                        baseUrl: 'https://base/path',
+                        knownPages: ['https://base/path/known1', 'https://base/path/known2'],
+                        discoveryPatterns: ['pattern1', 'pattern2'],
+                    },
                     reportGroups: [{ consolidatedId: 'reportGroupId' }],
                     deepScan: true,
                 }, // valid request
@@ -201,7 +205,11 @@ describe(ScanRequestController, () => {
                     url: 'https://abs/path/',
                     priority: 1,
                     scanNotifyUrl: 'https://notify/path/',
-                    site: { baseUrl: 'https://base/path', knownPages: ['https://base/path/known1', 'https://base/path/known2'] },
+                    site: {
+                        baseUrl: 'https://base/path',
+                        knownPages: ['https://base/path/known1', 'https://base/path/known2'],
+                        discoveryPatterns: ['pattern1', 'pattern2'],
+                    },
                     reportGroups: [{ consolidatedId: 'reportGroupId' }],
                     deepScan: true,
                 },

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -141,6 +141,7 @@ describe(ScanBatchRequestFeedController, () => {
                         site: {
                             baseUrl: 'base-url-4',
                             knownPages: ['page1'],
+                            discoveryPatterns: ['pattern1'],
                         },
                         reportGroups: [{ consolidatedId: 'consolidated-id-2' }],
                         deepScan: true,
@@ -210,6 +211,7 @@ function setupWebsiteScanResultProviderMock(documents: OnDemandPageScanBatchRequ
                             },
                         ],
                         knownPages: request.site.knownPages,
+                        discoveryPatterns: request.site.discoveryPatterns,
                     } as WebsiteScanResult;
 
                     const documentId = `db-id-${reportGroup.consolidatedId}`;

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -158,6 +158,7 @@ export class ScanBatchRequestFeedController extends WebController {
                             },
                         ],
                         knownPages: request.site.knownPages,
+                        discoveryPatterns: request.site.discoveryPatterns,
                     });
                 }
             }


### PR DESCRIPTION
#### Description of changes

We need to add discovery patterns property to AI REST API for the deep scan since we might have more complicated scenario when sending website crawl request.

`// RegEx patterns used by web crawler to specify which URLs should website include`
`discoveryPatterns?: string[]; `

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
