### PR TITLE
feat(cloud-crawler): expose underlying puppeteer page to Runner

### DIFF
--- a/packages/cli/src/scanner/ai-scanner.spec.ts
+++ b/packages/cli/src/scanner/ai-scanner.spec.ts
@@ -27,7 +27,8 @@ describe('AIScanner', () => {
     it('should launch browser page with given url and scan the page with axe-core', async () => {
         const url = 'some url';
         const axeResultsStub = ('axe results' as any) as AxeResults;
-        setupNewPageCall(url);
+        setupNewPageCall();
+        setupPageNavigateCall(url);
         setupPageScanCall(url, axeResultsStub);
         await scanner.scan(url);
 
@@ -37,14 +38,15 @@ describe('AIScanner', () => {
     it('should close browser if exception occurs', async () => {
         const url = 'some url';
         const errorMessage: string = `An error occurred while scanning website page ${url}.`;
-        setupNewPageCall(url);
+        setupNewPageCall();
+        setupPageNavigateCall(url);
         setupPageErrorScanCall(url, errorMessage);
         setupPageCloseCall();
         const scanResult: AxeScanResults = await scanner.scan(url);
         expect(scanResult.error).not.toBeNull();
     });
 
-    function setupNewPageCall(url: string): void {
+    function setupNewPageCall(): void {
         pageMock.setup(async (p) => p.create(undefined)).verifiable(Times.once());
     }
 
@@ -52,16 +54,20 @@ describe('AIScanner', () => {
         pageMock.setup(async (b) => b.close()).verifiable();
     }
 
+    function setupPageNavigateCall(url: string): void {
+        pageMock.setup((p) => p.navigateToUrl(url)).verifiable(Times.once());
+    }
+
     function setupPageScanCall(url: string, axeResults: AxeResults): void {
         pageMock
-            .setup(async (p) => p.scanForA11yIssues(url, undefined))
+            .setup(async (p) => p.scanForA11yIssues(undefined))
             .returns(async () => Promise.resolve({ results: axeResults }))
             .verifiable(Times.once());
     }
 
     function setupPageErrorScanCall(url: string, errorMessage: string): void {
         pageMock
-            .setup(async (p) => p.scanForA11yIssues(url, undefined))
+            .setup(async (p) => p.scanForA11yIssues(undefined))
             .returns(async () => Promise.resolve({ error: errorMessage }))
             .verifiable(Times.once());
     }

--- a/packages/cli/src/scanner/ai-scanner.ts
+++ b/packages/cli/src/scanner/ai-scanner.ts
@@ -12,8 +12,9 @@ export class AIScanner {
         try {
             console.log(`Starting accessibility scanning of URL ${url}`);
             await this.page.create(chromePath);
+            await this.page.navigateToUrl(url);
 
-            return await this.page.scanForA11yIssues(url, sourcePath);
+            return await this.page.scanForA11yIssues(sourcePath);
         } catch (error) {
             console.log(error, `An error occurred while scanning website page ${url}`);
 

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -64,6 +64,14 @@ export class Page {
         }
     }
 
+    public getUnderlyingPage(): Puppeteer.Page | null {
+        if (!isNil(this.lastBrowserError) || isNil(this.navigationResponse) || isNil(this.page)) {
+            return null;
+        }
+
+        return this.page;
+    }
+
     private async scanPageForIssues(contentSourcePath?: string): Promise<AxeScanResults> {
         const axePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.page, contentSourcePath);
         let axeResults: axe.AxeResults;

--- a/packages/web-api-scan-runner/src/scanner/scanner.spec.ts
+++ b/packages/web-api-scan-runner/src/scanner/scanner.spec.ts
@@ -48,8 +48,9 @@ describe('Scanner', () => {
             const url = 'some url';
             const axeResultsStub = ('axe results' as any) as AxeResults;
 
-            setupNewPageCall(url);
-            setupPageScanCall(url, axeResultsStub);
+            setupNewPageCall();
+            setupPageNavigateCall(url);
+            setupPageScanCall(axeResultsStub);
             setupWaitForPromisetoReturnOriginalPromise();
 
             await scanner.scan(url);
@@ -60,9 +61,10 @@ describe('Scanner', () => {
         it('should close browser if exception occurs', async () => {
             const url = 'some url';
             const errorMessage: string = `An error occurred while scanning website page ${url}.`;
-            const axeScanResults = setupPageErrorScanCall(url, errorMessage);
+            const axeScanResults = setupPageErrorScanCall(errorMessage);
 
-            setupNewPageCall(url);
+            setupNewPageCall();
+            setupPageNavigateCall(url);
             setupPageCloseCall();
             setupWaitForPromisetoReturnOriginalPromise();
             loggerMock
@@ -86,8 +88,9 @@ describe('Scanner', () => {
             const url = 'some url';
             const errorMessage: string = `An error occurred while scanning website page ${url}.`;
 
-            setupNewPageCall(url);
-            setupPageErrorScanCall(url, errorMessage);
+            setupNewPageCall();
+            setupPageNavigateCall(url);
+            setupPageErrorScanCall(errorMessage);
             setupPageCloseCall();
             setupWaitForPromiseToReturnTimeoutPromise();
 
@@ -126,7 +129,7 @@ describe('Scanner', () => {
         }
     });
 
-    function setupNewPageCall(url: string): void {
+    function setupNewPageCall(): void {
         pageMock.setup(async (p) => p.create()).verifiable(Times.once());
     }
 
@@ -134,17 +137,21 @@ describe('Scanner', () => {
         pageMock.setup(async (b) => b.close()).verifiable();
     }
 
-    function setupPageScanCall(url: string, axeResults: AxeResults): void {
+    function setupPageNavigateCall(url: string): void {
+        pageMock.setup((p) => p.navigateToUrl(url)).verifiable(Times.once());
+    }
+
+    function setupPageScanCall(axeResults: AxeResults): void {
         pageMock
-            .setup(async (p) => p.scanForA11yIssues(url))
+            .setup(async (p) => p.scanForA11yIssues())
             .returns(async () => Promise.resolve({ results: axeResults, pageResponseCode: 101 }))
             .verifiable(Times.once());
     }
 
-    function setupPageErrorScanCall(url: string, errorMessage: string): AxeScanResults {
+    function setupPageErrorScanCall(errorMessage: string): AxeScanResults {
         const error = { error: errorMessage, pageResponseCode: 101 };
         pageMock
-            .setup(async (p) => p.scanForA11yIssues(url))
+            .setup(async (p) => p.scanForA11yIssues())
             .returns(async () => Promise.reject(error))
             .verifiable(Times.once());
 

--- a/packages/web-api-scan-runner/src/scanner/scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/scanner.ts
@@ -32,7 +32,8 @@ export class Scanner {
         try {
             this.logger.logInfo(`Starting accessibility website page scanning.`, { url });
             await this.page.create();
-            const scanResult = await this.page.scanForA11yIssues(url);
+            await this.page.navigateToUrl(url);
+            const scanResult = await this.page.scanForA11yIssues();
             this.logger.logInfo(`Accessibility scanning of website page successfully completed.`, { url });
 
             return scanResult;


### PR DESCRIPTION
#### Description of changes

- Separate page scanning from page navigation
- Expose the underlying puppeteer page so we can access it when crawling
- Move Page from Scanner into Runner, so it can be passed to the crawler when we add that step

#### Pull request checklist

- [x] Addresses an existing issue: #1808725
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
