### PR TITLE
fix: container setup function name

### DIFF
--- a/packages/web-api-scan-runner/src/index.ts
+++ b/packages/web-api-scan-runner/src/index.ts
@@ -5,11 +5,11 @@ import 'reflect-metadata';
 import './module-name-mapper';
 
 import { System } from 'common';
-import { setupWebApiScanRequestSenderContainer } from './setup-web-api-scan-runner-container';
+import { setupWebApiScanRunnerContainer } from './setup-web-api-scan-runner-container';
 import { WebApiScanRunnerEntryPoint } from './web-api-scan-runner-entry-point';
 
 (async () => {
-    await new WebApiScanRunnerEntryPoint(setupWebApiScanRequestSenderContainer()).start();
+    await new WebApiScanRunnerEntryPoint(setupWebApiScanRunnerContainer()).start();
 })().catch((error) => {
     console.log(System.serializeError(error));
     process.exitCode = 1;

--- a/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.spec.ts
+++ b/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.spec.ts
@@ -4,18 +4,18 @@ import 'reflect-metadata';
 
 import { ServiceConfiguration } from 'common';
 import { Runner } from './runner/runner';
-import { setupWebApiScanRequestSenderContainer } from './setup-web-api-scan-runner-container';
+import { setupWebApiScanRunnerContainer } from './setup-web-api-scan-runner-container';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-describe(setupWebApiScanRequestSenderContainer, () => {
+describe(setupWebApiScanRunnerContainer, () => {
     it('resolves runner dependencies', () => {
-        const container = setupWebApiScanRequestSenderContainer();
+        const container = setupWebApiScanRunnerContainer();
 
         expect(container.get(Runner)).toBeDefined();
     });
 
     it('resolves singleton dependencies', () => {
-        const container = setupWebApiScanRequestSenderContainer();
+        const container = setupWebApiScanRunnerContainer();
 
         const serviceConfig = container.get(ServiceConfiguration);
 

--- a/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
+++ b/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
@@ -7,7 +7,7 @@ import { registerLoggerToContainer } from 'logger';
 import { registerScannerToContainer } from 'scanner-global-library';
 import { registerReportGeneratorToContainer } from './report-generator/register-report-generator-to-container';
 
-export function setupWebApiScanRequestSenderContainer(): inversify.Container {
+export function setupWebApiScanRunnerContainer(): inversify.Container {
     const container = new inversify.Container({ autoBindInjectable: true });
     setupRuntimeConfigContainer(container);
     registerLoggerToContainer(container);


### PR DESCRIPTION
#### Description of changes

Rename the container setup function in web-api-scan-runner to "setupWebApiScanRunnerContainer"

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
