### PR TITLE
refactor(cloud-crawler): create combined report generator

### DIFF
--- a/packages/web-api-scan-runner/src/runner/combined-report-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-report-generator.spec.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import 'reflect-metadata';
-
 import { GuidGenerator } from 'common';
 import { AxeScanResults } from 'scanner-global-library';
 import { PageScanRunReportProvider } from 'service-library';
-import { CombinedScanResults, WebsiteScanReport, WebsiteScanResult } from 'storage-documents';
+import { CombinedScanResults, WebsiteScanResult } from 'storage-documents';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
 import { MockableLogger } from '../test-utilities/mockable-logger';

--- a/packages/web-api-scan-runner/src/runner/combined-report-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-report-generator.spec.ts
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { GuidGenerator } from 'common';
+import { AxeScanResults } from 'scanner-global-library';
+import { PageScanRunReportProvider } from 'service-library';
+import { CombinedScanResults, WebsiteScanReport, WebsiteScanResult } from 'storage-documents';
+import { IMock, Mock, MockBehavior } from 'typemoq';
+import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { CombinedReportGenerator } from './combined-report-generator';
+
+describe(CombinedReportGenerator, () => {
+    let loggerMock: IMock<MockableLogger>;
+    let pageScanRunReportProviderMock: IMock<PageScanRunReportProvider>;
+    let guidGeneratorMock: IMock<GuidGenerator>;
+    let reportGeneratorMock: IMock<ReportGenerator>;
+
+    let scanStarted: Date;
+    let websiteScanResult: WebsiteScanResult;
+    let combinedScanResults: CombinedScanResults;
+    let generatedReportStub: GeneratedReport;
+    const baseUrl = 'baseUrl';
+    const passedAxeScanResults: AxeScanResults = {
+        userAgent: 'userAgent',
+        browserResolution: '1920x1080',
+    };
+    let hrefStub: string;
+
+    let testSubject: CombinedReportGenerator;
+
+    beforeEach(() => {
+        scanStarted = new Date(2020, 11, 12);
+        loggerMock = Mock.ofType(MockableLogger);
+        guidGeneratorMock = Mock.ofType(GuidGenerator);
+        pageScanRunReportProviderMock = Mock.ofType(PageScanRunReportProvider, MockBehavior.Strict);
+        reportGeneratorMock = Mock.ofType<ReportGenerator>();
+
+        websiteScanResult = {
+            baseUrl,
+            pageScans: [{ timestamp: scanStarted.toISOString() }],
+            _etag: 'etag',
+        } as WebsiteScanResult;
+
+        combinedScanResults = {
+            urlCount: {
+                total: 1,
+                passed: 1,
+            },
+            axeResults: {},
+        } as CombinedScanResults;
+
+        generatedReportStub = {
+            content: 'consolidated report content',
+            format: 'consolidated.html',
+        } as GeneratedReport;
+
+        hrefStub = 'href-stub';
+
+        testSubject = new CombinedReportGenerator(
+            guidGeneratorMock.object,
+            loggerMock.object,
+            reportGeneratorMock.object,
+            pageScanRunReportProviderMock.object,
+        );
+    });
+
+    afterEach(() => {
+        guidGeneratorMock.verifyAll();
+        loggerMock.verifyAll();
+        pageScanRunReportProviderMock.verifyAll();
+        reportGeneratorMock.verifyAll();
+    });
+
+    it('generate combined scan report with existing combined result', async () => {
+        const reportId = 'existing-report-id';
+        websiteScanResult.reports = [
+            {
+                reportId,
+                href: hrefStub,
+                format: 'consolidated.html',
+            },
+        ];
+
+        setupSaveReportCall(generatedReportStub, hrefStub);
+        setupGetConsolidatedReportCall(reportId);
+
+        await testSubject.generate(
+            combinedScanResults,
+            websiteScanResult,
+            passedAxeScanResults.userAgent,
+            passedAxeScanResults.browserResolution,
+        );
+    });
+
+    it('generate combined scan report with non-existing combined result', async () => {
+        const reportId = 'new-report-id';
+
+        guidGeneratorMock.setup((mock) => mock.createGuid()).returns(() => reportId);
+        setupSaveReportCall(generatedReportStub, hrefStub);
+        setupGetConsolidatedReportCall(reportId);
+
+        await testSubject.generate(
+            combinedScanResults,
+            websiteScanResult,
+            passedAxeScanResults.userAgent,
+            passedAxeScanResults.browserResolution,
+        );
+    });
+
+    it('generate combined scan report with combined result without reports', async () => {
+        const reportId = 'new-report-id';
+        websiteScanResult.reports = [];
+
+        guidGeneratorMock.setup((mock) => mock.createGuid()).returns(() => reportId);
+        setupSaveReportCall(generatedReportStub, hrefStub);
+        setupGetConsolidatedReportCall(reportId);
+
+        await testSubject.generate(
+            combinedScanResults,
+            websiteScanResult,
+            passedAxeScanResults.userAgent,
+            passedAxeScanResults.browserResolution,
+        );
+    });
+
+    function setupGetConsolidatedReportCall(givenReportId: string): void {
+        reportGeneratorMock
+            .setup((r) =>
+                r.generateConsolidatedReport(combinedScanResults, {
+                    reportId: givenReportId,
+                    baseUrl,
+                    userAgent: passedAxeScanResults.userAgent,
+                    browserResolution: passedAxeScanResults.browserResolution,
+                    scanStarted,
+                }),
+            )
+            .returns(() => generatedReportStub);
+    }
+
+    function setupSaveReportCall(report: GeneratedReport, href: string): void {
+        pageScanRunReportProviderMock
+            .setup(async (s) => s.saveReport(report.id, report.content))
+            .returns(async () => Promise.resolve(href))
+            .verifiable();
+    }
+});

--- a/packages/web-api-scan-runner/src/runner/combined-report-generator.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-report-generator.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 import { GuidGenerator } from 'common';
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { CombinedScanResults, WebsiteScanResult } from 'storage-documents';
 import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
 
+@injectable()
 export class CombinedReportGenerator {
     public constructor(
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,

--- a/packages/web-api-scan-runner/src/runner/combined-report-generator.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-report-generator.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { GuidGenerator } from 'common';
+import { inject } from 'inversify';
+import { GlobalLogger } from 'logger';
+import { PageScanRunReportProvider } from 'service-library';
+import { CombinedScanResults, OnDemandPageScanReport, WebsiteScanResult } from 'storage-documents';
+import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
+
+export class CombinedReportGenerator {
+    public constructor(
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
+        @inject(PageScanRunReportProvider) private readonly pageScanRunReportProvider: PageScanRunReportProvider,
+    ) {}
+
+    public async generate(
+        combinedAxeResults: CombinedScanResults,
+        websiteScanResult: WebsiteScanResult,
+        userAgent: string,
+        browserResolution: string,
+    ): Promise<OnDemandPageScanReport> {
+        let reportId: string;
+        if (websiteScanResult.reports) {
+            reportId = websiteScanResult.reports.find((ref) => ref.format === 'consolidated.html')?.reportId;
+        }
+
+        reportId = reportId ?? this.guidGenerator.createGuid();
+        const scanStarted = new Date(Math.min(...websiteScanResult.pageScans.map((pageScan) => new Date(pageScan.timestamp).valueOf())));
+
+        this.logger.logInfo(`Generating combined reports from scan results.`);
+        const report = this.reportGenerator.generateConsolidatedReport(combinedAxeResults, {
+            reportId,
+            baseUrl: websiteScanResult.baseUrl,
+            userAgent,
+            browserResolution,
+            scanStarted,
+        });
+
+        return this.saveScanReport(report);
+    }
+
+    private async saveScanReport(report: GeneratedReport): Promise<OnDemandPageScanReport> {
+        const href = await this.pageScanRunReportProvider.saveReport(report.id, report.content);
+        this.logger.logInfo(`The '${report.format}' report saved to a blob storage.`, { reportId: report.id, blobUrl: href });
+
+        return {
+            format: report.format,
+            href,
+            reportId: report.id,
+        };
+    }
+}

--- a/packages/web-api-scan-runner/src/runner/combined-report-generator.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-report-generator.ts
@@ -4,8 +4,7 @@
 import { GuidGenerator } from 'common';
 import { inject } from 'inversify';
 import { GlobalLogger } from 'logger';
-import { PageScanRunReportProvider } from 'service-library';
-import { CombinedScanResults, OnDemandPageScanReport, WebsiteScanResult } from 'storage-documents';
+import { CombinedScanResults, WebsiteScanResult } from 'storage-documents';
 import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
 
 export class CombinedReportGenerator {
@@ -13,15 +12,14 @@ export class CombinedReportGenerator {
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
-        @inject(PageScanRunReportProvider) private readonly pageScanRunReportProvider: PageScanRunReportProvider,
     ) {}
 
-    public async generate(
+    public generate(
         combinedAxeResults: CombinedScanResults,
         websiteScanResult: WebsiteScanResult,
         userAgent: string,
         browserResolution: string,
-    ): Promise<OnDemandPageScanReport> {
+    ): GeneratedReport {
         let reportId: string;
         if (websiteScanResult.reports) {
             reportId = websiteScanResult.reports.find((ref) => ref.format === 'consolidated.html')?.reportId;
@@ -39,17 +37,6 @@ export class CombinedReportGenerator {
             scanStarted,
         });
 
-        return this.saveScanReport(report);
-    }
-
-    private async saveScanReport(report: GeneratedReport): Promise<OnDemandPageScanReport> {
-        const href = await this.pageScanRunReportProvider.saveReport(report.id, report.content);
-        this.logger.logInfo(`The '${report.format}' report saved to a blob storage.`, { reportId: report.id, blobUrl: href });
-
-        return {
-            format: report.format,
-            href,
-            reportId: report.id,
-        };
+        return report;
     }
 }

--- a/packages/web-api-scan-runner/src/runner/report-saver.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/report-saver.spec.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+import { PageScanRunReportProvider } from 'service-library';
+import { IMock, Mock, MockBehavior } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { ReportSaver } from './report-saver';
+import { GeneratedReport } from '../report-generator/report-generator';
+import { OnDemandPageScanReport } from 'storage-documents';
+
+describe(ReportSaver, () => {
+    let loggerMock: IMock<MockableLogger>;
+    let pageScanRunReportProviderMock: IMock<PageScanRunReportProvider>;
+    let testSubject: ReportSaver;
+
+    let hrefStub: string;
+
+    beforeEach(() => {
+        pageScanRunReportProviderMock = Mock.ofType(PageScanRunReportProvider, MockBehavior.Strict);
+        loggerMock = Mock.ofType(MockableLogger);
+        hrefStub = 'some-href';
+
+        testSubject = new ReportSaver(loggerMock.object, pageScanRunReportProviderMock.object);
+    });
+
+    test('save report', async () => {
+        const generatedReportStub = {
+            content: 'consolidated report content',
+            format: 'consolidated.html',
+            id: 'some-id',
+        } as GeneratedReport;
+
+        const expectedReport: OnDemandPageScanReport = {
+            format: generatedReportStub.format,
+            reportId: generatedReportStub.id,
+            href: hrefStub,
+        };
+
+        setupSaveReportCall(generatedReportStub, hrefStub);
+
+        expect(await testSubject.save(generatedReportStub)).toEqual(expectedReport);
+    });
+
+    function setupSaveReportCall(report: GeneratedReport, href: string): void {
+        pageScanRunReportProviderMock
+            .setup(async (s) => s.saveReport(report.id, report.content))
+            .returns(async () => Promise.resolve(href))
+            .verifiable();
+    }
+});

--- a/packages/web-api-scan-runner/src/runner/report-saver.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/report-saver.spec.ts
@@ -4,10 +4,10 @@
 import 'reflect-metadata';
 import { PageScanRunReportProvider } from 'service-library';
 import { IMock, Mock, MockBehavior } from 'typemoq';
-import { MockableLogger } from '../test-utilities/mockable-logger';
-import { ReportSaver } from './report-saver';
-import { GeneratedReport } from '../report-generator/report-generator';
 import { OnDemandPageScanReport } from 'storage-documents';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { GeneratedReport } from '../report-generator/report-generator';
+import { ReportSaver } from './report-saver';
 
 describe(ReportSaver, () => {
     let loggerMock: IMock<MockableLogger>;

--- a/packages/web-api-scan-runner/src/runner/report-saver.ts
+++ b/packages/web-api-scan-runner/src/runner/report-saver.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inject, injectable } from 'inversify';
+import { GlobalLogger } from 'logger';
+import { PageScanRunReportProvider } from 'service-library';
+import { OnDemandPageScanReport } from 'storage-documents';
+import { GeneratedReport } from '../report-generator/report-generator';
+
+@injectable()
+export class ReportSaver {
+    public constructor(
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(PageScanRunReportProvider) private readonly pageScanRunReportProvider: PageScanRunReportProvider,
+    ) {}
+
+    public async save(report: GeneratedReport): Promise<OnDemandPageScanReport> {
+        const href = await this.pageScanRunReportProvider.saveReport(report.id, report.content);
+        this.logger.logInfo(`The '${report.format}' report saved to a blob storage.`, { reportId: report.id, blobUrl: href });
+
+        return {
+            format: report.format,
+            href,
+            reportId: report.id,
+        };
+    }
+}


### PR DESCRIPTION
#### Description of changes

This is creating a component responsible for generating combined scan report (currently done in runner).

This does not update the runner as this will not be consumed by the runner (but another component instead).

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
