### PR TITLE
feat(cloud-crawler): Create CrawlRunner class to manage crawling during a run

### DIFF
--- a/packages/crawler/src/crawler.ts
+++ b/packages/crawler/src/crawler.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Container } from 'inversify';
+import { interfaces } from 'inversify';
 import { CrawlerEngine } from './crawler/crawler-engine';
 import { registerCrawlerRunOptions } from './setup-crawler-container';
 import { CrawlerRunOptions } from './types/crawler-run-options';
 import { iocTypes } from './types/ioc-types';
 
 export class Crawler<T> {
-    constructor(private readonly container: Container) {}
+    constructor(private readonly container: interfaces.Container) {}
 
     public async crawl(crawlerRunOptions: CrawlerRunOptions): Promise<T> {
         registerCrawlerRunOptions(this.container, crawlerRunOptions);

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -5,6 +5,9 @@
 import './global-overrides';
 
 export { CrawlerRunOptions } from './types/crawler-run-options';
+export { SimpleCrawlerRunOptions } from './crawler/simple-crawler-engine';
+
+export { iocTypes } from './types/ioc-types';
 export { Crawler } from './crawler';
 export { setupLocalCrawlerContainer, setupCloudCrawlerContainer } from './setup-crawler-container';
 export * from './level-storage/storage-documents';

--- a/packages/crawler/src/setup-crawler-container.ts
+++ b/packages/crawler/src/setup-crawler-container.ts
@@ -3,6 +3,7 @@
 import { reporterFactory } from 'accessibility-insights-report';
 import * as inversify from 'inversify';
 import { ApifyResourceCreator } from './apify/apify-resource-creator';
+import { Crawler } from './crawler';
 import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
 import { SimpleCrawlerEngine } from './crawler/simple-crawler-engine';
 import { DataBase } from './level-storage/data-base';
@@ -58,12 +59,17 @@ export function setupCloudCrawlerContainer(container: inversify.Container): inve
             crawlerRunOptions.inputUrls,
         );
     });
+
     container.bind(iocTypes.RequestProcessor).to(UrlCollectionRequestProcessor);
+
+    setupSingletonProvider(iocTypes.CrawlerProvider, container, async (context: inversify.interfaces.Context) => {
+        return new Crawler(context.container);
+    });
 
     return container;
 }
 
-export function registerCrawlerRunOptions(container: inversify.Container, crawlerRunOptions: CrawlerRunOptions): void {
+export function registerCrawlerRunOptions(container: inversify.interfaces.Container, crawlerRunOptions: CrawlerRunOptions): void {
     container.bind(iocTypes.CrawlerRunOptions).toConstantValue(crawlerRunOptions);
 }
 

--- a/packages/crawler/src/types/ioc-types.ts
+++ b/packages/crawler/src/types/ioc-types.ts
@@ -13,6 +13,7 @@ export const iocTypes = {
     LevelUp: 'levelup.LevelUp',
     CrawlerEngine: 'CrawlerEngine',
     RequestProcessor: 'RequestProcessor',
+    CrawlerProvider: 'CrawlerProvider',
 };
 
 export type PageProcessorFactory = () => PageProcessorBase;

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -50,8 +50,10 @@
     },
     "dependencies": {
         "@axe-core/puppeteer": "^4.1.0",
-        "@azure/cosmos": "^3.9.5",
+"@azure/cosmos": "^3.9.3",
+        "accessibility-insights-crawler": "^1.0.0",
         "accessibility-insights-report": "4.0.0",
+        "apify": "^0.21.8",
         "applicationinsights": "^1.8.8",
         "axe-core": "4.1.1",
         "axe-sarif-converter": "^2.6.0",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "@axe-core/puppeteer": "^4.1.0",
-"@azure/cosmos": "^3.9.3",
+        "@azure/cosmos": "^3.9.3",
         "accessibility-insights-crawler": "^1.0.0",
         "accessibility-insights-report": "4.0.0",
         "apify": "^0.21.8",

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
@@ -32,10 +32,13 @@ describe('CrawlRunner', () => {
 
     beforeEach(() => {
         loggerMock = Mock.ofType<GlobalLogger>(undefined, MockBehavior.Loose);
-        loggerMock.setup((m) => m.setCommonProperties({ scanId: scanId }));
+        loggerMock.setup((m) => m.setCommonProperties({ scanId: scanId })).verifiable();
 
         scanMetaDataConfigMock = Mock.ofType<ScanMetadataConfig>(undefined, MockBehavior.Strict);
-        scanMetaDataConfigMock.setup((m) => m.getConfig()).returns(() => ({ id: scanId } as ScanMetadata));
+        scanMetaDataConfigMock
+            .setup((m) => m.getConfig())
+            .returns(() => ({ id: scanId } as ScanMetadata))
+            .verifiable();
     });
 
     afterEach(() => {
@@ -55,7 +58,10 @@ describe('CrawlRunner', () => {
 
     it('returns undefined if crawler throws exception', async () => {
         const crawlerMock = Mock.ofType(CrawlerMock);
-        crawlerMock.setup((m) => m.crawl(It.isAny())).throws(Error());
+        crawlerMock
+            .setup((m) => m.crawl(It.isAny()))
+            .throws(Error())
+            .verifiable();
 
         const crawlerProviderMock = createCrawlerProviderMock(crawlerMock.object);
 
@@ -83,7 +89,8 @@ describe('CrawlRunner', () => {
         crawlerMock
             .setup((m) => m.crawl(It.isAny()))
             .callback((runOptions) => (actualRunOptions = runOptions))
-            .returns(async () => expectedRetVal);
+            .returns(async () => expectedRetVal)
+            .verifiable();
 
         const crawlerProviderMock = createCrawlerProviderMock(crawlerMock.object);
 
@@ -100,7 +107,9 @@ describe('CrawlRunner', () => {
 
     function createCrawlerProviderMock(crawler: Crawler<string[]> | null): IMock<CrawlerProvider> {
         const crawlerProviderMock = Mock.ofType<CrawlerProvider>();
-        crawlerProviderMock.setup((m) => m()).returns(async () => crawler);
+        crawlerProviderMock.setup((m) => m())
+        .returns(async () => crawler)
+        .verifiable();
 
         return crawlerProviderMock;
     }

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
@@ -107,9 +107,10 @@ describe('CrawlRunner', () => {
 
     function createCrawlerProviderMock(crawler: Crawler<string[]> | null): IMock<CrawlerProvider> {
         const crawlerProviderMock = Mock.ofType<CrawlerProvider>();
-        crawlerProviderMock.setup((m) => m())
-        .returns(async () => crawler)
-        .verifiable();
+        crawlerProviderMock
+            .setup((m) => m())
+            .returns(async () => crawler)
+            .verifiable();
 
         return crawlerProviderMock;
     }

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
@@ -101,13 +101,11 @@ describe('CrawlRunner', () => {
             maxRequestsPerCrawl: urlCrawlLimit,
         } as SimpleCrawlerRunOptions;
 
-        let actualRunOptions: SimpleCrawlerRunOptions;
         const expectedRetVal = ['discoveredUrl'];
 
         const crawlerMock = Mock.ofType(CrawlerMock);
         crawlerMock
-            .setup((m) => m.crawl(It.isAny()))
-            .callback((runOptions) => (actualRunOptions = runOptions))
+            .setup((m) => m.crawl(expectedRunOptions))
             .returns(async () => expectedRetVal)
             .verifiable();
 
@@ -124,7 +122,6 @@ describe('CrawlRunner', () => {
 
         const actualRetVal = await crawlRunner.run(baseUrl, discoveryPatterns, page);
 
-        expect(actualRunOptions).toMatchObject(expectedRunOptions);
         expect(actualRetVal).toBe(expectedRetVal);
 
         crawlerProviderMock.verifyAll();

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Crawler, SimpleCrawlerRunOptions } from 'accessibility-insights-crawler';
+import { GlobalLogger } from 'logger';
+import { Page } from 'puppeteer';
+import { IMock, It, Mock, MockBehavior } from 'typemoq';
+import { ScanMetadataConfig } from '../scan-metadata-config';
+import { ScanMetadata } from '../types/scan-metadata';
+import { CrawlRunner } from './crawl-runner';
+
+// This class exists because trying to mock a Crawler without it
+// caused an unexplained timeout while calling the real Crawler class' constructor
+class CrawlerMock extends Crawler<string[]> {
+    constructor() {
+        super(null);
+    }
+}
+
+type CrawlerProvider = () => Promise<Crawler<string[]>>;
+
+describe('CrawlRunner', () => {
+    const scanId = 'testId';
+    const baseUrl = 'testUrl';
+    const discoveryPatterns = ['testPattern'];
+    const page = {} as Page;
+
+    let loggerMock: IMock<GlobalLogger>;
+    let scanMetaDataConfigMock: IMock<ScanMetadataConfig>;
+
+    beforeEach(() => {
+        loggerMock = Mock.ofType<GlobalLogger>(undefined, MockBehavior.Loose);
+        loggerMock.setup((m) => m.setCommonProperties({ scanId: scanId }));
+
+        scanMetaDataConfigMock = Mock.ofType<ScanMetadataConfig>(undefined, MockBehavior.Strict);
+        scanMetaDataConfigMock.setup((m) => m.getConfig()).returns(() => ({ id: scanId } as ScanMetadata));
+    });
+
+    afterEach(() => {
+        loggerMock.verifyAll();
+        scanMetaDataConfigMock.verifyAll();
+    });
+
+    it('returns undefined when crawler provider returns null', async () => {
+        const crawlerProviderMock = createCrawlerProviderMock(null);
+
+        const crawlRunner = new CrawlRunner(crawlerProviderMock.object, loggerMock.object, scanMetaDataConfigMock.object);
+
+        expect(await crawlRunner.run(baseUrl, discoveryPatterns, page)).toBeUndefined();
+
+        crawlerProviderMock.verifyAll();
+    });
+
+    it('returns undefined if crawler throws exception', async () => {
+        const crawlerMock = Mock.ofType(CrawlerMock);
+        crawlerMock.setup((m) => m.crawl(It.isAny())).throws(Error());
+
+        const crawlerProviderMock = createCrawlerProviderMock(crawlerMock.object);
+
+        const crawlRunner = new CrawlRunner(crawlerProviderMock.object, loggerMock.object, scanMetaDataConfigMock.object);
+
+        const retVal = await crawlRunner.run(baseUrl, discoveryPatterns, page);
+
+        expect(retVal).toBeUndefined();
+
+        crawlerProviderMock.verifyAll();
+        crawlerMock.verifyAll();
+    });
+
+    it('crawler receives expected data and run returns value from crawler', async () => {
+        const expectedRunOptions = {
+            baseUrl,
+            discoveryPatterns,
+            page,
+        } as SimpleCrawlerRunOptions;
+
+        let actualRunOptions: SimpleCrawlerRunOptions;
+        const expectedRetVal = ['discoveredUrl'];
+
+        const crawlerMock = Mock.ofType(CrawlerMock);
+        crawlerMock
+            .setup((m) => m.crawl(It.isAny()))
+            .callback((runOptions) => (actualRunOptions = runOptions))
+            .returns(async () => expectedRetVal);
+
+        const crawlerProviderMock = createCrawlerProviderMock(crawlerMock.object);
+
+        const crawlRunner = new CrawlRunner(crawlerProviderMock.object, loggerMock.object, scanMetaDataConfigMock.object);
+
+        const actualRetVal = await crawlRunner.run(baseUrl, discoveryPatterns, page);
+
+        expect(actualRunOptions).toMatchObject(expectedRunOptions);
+        expect(actualRetVal).toBe(expectedRetVal);
+
+        crawlerProviderMock.verifyAll();
+        crawlerMock.verifyAll();
+    });
+
+    function createCrawlerProviderMock(crawler: Crawler<string[]> | null): IMock<CrawlerProvider> {
+        const crawlerProviderMock = Mock.ofType<CrawlerProvider>();
+        crawlerProviderMock.setup((m) => m()).returns(async () => crawler);
+
+        return crawlerProviderMock;
+    }
+});

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -45,7 +45,7 @@ export class CrawlRunner {
             return undefined;
         }
 
-        this.logger.logInfo('Web page crawling completed successfully');
+        this.logger.logInfo(`Web page crawling completed successfully. Found ${retVal ? retVal.length : 0} urls.`);
 
         return retVal;
     }

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -40,8 +40,7 @@ export class CrawlRunner {
         try {
             retVal = await crawler.crawl(crawlerRunOptions);
         } catch (ex) {
-            this.logger.logError('Exception thrown during crawl');
-            this.logger.logInfo(ex);
+            this.logger.logError('Failure while crawling web page', { error: JSON.stringify(ex) });
 
             return undefined;
         }

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { GlobalLogger } from 'logger';
+import { inject, injectable } from 'inversify';
+import { Crawler, iocTypes as crawlerIocTypes, SimpleCrawlerRunOptions } from 'accessibility-insights-crawler';
+import { Page } from 'puppeteer';
+import { ScanMetadataConfig } from '../scan-metadata-config';
+
+type CrawlerProvider = () => Promise<Crawler<string[]>>;
+
+@injectable()
+export class CrawlRunner {
+    constructor(
+        @inject(crawlerIocTypes.CrawlerProvider) private readonly getCrawler: CrawlerProvider,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(ScanMetadataConfig) scanMetadataConfig: ScanMetadataConfig,
+    ) {
+        const scanMetadata = scanMetadataConfig.getConfig();
+        this.logger.setCommonProperties({ scanId: scanMetadata.id });
+    }
+
+    public async run(baseUrl: string, discoveryPatterns: string[], page: Page): Promise<string[] | undefined> {
+        const crawler = await this.getCrawler();
+        if (crawler == null) {
+            this.logger.logInfo('No crawler provided by crawler provider');
+
+            return undefined;
+        }
+
+        const crawlerRunOptions = {
+            baseUrl,
+            discoveryPatterns,
+            page,
+        } as SimpleCrawlerRunOptions;
+
+        this.logger.logInfo('begin crawl');
+
+        let retVal: string[] | undefined;
+
+        try {
+            retVal = await crawler.crawl(crawlerRunOptions);
+        } catch (ex) {
+            this.logger.logError('Exception thrown during crawl');
+            this.logger.logInfo(ex);
+
+            return undefined;
+        }
+
+        this.logger.logInfo('crawl succeeded');
+
+        return retVal;
+    }
+}

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -6,7 +6,6 @@ import { inject, injectable } from 'inversify';
 import { Crawler, iocTypes as crawlerIocTypes, SimpleCrawlerRunOptions } from 'accessibility-insights-crawler';
 import { Page } from 'puppeteer';
 import { ScanMetadataConfig } from '../scan-metadata-config';
-import { System } from 'common';
 type CrawlerProvider = () => Promise<Crawler<string[]>>;
 
 @injectable()

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -6,7 +6,7 @@ import { inject, injectable } from 'inversify';
 import { Crawler, iocTypes as crawlerIocTypes, SimpleCrawlerRunOptions } from 'accessibility-insights-crawler';
 import { Page } from 'puppeteer';
 import { ScanMetadataConfig } from '../scan-metadata-config';
-
+import { System } from 'common';
 type CrawlerProvider = () => Promise<Crawler<string[]>>;
 
 @injectable()
@@ -34,7 +34,7 @@ export class CrawlRunner {
             page,
         } as SimpleCrawlerRunOptions;
 
-        this.logger.logInfo('begin crawl');
+        this.logger.logInfo('Starting web page crawling');
 
         let retVal: string[] | undefined;
 
@@ -47,7 +47,7 @@ export class CrawlRunner {
             return undefined;
         }
 
-        this.logger.logInfo('crawl succeeded');
+        this.logger.logInfo('Web page crawling completed successfully');
 
         return retVal;
     }

--- a/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
+++ b/packages/web-api-scan-runner/src/setup-web-api-scan-runner-container.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { setupCloudCrawlerContainer } from 'accessibility-insights-crawler';
 import { registerAzureServicesToContainer } from 'azure-services';
 import { setupRuntimeConfigContainer } from 'common';
 import * as inversify from 'inversify';
@@ -14,6 +15,7 @@ export function setupWebApiScanRunnerContainer(): inversify.Container {
     registerAzureServicesToContainer(container);
     registerScannerToContainer(container);
     registerReportGeneratorToContainer(container);
+    setupCloudCrawlerContainer(container);
 
     return container;
 }

--- a/packages/web-api-scan-runner/webpack.config.js
+++ b/packages/web-api-scan-runner/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = (env) => {
 
     return {
         devtool: 'cheap-source-map',
-        externals: ['puppeteer', 'yargs', 'axe-core', '@axe-core/puppeteer', 'applicationinsights', 'accessibility-insights-report'],
+        externals: ['puppeteer', 'yargs', 'axe-core', '@axe-core/puppeteer', 'applicationinsights', 'accessibility-insights-report', 'apify'],
         entry: {
             ['web-api-scan-runner']: path.resolve('./src/index.ts'),
         },

--- a/packages/web-api-scan-runner/webpack.config.js
+++ b/packages/web-api-scan-runner/webpack.config.js
@@ -11,7 +11,15 @@ module.exports = (env) => {
 
     return {
         devtool: 'cheap-source-map',
-        externals: ['puppeteer', 'yargs', 'axe-core', '@axe-core/puppeteer', 'applicationinsights', 'accessibility-insights-report', 'apify'],
+        externals: [
+            'puppeteer',
+            'yargs',
+            'axe-core',
+            '@axe-core/puppeteer',
+            'applicationinsights',
+            'accessibility-insights-report',
+            'apify',
+        ],
         entry: {
             ['web-api-scan-runner']: path.resolve('./src/index.ts'),
         },


### PR DESCRIPTION
#### Description of changes



At present, this class manages logging and error handling for crawling during a run. In future, it can also manage adding known urls to scan results.

Note: In a few places, the use of `inversify.Container` was changed to `inversify.interfaces.Container` because functions which create the crawler only have the interface type available.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
