### PR TITLE
refactor(cloud-crawler): refactor out axe result merger of runner

### DIFF
--- a/packages/web-api-scan-runner/src/runner/axe-result-merger.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/axe-result-merger.spec.ts
@@ -5,7 +5,6 @@ import axe, { AxeResults } from 'axe-core';
 import { AxeResultsReducer } from 'axe-result-converter';
 import { cloneDeep } from 'lodash';
 import { CombinedScanResultsProvider, CombinedScanResultsReadResponse, CombinedScanResultsWriteResponse } from 'service-library';
-import { CombinedScanResultsError, WriteErrorCode } from 'service-library/dist/data-providers/combined-scan-results-provider';
 import { CombinedScanResults } from 'storage-documents';
 import { IMock, It, Mock } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
@@ -162,7 +161,7 @@ describe(AxeResultMerger, () => {
             setupBlobRead(combinedResultsBlobId, combinedScanResultsBlobRead);
             combinedScanResultsProviderMock.setup((m) => m.getEmptyResponse()).returns(() => combinedScanResultsBlobRead);
             setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {
-                error: {} as CombinedScanResultsError<WriteErrorCode>,
+                error: {} as any,
             });
 
             await expect(testSubject.mergeAxeResults(axeResults, combinedResultsBlobId)).rejects.toThrowError(
@@ -176,13 +175,13 @@ describe(AxeResultMerger, () => {
         expectedETag: string,
         expectedCombinedResultsBlobId: string,
         responseStub: CombinedScanResultsWriteResponse,
-    ) {
+    ): void {
         combinedScanResultsProviderMock
             .setup((m) => m.writeCombinedResults(expectedCombinedResultsBlobId, It.isValue(expectedCombinedResults), expectedETag))
             .returns(() => Promise.resolve(responseStub));
     }
 
-    function setupBlobRead(expectedCombinedResultsBlobId: string, response: CombinedScanResultsReadResponse) {
+    function setupBlobRead(expectedCombinedResultsBlobId: string, response: CombinedScanResultsReadResponse): void {
         combinedScanResultsProviderMock
             .setup((m) => m.readCombinedResults(expectedCombinedResultsBlobId))
             .returns(() => Promise.resolve(response));

--- a/packages/web-api-scan-runner/src/runner/axe-result-merger.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/axe-result-merger.spec.ts
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+import axe, { AxeResults } from 'axe-core';
+import { AxeResultsReducer } from 'axe-result-converter';
+import { cloneDeep } from 'lodash';
+import { CombinedScanResultsProvider, CombinedScanResultsReadResponse, CombinedScanResultsWriteResponse } from 'service-library';
+import { CombinedScanResultsError, WriteErrorCode } from 'service-library/dist/data-providers/combined-scan-results-provider';
+import { CombinedScanResults } from 'storage-documents';
+import { IMock, It, Mock } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { AxeResultMerger } from './axe-result-merger';
+
+describe(AxeResultMerger, () => {
+    let combinedScanResultsProviderMock: IMock<CombinedScanResultsProvider>;
+    let axeResultsReducerMock: IMock<AxeResultsReducer>;
+    let loggerMock: IMock<MockableLogger>;
+    let testSubject: AxeResultMerger;
+
+    let combinedScanResults: CombinedScanResults;
+    let combinedScanResultsBlobRead: CombinedScanResultsReadResponse;
+    let axeResults: AxeResults;
+    let combinedResultsBlobId: string;
+    let blobReadETagStub: string;
+
+    beforeEach(() => {
+        loggerMock = Mock.ofType(MockableLogger);
+        combinedScanResultsProviderMock = Mock.ofType<CombinedScanResultsProvider>();
+        axeResultsReducerMock = Mock.ofType<AxeResultsReducer>();
+
+        axeResults = {
+            url: 'url',
+            timestamp: 'timestamp',
+            passes: [],
+            violations: [],
+            incomplete: [],
+            inapplicable: [],
+        } as AxeResults;
+        combinedResultsBlobId = 'combinedResultsBlobId';
+        combinedScanResults = {
+            urlCount: {
+                total: 1,
+                passed: 1,
+                failed: 0,
+            },
+            axeResults: {},
+        } as CombinedScanResults;
+        blobReadETagStub = 'some-e-tag';
+
+        testSubject = new AxeResultMerger(loggerMock.object, combinedScanResultsProviderMock.object, axeResultsReducerMock.object);
+    });
+
+    describe('Success', () => {
+        test('generate combined scan results with no new violations', async () => {
+            combinedScanResultsBlobRead = {
+                results: { ...combinedScanResults },
+                etag: blobReadETagStub,
+            } as CombinedScanResultsReadResponse;
+
+            const expectedCombinedScanResults = cloneDeep(combinedScanResults);
+            expectedCombinedScanResults.urlCount.passed++;
+            expectedCombinedScanResults.urlCount.total++;
+
+            setupBlobRead(combinedResultsBlobId, combinedScanResultsBlobRead);
+            setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {});
+            const combinedResults = await testSubject.mergeAxeResults(axeResults, combinedResultsBlobId);
+            expect(combinedResults).toEqual(expectedCombinedScanResults);
+        });
+
+        test('generate combined scan results with new violations', async () => {
+            combinedScanResultsBlobRead = {
+                results: { ...combinedScanResults },
+                etag: blobReadETagStub,
+            } as CombinedScanResultsReadResponse;
+
+            axeResults.violations = [{} as axe.Result];
+
+            const expectedCombinedScanResults = cloneDeep(combinedScanResults);
+            expectedCombinedScanResults.urlCount.failed++;
+            expectedCombinedScanResults.urlCount.total++;
+
+            setupBlobRead(combinedResultsBlobId, combinedScanResultsBlobRead);
+            setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {});
+
+            const combinedResults = await testSubject.mergeAxeResults(axeResults, combinedResultsBlobId);
+            expect(combinedResults).toEqual(expectedCombinedScanResults);
+        });
+
+        test('generate new scan results when no blob id provided', async () => {
+            combinedScanResultsBlobRead = {
+                results: { ...combinedScanResults, urlCount: { passed: 0, failed: 0, total: 0 } },
+                etag: blobReadETagStub,
+            } as CombinedScanResultsReadResponse;
+            combinedResultsBlobId = undefined;
+
+            const expectedCombinedScanResults = cloneDeep(combinedScanResultsBlobRead.results);
+            expectedCombinedScanResults.urlCount.passed++;
+            expectedCombinedScanResults.urlCount.total++;
+
+            combinedScanResultsProviderMock.setup((m) => m.getEmptyResponse()).returns(() => combinedScanResultsBlobRead);
+            setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {});
+
+            const combinedResults = await testSubject.mergeAxeResults(axeResults, combinedResultsBlobId);
+            expect(combinedResults).toEqual(expectedCombinedScanResults);
+        });
+
+        test('generate new scan results when blob not found when reading', async () => {
+            combinedScanResultsBlobRead = {
+                results: { ...combinedScanResults, urlCount: { passed: 0, failed: 0, total: 0 } },
+                etag: blobReadETagStub,
+                error: {
+                    errorCode: 'blobNotFound',
+                },
+            } as CombinedScanResultsReadResponse;
+
+            const expectedCombinedScanResults = cloneDeep(combinedScanResultsBlobRead.results);
+            expectedCombinedScanResults.urlCount.passed++;
+            expectedCombinedScanResults.urlCount.total++;
+
+            setupBlobRead(combinedResultsBlobId, combinedScanResultsBlobRead);
+            combinedScanResultsProviderMock.setup((m) => m.getEmptyResponse()).returns(() => combinedScanResultsBlobRead);
+            setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {});
+
+            const combinedResults = await testSubject.mergeAxeResults(axeResults, combinedResultsBlobId);
+            expect(combinedResults).toEqual(expectedCombinedScanResults);
+        });
+    });
+
+    describe('Error', () => {
+        test('throw for when read blob error code is not blobNotFound', async () => {
+            combinedScanResultsBlobRead = {
+                results: { ...combinedScanResults, urlCount: { passed: 0, failed: 0, total: 0 } },
+                etag: blobReadETagStub,
+                error: {
+                    errorCode: 'jsonParseError',
+                },
+            } as CombinedScanResultsReadResponse;
+
+            const expectedCombinedScanResults = cloneDeep(combinedScanResultsBlobRead.results);
+            expectedCombinedScanResults.urlCount.passed++;
+            expectedCombinedScanResults.urlCount.total++;
+
+            setupBlobRead(combinedResultsBlobId, combinedScanResultsBlobRead);
+            combinedScanResultsProviderMock.setup((m) => m.getEmptyResponse()).returns(() => combinedScanResultsBlobRead);
+            setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {});
+
+            await expect(testSubject.mergeAxeResults(axeResults, combinedResultsBlobId)).rejects.toThrowError(
+                'Failed to read combined axe results blob.',
+            );
+        });
+
+        test('throw for when error code is not blobNotFound', async () => {
+            combinedScanResultsBlobRead = {
+                results: { ...combinedScanResults, urlCount: { passed: 0, failed: 0, total: 0 } },
+                etag: blobReadETagStub,
+            } as CombinedScanResultsReadResponse;
+
+            const expectedCombinedScanResults = cloneDeep(combinedScanResultsBlobRead.results);
+            expectedCombinedScanResults.urlCount.passed++;
+            expectedCombinedScanResults.urlCount.total++;
+
+            setupBlobRead(combinedResultsBlobId, combinedScanResultsBlobRead);
+            combinedScanResultsProviderMock.setup((m) => m.getEmptyResponse()).returns(() => combinedScanResultsBlobRead);
+            setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {
+                error: {} as CombinedScanResultsError<WriteErrorCode>,
+            });
+
+            await expect(testSubject.mergeAxeResults(axeResults, combinedResultsBlobId)).rejects.toThrowError(
+                'Failed to write new combined axe scan results blob.',
+            );
+        });
+    });
+
+    function setupBlobWrite(
+        expectedCombinedResults: CombinedScanResults,
+        expectedETag: string,
+        expectedCombinedResultsBlobId: string,
+        responseStub: CombinedScanResultsWriteResponse,
+    ) {
+        combinedScanResultsProviderMock
+            .setup((m) => m.writeCombinedResults(expectedCombinedResultsBlobId, It.isValue(expectedCombinedResults), expectedETag))
+            .returns(() => Promise.resolve(responseStub));
+    }
+
+    function setupBlobRead(expectedCombinedResultsBlobId: string, response: CombinedScanResultsReadResponse) {
+        combinedScanResultsProviderMock
+            .setup((m) => m.readCombinedResults(expectedCombinedResultsBlobId))
+            .returns(() => Promise.resolve(response));
+    }
+});

--- a/packages/web-api-scan-runner/src/runner/axe-result-merger.ts
+++ b/packages/web-api-scan-runner/src/runner/axe-result-merger.ts
@@ -3,11 +3,12 @@
 
 import axe from 'axe-core';
 import { AxeResultsReducer } from 'axe-result-converter';
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { CombinedScanResultsProvider, CombinedScanResultsReadResponse } from 'service-library';
 import { CombinedScanResults } from 'storage-documents';
 
+@injectable()
 export class AxeResultMerger {
     public constructor(
         @inject(GlobalLogger) private readonly logger: GlobalLogger,

--- a/packages/web-api-scan-runner/src/runner/axe-result-merger.ts
+++ b/packages/web-api-scan-runner/src/runner/axe-result-merger.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import axe from 'axe-core';
+import { AxeResultsReducer } from 'axe-result-converter';
+import { inject } from 'inversify';
+import { GlobalLogger } from 'logger';
+import { CombinedScanResultsProvider, CombinedScanResultsReadResponse } from 'service-library';
+import { CombinedScanResults } from 'storage-documents';
+
+export class AxeResultMerger {
+    public constructor(
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(CombinedScanResultsProvider) protected readonly combinedScanResultsProvider: CombinedScanResultsProvider,
+        @inject(AxeResultsReducer) protected readonly axeResultsReducer: AxeResultsReducer,
+    ) {}
+
+    public async mergeAxeResults(axeScanResults: axe.AxeResults, combinedResultsBlobId: string): Promise<CombinedScanResults> {
+        const blobReadResponse = await this.getOrCreateCombinedResultsBlob(combinedResultsBlobId);
+        const combinedScanResults = blobReadResponse.results;
+
+        combinedScanResults.urlCount.total++;
+        if (axeScanResults.violations.length > 0) {
+            combinedScanResults.urlCount.failed++;
+        } else {
+            combinedScanResults.urlCount.passed++;
+        }
+
+        this.axeResultsReducer.reduce(combinedScanResults.axeResults, axeScanResults);
+        const blobWriteResponse = await this.combinedScanResultsProvider.writeCombinedResults(
+            combinedResultsBlobId,
+            combinedScanResults,
+            blobReadResponse.etag,
+        );
+
+        if (blobWriteResponse.error) {
+            this.logger.logError('Failed to write new combined axe scan results blob.', {
+                error: JSON.stringify(blobWriteResponse.error),
+            });
+
+            throw new Error(
+                `Failed to write new combined axe scan results blob. Blob Id: ${combinedResultsBlobId} Error: ${JSON.stringify(
+                    blobWriteResponse.error,
+                )}`,
+            );
+        }
+
+        return combinedScanResults;
+    }
+
+    private async getOrCreateCombinedResultsBlob(combinedResultsBlobId: string | undefined): Promise<CombinedScanResultsReadResponse> {
+        if (combinedResultsBlobId === undefined) {
+            this.logger.logInfo('No combined axe scan results blob associated with this website scan. Creating a new blob.');
+
+            return this.combinedScanResultsProvider.getEmptyResponse();
+        }
+
+        const response = await this.combinedScanResultsProvider.readCombinedResults(combinedResultsBlobId);
+
+        if (response.error) {
+            if (response.error.errorCode === 'blobNotFound') {
+                this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.');
+
+                return this.combinedScanResultsProvider.getEmptyResponse();
+            }
+
+            this.logger.logError('Failed to read combined axe results blob.', {
+                error: JSON.stringify(response.error),
+            });
+
+            throw new Error(
+                `Failed to read combined axe results blob. Blob Id: ${combinedResultsBlobId} Error: ${JSON.stringify(response.error)}`,
+            );
+        }
+
+        this.logger.logInfo('Successfully retrieved combined axe scan results from a blob storage.');
+
+        return response;
+    }
+}

--- a/packages/web-api-scan-runner/src/runner/combined-results-blob-getter.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-results-blob-getter.spec.ts
@@ -77,7 +77,7 @@ describe(CombinedResultsBlobGetter, () => {
         expect(await testSubject.getBlobInfo(givenResultsBlobIdStub)).toEqual(expectedBlobInfo);
     });
 
-    test('readResponse has blobNotFound error code', async () => {
+    test('readResponse has jsonParseError error code', async () => {
         const readResponseWithError: CombinedScanResultsReadResponse = {
             error: {
                 errorCode: 'jsonParseError',

--- a/packages/web-api-scan-runner/src/runner/combined-results-blob-getter.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-results-blob-getter.spec.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+import { GuidGenerator } from 'common';
+import { CombinedScanResultsProvider, CombinedScanResultsReadResponse } from 'service-library';
+import { IMock, Mock } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { CombinedResultsBlobGetter, CombinedResultsBlobInfo } from './combined-results-blob-getter';
+
+describe(CombinedResultsBlobGetter, () => {
+    let combinedScanResultsProviderMock: IMock<CombinedScanResultsProvider>;
+    let loggerMock: IMock<MockableLogger>;
+    let guidGeneratorMock: IMock<GuidGenerator>;
+    let testSubject: CombinedResultsBlobGetter;
+
+    let givenResultsBlobIdStub: string;
+    let emptyReadResponseStub: CombinedScanResultsReadResponse;
+    let readResponseStub: CombinedScanResultsReadResponse;
+
+    beforeEach(() => {
+        loggerMock = Mock.ofType(MockableLogger);
+        combinedScanResultsProviderMock = Mock.ofType<CombinedScanResultsProvider>();
+        guidGeneratorMock = Mock.ofType(GuidGenerator);
+
+        givenResultsBlobIdStub = 'some-blob-id';
+        emptyReadResponseStub = {
+            etag: 'empty-response-etag',
+        };
+        readResponseStub = {
+            etag: 'some-response-etag',
+        };
+
+        testSubject = new CombinedResultsBlobGetter(loggerMock.object, guidGeneratorMock.object, combinedScanResultsProviderMock.object);
+    });
+
+    test('givenResultsBlobId is undefined', async () => {
+        givenResultsBlobIdStub = undefined;
+        const generatedGuidStub = 'some-generated-guid';
+        const expectedBlobInfo: CombinedResultsBlobInfo = {
+            blobId: generatedGuidStub,
+            response: emptyReadResponseStub,
+        };
+
+        guidGeneratorMock.setup((mock) => mock.createGuid()).returns(() => generatedGuidStub);
+        combinedScanResultsProviderMock.setup((mock) => mock.getEmptyResponse()).returns(() => emptyReadResponseStub);
+
+        expect(await testSubject.getBlobInfo(givenResultsBlobIdStub)).toEqual(expectedBlobInfo);
+    });
+
+    test('readResponse has blobNotFound error code', async () => {
+        const expectedBlobInfo: CombinedResultsBlobInfo = {
+            blobId: givenResultsBlobIdStub,
+            response: emptyReadResponseStub,
+        };
+
+        const readResponseWithBlobNotFound: CombinedScanResultsReadResponse = {
+            error: {
+                errorCode: 'blobNotFound',
+            },
+        };
+
+        setupBlobRead(givenResultsBlobIdStub, readResponseWithBlobNotFound);
+        combinedScanResultsProviderMock.setup((mock) => mock.getEmptyResponse()).returns(() => emptyReadResponseStub);
+
+        expect(await testSubject.getBlobInfo(givenResultsBlobIdStub)).toEqual(expectedBlobInfo);
+    });
+
+    test('Successfully retrieves the combined results', async () => {
+        const expectedBlobInfo: CombinedResultsBlobInfo = {
+            blobId: givenResultsBlobIdStub,
+            response: readResponseStub,
+        };
+
+        setupBlobRead(givenResultsBlobIdStub, readResponseStub);
+
+        expect(await testSubject.getBlobInfo(givenResultsBlobIdStub)).toEqual(expectedBlobInfo);
+    });
+
+    test('readResponse has blobNotFound error code', async () => {
+        const readResponseWithError: CombinedScanResultsReadResponse = {
+            error: {
+                errorCode: 'jsonParseError',
+            },
+        };
+
+        setupBlobRead(givenResultsBlobIdStub, readResponseWithError);
+
+        await expect(testSubject.getBlobInfo(givenResultsBlobIdStub)).rejects.toThrowError('Failed to read combined axe results blob.');
+    });
+
+    function setupBlobRead(expectedCombinedResultsBlobId: string, response: CombinedScanResultsReadResponse): void {
+        combinedScanResultsProviderMock
+            .setup((m) => m.readCombinedResults(expectedCombinedResultsBlobId))
+            .returns(() => Promise.resolve(response));
+    }
+});

--- a/packages/web-api-scan-runner/src/runner/combined-results-blob-getter.ts
+++ b/packages/web-api-scan-runner/src/runner/combined-results-blob-getter.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { GuidGenerator } from 'common';
+import { inject, injectable } from 'inversify';
+import { GlobalLogger } from 'logger';
+import { CombinedScanResultsProvider, CombinedScanResultsReadResponse } from 'service-library';
+
+export interface CombinedResultsBlobInfo {
+    response: CombinedScanResultsReadResponse;
+    blobId: string;
+}
+
+@injectable()
+export class CombinedResultsBlobGetter {
+    public constructor(
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+        @inject(CombinedScanResultsProvider) protected readonly combinedScanResultsProvider: CombinedScanResultsProvider,
+    ) {}
+
+    public async getBlobInfo(givenResultsBlobId: string): Promise<CombinedResultsBlobInfo> {
+        let returnedResultsBlobId = givenResultsBlobId;
+        let blobReadResponse: CombinedScanResultsReadResponse;
+
+        if (givenResultsBlobId === undefined) {
+            returnedResultsBlobId = this.guidGenerator.createGuid();
+            this.logger.logInfo('No combined axe scan results blob associated with this website scan. Creating a new blob.');
+            blobReadResponse = this.combinedScanResultsProvider.getEmptyResponse();
+        } else {
+            blobReadResponse = await this.getCombinedResultsBlob(returnedResultsBlobId);
+        }
+
+        return {
+            response: blobReadResponse,
+            blobId: returnedResultsBlobId,
+        };
+    }
+
+    private async getCombinedResultsBlob(combinedResultsBlobId: string | undefined): Promise<CombinedScanResultsReadResponse> {
+        const response = await this.combinedScanResultsProvider.readCombinedResults(combinedResultsBlobId);
+
+        if (response.error) {
+            if (response.error.errorCode === 'blobNotFound') {
+                this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.');
+
+                return this.combinedScanResultsProvider.getEmptyResponse();
+            }
+
+            this.logger.logError('Failed to read combined axe results blob.', {
+                error: JSON.stringify(response.error),
+            });
+
+            throw new Error(
+                `Failed to read combined axe results blob. Blob Id: ${combinedResultsBlobId} Error: ${JSON.stringify(response.error)}`,
+            );
+        }
+
+        this.logger.logInfo('Successfully retrieved combined axe scan results from a blob storage.');
+
+        return response;
+    }
+}


### PR DESCRIPTION
#### Description of changes

I modified the logic slightly as there was a bit of redundancy in the checks.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
