### PR TITLE
refactor(cloud-crawler): Crawler baseCrawlPage option

### DIFF
--- a/packages/crawler/src/apify/apify-resource-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-resource-creator.spec.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 import * as fs from 'fs';
 import Apify from 'apify';
 import { IMock, It, Mock, Times } from 'typemoq';
+import { Page } from 'puppeteer';
 import { apifySettingsHandler, ApifySettingsHandler } from '../apify/apify-settings';
 import { getPromisableDynamicMock } from '../test-utilities/promisable-mock';
 import { ApifyResourceCreator } from './apify-resource-creator';
@@ -14,6 +15,7 @@ describe(ApifyResourceCreator, () => {
     let settingsHandlerMock: IMock<typeof apifySettingsHandler>;
     let fsMock: IMock<typeof fs>;
     let queueMock: IMock<Apify.RequestQueue>;
+    let enqueueLinksMock: IMock<typeof Apify.utils.enqueueLinks>;
 
     let apifyResourceCreator: ApifyResourceCreator;
 
@@ -25,7 +27,13 @@ describe(ApifyResourceCreator, () => {
         settingsHandlerMock = Mock.ofType<ApifySettingsHandler>();
         fsMock = Mock.ofType<typeof fs>();
         queueMock = getPromisableDynamicMock(Mock.ofType<Apify.RequestQueue>());
-        apifyResourceCreator = new ApifyResourceCreator(apifyMock.object, settingsHandlerMock.object, fsMock.object);
+        enqueueLinksMock = Mock.ofType<typeof Apify.utils.enqueueLinks>();
+        apifyResourceCreator = new ApifyResourceCreator(
+            apifyMock.object,
+            settingsHandlerMock.object,
+            fsMock.object,
+            enqueueLinksMock.object,
+        );
     });
 
     afterEach(() => {
@@ -35,7 +43,7 @@ describe(ApifyResourceCreator, () => {
     });
 
     describe('createRequestQueue', () => {
-        it('with empty=false', async () => {
+        it('with clear=false', async () => {
             setupCreateRequestQueue();
             fsMock.setup((fsm) => fsm.rmdirSync(It.isAny(), It.isAny())).verifiable(Times.never());
 
@@ -48,7 +56,7 @@ describe(ApifyResourceCreator, () => {
             setupClearRequestQueue(true);
             setupCreateRequestQueue();
 
-            const queue = await apifyResourceCreator.createRequestQueue(url, true);
+            const queue = await apifyResourceCreator.createRequestQueue(url, { clear: true });
 
             expect(queue).toBe(queueMock.object);
         });
@@ -57,7 +65,7 @@ describe(ApifyResourceCreator, () => {
             setupClearRequestQueue(false);
             setupCreateRequestQueue();
 
-            const queue = await apifyResourceCreator.createRequestQueue(url, true);
+            const queue = await apifyResourceCreator.createRequestQueue(url, { clear: true });
 
             expect(queue).toBe(queueMock.object);
         });
@@ -70,7 +78,23 @@ describe(ApifyResourceCreator, () => {
             queueMock.setup((q) => q.addRequest({ url: 'ur1' }, { forefront: true })).verifiable();
             queueMock.setup((q) => q.addRequest({ url: 'ur2' }, { forefront: true })).verifiable();
 
-            const queue = await apifyResourceCreator.createRequestQueue(url, false, inputUrls);
+            const queue = await apifyResourceCreator.createRequestQueue(url, { clear: false, inputUrls: inputUrls });
+            expect(queue).toBe(queueMock.object);
+        });
+
+        it('with a page to crawl', async () => {
+            const discoveryPatterns = ['pattern1', 'pattern2'];
+            const page = {} as Page;
+            const expectedEnqueueLinksOpts = {
+                page: page,
+                requestQueue: queueMock.object,
+                pseudoUrls: discoveryPatterns,
+            };
+            setupCreateRequestQueue();
+            enqueueLinksMock.setup((el) => el(expectedEnqueueLinksOpts));
+
+            const queue = await apifyResourceCreator.createRequestQueue(url, { page, discoveryPatterns });
+
             expect(queue).toBe(queueMock.object);
         });
     });

--- a/packages/crawler/src/apify/apify-resource-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-resource-creator.spec.ts
@@ -40,6 +40,7 @@ describe(ApifyResourceCreator, () => {
         apifyMock.verifyAll();
         settingsHandlerMock.verifyAll();
         fsMock.verifyAll();
+        enqueueLinksMock.verifyAll();
     });
 
     describe('createRequestQueue', () => {
@@ -91,7 +92,7 @@ describe(ApifyResourceCreator, () => {
                 pseudoUrls: discoveryPatterns,
             };
             setupCreateRequestQueue();
-            enqueueLinksMock.setup((el) => el(expectedEnqueueLinksOpts));
+            enqueueLinksMock.setup((el) => el(expectedEnqueueLinksOpts)).verifiable();
 
             const queue = await apifyResourceCreator.createRequestQueue(url, { page, discoveryPatterns });
 

--- a/packages/crawler/src/apify/apify-resource-creator.ts
+++ b/packages/crawler/src/apify/apify-resource-creator.ts
@@ -28,7 +28,7 @@ export class ApifyResourceCreator implements ResourceCreator {
             await requestQueue.addRequest({ url: baseUrl.trim() });
         }
         await this.addUrlsFromList(requestQueue, options?.inputUrls);
-        await this.addUrlsFromPageCrawl(requestQueue, options?.page, options?.discoveryPatterns);
+        await this.addUrlsDiscoveredInPage(requestQueue, options?.page, options?.discoveryPatterns);
 
         return requestQueue;
     }
@@ -43,9 +43,9 @@ export class ApifyResourceCreator implements ResourceCreator {
         }
     }
 
-    private async addUrlsFromPageCrawl(requestQueue: Apify.RequestQueue, page?: Page, discoveryPatterns?: string[]): Promise<void> {
+    private async addUrlsDiscoveredInPage(requestQueue: Apify.RequestQueue, page?: Page, discoveryPatterns?: string[]): Promise<void> {
         if (page === undefined || discoveryPatterns === undefined) {
-            return Promise.resolve();
+            return;
         }
 
         await this.enqueueLinksExt({

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -5,7 +5,6 @@
 import './global-overrides';
 
 export { CrawlerRunOptions } from './types/crawler-run-options';
-export { SimpleCrawlerRunOptions } from './crawler/simple-crawler-engine';
 
 export { iocTypes } from './types/ioc-types';
 export { Crawler } from './crawler';

--- a/packages/crawler/src/setup-crawler-container.ts
+++ b/packages/crawler/src/setup-crawler-container.ts
@@ -23,11 +23,12 @@ export function setupLocalCrawlerContainer(container: inversify.Container): inve
         const apifyResourceCreator = context.container.get(ApifyResourceCreator);
         const crawlerRunOptions = context.container.get<CrawlerRunOptions>(iocTypes.CrawlerRunOptions);
 
-        return apifyResourceCreator.createRequestQueue(
-            crawlerRunOptions.baseUrl,
-            crawlerRunOptions.restartCrawl,
-            crawlerRunOptions.inputUrls,
-        );
+        return apifyResourceCreator.createRequestQueue(crawlerRunOptions.baseUrl, {
+            clear: crawlerRunOptions.restartCrawl,
+            inputUrls: crawlerRunOptions.inputUrls,
+            page: crawlerRunOptions.baseCrawlPage,
+            discoveryPatterns: crawlerRunOptions.discoveryPatterns,
+        });
     });
 
     container
@@ -53,11 +54,12 @@ export function setupCloudCrawlerContainer(container: inversify.Container): inve
         const apifyResourceCreator = context.container.get(ApifyResourceCreator);
         const crawlerRunOptions = context.container.get<CrawlerRunOptions>(iocTypes.CrawlerRunOptions);
 
-        return apifyResourceCreator.createRequestQueue(
-            crawlerRunOptions.baseUrl,
-            crawlerRunOptions.restartCrawl,
-            crawlerRunOptions.inputUrls,
-        );
+        return apifyResourceCreator.createRequestQueue(crawlerRunOptions.baseUrl, {
+            clear: crawlerRunOptions.restartCrawl,
+            inputUrls: crawlerRunOptions.inputUrls,
+            page: crawlerRunOptions.baseCrawlPage,
+            discoveryPatterns: crawlerRunOptions.discoveryPatterns,
+        });
     });
 
     container.bind(iocTypes.RequestProcessor).to(UrlCollectionRequestProcessor);

--- a/packages/crawler/src/types/crawler-run-options.ts
+++ b/packages/crawler/src/types/crawler-run-options.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { Page } from 'puppeteer';
+
 export interface CrawlerRunOptions {
     crawl?: boolean;
     baseUrl: string;
@@ -15,4 +17,5 @@ export interface CrawlerRunOptions {
     memoryMBytes?: number;
     silentMode?: boolean;
     debug?: boolean;
+    baseCrawlPage?: Page;
 }

--- a/packages/crawler/src/types/resource-creator.ts
+++ b/packages/crawler/src/types/resource-creator.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import Apify from 'apify';
+import { Page } from 'puppeteer';
+
+export type RequestQueueOptions = {
+    clear?: boolean;
+    inputUrls?: string[];
+    page?: Page;
+    discoveryPatterns?: string[]; // Only needed if page is provided
+};
 
 export interface ResourceCreator {
-    createRequestQueue(baseUrl: string, empty?: boolean, inputUrls?: string[]): Promise<Apify.RequestQueue>;
+    createRequestQueue(baseUrl: string, options?: RequestQueueOptions): Promise<Apify.RequestQueue>;
 }

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
@@ -3,7 +3,7 @@
 
 import 'reflect-metadata';
 
-import { Crawler, SimpleCrawlerRunOptions } from 'accessibility-insights-crawler';
+import { Crawler, CrawlerRunOptions } from 'accessibility-insights-crawler';
 import { GlobalLogger } from 'logger';
 import { Page } from 'puppeteer';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
@@ -97,9 +97,9 @@ describe('CrawlRunner', () => {
         const expectedRunOptions = {
             baseUrl,
             discoveryPatterns,
-            page,
+            baseCrawlPage: page,
             maxRequestsPerCrawl: urlCrawlLimit,
-        } as SimpleCrawlerRunOptions;
+        } as CrawlerRunOptions;
 
         const expectedRetVal = ['discoveredUrl'];
 

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -3,7 +3,7 @@
 
 import { GlobalLogger } from 'logger';
 import { inject, injectable } from 'inversify';
-import { Crawler, iocTypes as crawlerIocTypes, SimpleCrawlerRunOptions } from 'accessibility-insights-crawler';
+import { Crawler, CrawlerRunOptions, iocTypes as crawlerIocTypes } from 'accessibility-insights-crawler';
 import { Page } from 'puppeteer';
 import { ServiceConfiguration } from 'common';
 import { ScanMetadataConfig } from '../scan-metadata-config';
@@ -37,9 +37,9 @@ export class CrawlRunner {
             const crawlerRunOptions = {
                 baseUrl,
                 discoveryPatterns,
-                page,
+                baseCrawlPage: page,
                 maxRequestsPerCrawl: (await this.serviceConfig.getConfigValue('crawlConfig')).urlCrawlLimit,
-            } as SimpleCrawlerRunOptions;
+            } as CrawlerRunOptions;
 
             retVal = await crawler.crawl(crawlerRunOptions);
         } catch (ex) {


### PR DESCRIPTION
#### Description of changes

- Add baseCrawlPage to CrawlerRunOptions, instead of having a separate SimpleCrawlerRunOptions type
- Move initial enqueueLinks call from SimpleCrawlerEngine to ApifyResourceProvider. ApifyResourceProvider now enqueues the baseUrl, enqueues any urls in urlList if it exists, and enqueues any links discovered on the puppeteer page if it exists

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
