### PR TITLE
fix: add leveldown as external

### DIFF
--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -62,6 +62,7 @@
         "common": "^1.0.0",
         "dotenv": "^8.2.0",
         "inversify": "^5.0.5",
+        "leveldown": "^5.6.0",
         "lodash": "^4.17.20",
         "logger": "1.0.0",
         "puppeteer": "^5.5.0",

--- a/packages/web-api-scan-runner/webpack.config.js
+++ b/packages/web-api-scan-runner/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = (env) => {
             'applicationinsights',
             'accessibility-insights-report',
             'apify',
+            'leveldown',
         ],
         entry: {
             ['web-api-scan-runner']: path.resolve('./src/index.ts'),


### PR DESCRIPTION
#### Description of changes

Add leveldown as external in batch workers to fix "No native build was found" errors

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
