### PR TITLE
feat(cloud-crawler): fix cloud crawler settings

### DIFF
--- a/packages/azure-services/src/azure-batch/batch-config.spec.ts
+++ b/packages/azure-services/src/azure-batch/batch-config.spec.ts
@@ -12,11 +12,13 @@ describe(BatchConfig, () => {
         process.env.AZ_BATCH_ACCOUNT_URL = 'test account url';
         process.env.AZ_BATCH_POOL_ID = 'pool id';
         process.env.AZ_BATCH_JOB_ID = 'job id';
+        process.env.AZ_BATCH_TASK_WORKING_DIR = 'task working directory';
         batchConfig = new BatchConfig();
 
         expect(batchConfig.accountName).toEqual(process.env.AZ_BATCH_ACCOUNT_NAME);
         expect(batchConfig.accountUrl).toEqual(process.env.AZ_BATCH_ACCOUNT_URL);
         expect(batchConfig.poolId).toEqual(process.env.AZ_BATCH_POOL_ID);
         expect(batchConfig.jobId).toEqual(process.env.AZ_BATCH_JOB_ID);
+        expect(batchConfig.taskWorkingDir).toEqual(process.env.AZ_BATCH_TASK_WORKING_DIR);
     });
 });

--- a/packages/azure-services/src/azure-batch/batch-config.ts
+++ b/packages/azure-services/src/azure-batch/batch-config.ts
@@ -9,6 +9,7 @@ export class BatchConfig {
     public readonly accountUrl: string = process.env.AZ_BATCH_ACCOUNT_URL;
     public readonly poolId: string = process.env.AZ_BATCH_POOL_ID;
     public readonly jobId: string = process.env.AZ_BATCH_JOB_ID;
+    public readonly taskWorkingDir: string = process.env.AZ_BATCH_TASK_WORKING_DIR;
 }
 
 export const batchConfig = new BatchConfig();

--- a/packages/azure-services/src/azure-batch/batch.spec.ts
+++ b/packages/azure-services/src/azure-batch/batch.spec.ts
@@ -73,7 +73,7 @@ describe(Batch, () => {
             accountUrl: 'accountUrl',
             poolId: 'poolId',
             jobId: 'jobId',
-        };
+        } as BatchConfig;
         serviceConfigMock = Mock.ofType(ServiceConfiguration);
         serviceConfigMock
             .setup(async (s) => s.getConfigValue('taskConfig'))

--- a/packages/service-library/src/batch/batch-task-creator.spec.ts
+++ b/packages/service-library/src/batch/batch-task-creator.spec.ts
@@ -190,7 +190,7 @@ describe(BatchTaskCreator, () => {
             accountUrl: '',
             poolId: 'pool-id',
             jobId: 'job-id',
-        };
+        } as BatchConfig;
         batchMock = Mock.ofType(Batch);
         queueMock = Mock.ofType(Queue);
         serviceConfigMock = Mock.ofType(ServiceConfiguration);

--- a/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
+++ b/packages/web-api-scan-job-manager/src/worker/worker.spec.ts
@@ -155,7 +155,7 @@ describe(Worker, () => {
             accountUrl: '',
             poolId: 'pool-Id',
             jobId: 'batch-job-id',
-        };
+        } as BatchConfig;
 
         poolMetricsInfo = {
             id: 'pool-id',

--- a/packages/web-api-scan-runner/docker-image-config/Dockerfile
+++ b/packages/web-api-scan-runner/docker-image-config/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libxtst6 \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libxtst6 procps \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
@@ -8,6 +8,7 @@ import { GlobalLogger } from 'logger';
 import { Page } from 'puppeteer';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 import { ServiceConfiguration } from 'common';
+import { BatchConfig } from 'azure-services';
 import { ScanMetadataConfig } from '../scan-metadata-config';
 import { ScanMetadata } from '../types/scan-metadata';
 import { CrawlRunner } from './crawl-runner';
@@ -28,6 +29,10 @@ describe('CrawlRunner', () => {
     const discoveryPatterns = ['testPattern'];
     const page = {} as Page;
     const urlCrawlLimit = 42;
+    const workingDir = '/workingDir';
+    const batchConfigStub = {
+        taskWorkingDir: workingDir,
+    } as BatchConfig;
 
     let loggerMock: IMock<GlobalLogger>;
     let scanMetaDataConfigMock: IMock<ScanMetadataConfig>;
@@ -60,6 +65,7 @@ describe('CrawlRunner', () => {
             loggerMock.object,
             serviceConfigMock.object,
             scanMetaDataConfigMock.object,
+            batchConfigStub,
         );
 
         expect(await crawlRunner.run(baseUrl, discoveryPatterns, page)).toBeUndefined();
@@ -83,6 +89,7 @@ describe('CrawlRunner', () => {
             loggerMock.object,
             serviceConfigMock.object,
             scanMetaDataConfigMock.object,
+            batchConfigStub,
         );
 
         const retVal = await crawlRunner.run(baseUrl, discoveryPatterns, page);
@@ -99,6 +106,9 @@ describe('CrawlRunner', () => {
             discoveryPatterns,
             baseCrawlPage: page,
             maxRequestsPerCrawl: urlCrawlLimit,
+            silentMode: true,
+            restartCrawl: true,
+            localOutputDir: `${workingDir}/crawler_storage`,
         } as CrawlerRunOptions;
 
         const expectedRetVal = ['discoveredUrl'];
@@ -118,6 +128,7 @@ describe('CrawlRunner', () => {
             loggerMock.object,
             serviceConfigMock.object,
             scanMetaDataConfigMock.object,
+            batchConfigStub,
         );
 
         const actualRetVal = await crawlRunner.run(baseUrl, discoveryPatterns, page);

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-creator.spec.ts
@@ -34,7 +34,7 @@ describe(SendNotificationTaskCreator, () => {
         accountUrl: '',
         poolId: 'pool-Id',
         jobId: 'batch-job-id',
-    };
+    } as BatchConfig;
 
     beforeEach(() => {
         batchMock = Mock.ofType(Batch, MockBehavior.Strict);


### PR DESCRIPTION
#### Description of changes

- make sure ps is installed on the docker image for scan runner (required for Apify)
- Set the local storage directory for the crawl to the working directory for the task (fixes permissions error)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1793075
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
