### PR TITLE
refactor: ScanRunnerTelemetryManager

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -20,3 +20,4 @@ export {
 export { AvailabilityTelemetry } from './availability-telemetry';
 export { LoggerProperties } from './logger-properties';
 export { ConsoleLoggerClient } from './console-logger-client';
+export { LoggerEvent } from './logger-event';

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -232,9 +232,9 @@ describe(Runner, () => {
 
         setupUpdateScanRunResultCall(getFailingJobStateScanResult(unscannableAxeScanResults.error));
 
-        telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable(Times.never());
-        telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanStarted(scanSubmittedDate)).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanTaskFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup((t) => t.trackScanCompleted()).verifiable();
 
         await runner.run();
     });
@@ -246,9 +246,9 @@ describe(Runner, () => {
 
         setupUpdateScanRunResultCall(getFailingJobStateScanResult(System.serializeError(failureMessage), false));
 
-        telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanStarted(scanSubmittedDate)).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanTaskFailed()).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanCompleted()).verifiable();
 
         await runner.run();
     });
@@ -263,7 +263,7 @@ describe(Runner, () => {
                 ),
             )
             .verifiable();
-        telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable(Times.never());
+        telemetryManagerMock.setup((t) => t.trackScanStarted(scanSubmittedDate)).verifiable(Times.never());
 
         await runner.run();
     });
@@ -306,10 +306,10 @@ describe(Runner, () => {
     });
 
     it('sends telemetry event on successful scan', async () => {
-        telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable(Times.never());
-        telemetryManagerMock.setup(t => t.trackBrowserScanFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup((t) => t.trackScanStarted(scanSubmittedDate)).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanCompleted()).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanTaskFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup((t) => t.trackBrowserScanFailed()).verifiable(Times.never());
 
         setupTryUpdateScanRunResultCall(getRunningJobStateScanResult());
         setupPageScan(passedAxeScanResults);
@@ -322,10 +322,10 @@ describe(Runner, () => {
     });
 
     it('sends telemetry event on scan error', async () => {
-        telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackBrowserScanFailed()).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable(Times.never());
-        telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanStarted(scanSubmittedDate)).verifiable();
+        telemetryManagerMock.setup((t) => t.trackBrowserScanFailed()).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanTaskFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup((t) => t.trackScanCompleted()).verifiable();
 
         setupTryUpdateScanRunResultCall(getRunningJobStateScanResult());
         setupPageScan(unscannableAxeScanResults);

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -512,7 +512,7 @@ describe(Runner, () => {
 
             setupWebsiteScanResultsProviderMock(websiteScanResult, true);
             setupSuccessfulWebsiteScan();
-            telemetryManagerMock.setup(t => t.trackScanTaskFailed());
+            telemetryManagerMock.setup((t) => t.trackScanTaskFailed());
             setupCombinedScanResultsProviderMock(combinedScanResultsBlobRead, false, true);
             setupCallsAfterCombinedResultsUpdate(true);
 
@@ -592,7 +592,6 @@ describe(Runner, () => {
     });
 
     describe('deepScan', () => {
-
         it('run deep scan if deepScan=true', async () => {
             scanMetadata.deepScan = true;
             setupScanAndSaveReports();
@@ -768,17 +767,17 @@ describe(Runner, () => {
     }
 
     function setupBasicTelemetry(): void {
-        telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanCompleted());
+        telemetryManagerMock.setup((t) => t.trackScanStarted(scanSubmittedDate)).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanCompleted());
     }
 
     function setupTelemetryWithBrowserError(): void {
         setupBasicTelemetry();
-        telemetryManagerMock.setup(t => t.trackBrowserScanFailed());
+        telemetryManagerMock.setup((t) => t.trackBrowserScanFailed());
     }
 
     function setupTelemetryWithTaskFailure(): void {
         setupBasicTelemetry();
-        telemetryManagerMock.setup(t => t.trackScanTaskFailed());
+        telemetryManagerMock.setup((t) => t.trackScanTaskFailed());
     }
 });

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -233,7 +233,7 @@ describe(Runner, () => {
         setupUpdateScanRunResultCall(getFailingJobStateScanResult(unscannableAxeScanResults.error));
 
         telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable(Times.never());
         telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
 
         await runner.run();
@@ -247,7 +247,7 @@ describe(Runner, () => {
         setupUpdateScanRunResultCall(getFailingJobStateScanResult(System.serializeError(failureMessage), false));
 
         telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanFailed()).verifiable();
+        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable();
         telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
 
         await runner.run();
@@ -266,7 +266,6 @@ describe(Runner, () => {
         telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable(Times.never());
 
         await runner.run();
-        loggerMock.verifyAll();
     });
 
     it('sets scan status to pass if violation length = 0', async () => {
@@ -309,7 +308,8 @@ describe(Runner, () => {
     it('sends telemetry event on successful scan', async () => {
         telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
         telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup(t => t.trackBrowserScanFailed()).verifiable(Times.never());
 
         setupTryUpdateScanRunResultCall(getRunningJobStateScanResult());
         setupPageScan(passedAxeScanResults);
@@ -319,13 +319,12 @@ describe(Runner, () => {
         setupUpdateScanRunResultCall(scanResult);
 
         await runner.run();
-        loggerMock.verifyAll();
     });
 
     it('sends telemetry event on scan error', async () => {
-        loggerMock.setup((lm) => lm.trackEvent('BrowserScanFailed', undefined, { failedBrowserScans: 1 })).verifiable();
         telemetryManagerMock.setup(t => t.trackScanStarted(scanSubmittedDate)).verifiable();
-        telemetryManagerMock.setup(t => t.trackScanFailed()).verifiable(Times.never());
+        telemetryManagerMock.setup(t => t.trackBrowserScanFailed()).verifiable();
+        telemetryManagerMock.setup(t => t.trackScanTaskFailed()).verifiable(Times.never());
         telemetryManagerMock.setup(t => t.trackScanCompleted()).verifiable();
 
         setupTryUpdateScanRunResultCall(getRunningJobStateScanResult());
@@ -335,7 +334,6 @@ describe(Runner, () => {
         setupUpdateScanRunResultCall(scanResult);
 
         await runner.run();
-        loggerMock.verifyAll();
     });
 
     describe('enqueue notification, send notification feature flag is enabled', () => {

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -763,11 +763,10 @@ describe(Runner, () => {
     function setupGuidGenerator(): void {
         guidGeneratorMock.setup((g) => g.createGuid()).returns(() => reportId1);
         guidGeneratorMock.setup((g) => g.createGuid()).returns(() => reportId2);
-        guidGeneratorMock.setup((g) => g.getGuidTimestamp('id')).returns(() => scanSubmittedDate);
     }
 
     function setupBasicTelemetry(): void {
-        telemetryManagerMock.setup((t) => t.trackScanStarted(scanSubmittedDate)).verifiable();
+        telemetryManagerMock.setup((t) => t.trackScanStarted('id')).verifiable();
         telemetryManagerMock.setup((t) => t.trackScanCompleted());
     }
 

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -69,8 +69,7 @@ export class Runner {
             return;
         }
 
-        const scanSubmittedTimestamp = this.guidGenerator.getGuidTimestamp(scanMetadata.id);
-        this.telemetryManager.trackScanStarted(scanSubmittedTimestamp);
+        this.telemetryManager.trackScanStarted(scanMetadata.id);
 
         let axeScanResults: AxeScanResults;
         try {

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -85,7 +85,7 @@ export class Runner {
             const errorMessage = System.serializeError(error);
             pageScanResult.run = this.createRunResult('failed', errorMessage);
 
-            this.telemetryManager.trackScanFailed();
+            this.telemetryManager.trackScanTaskFailed();
         } finally {
             await this.closePage();
             this.telemetryManager.trackScanCompleted();
@@ -312,7 +312,7 @@ export class Runner {
             pageScanResult.run = this.createRunResult('failed', axeScanResults.error);
 
             this.logger.logError('Browser has failed to scan a page.', { error: JSON.stringify(axeScanResults.error) });
-            this.logger.trackEvent('BrowserScanFailed', undefined, { failedBrowserScans: 1 });
+            this.telemetryManager.trackBrowserScanFailed();
         }
 
         pageScanResult.run.pageTitle = axeScanResults.pageTitle;

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -85,6 +85,7 @@ export class Runner {
             const errorMessage = System.serializeError(error);
             pageScanResult.run = this.createRunResult('failed', errorMessage);
 
+            this.logger.logError(`The scanner failed to scan a page.`, { error: errorMessage });
             this.telemetryManager.trackScanTaskFailed();
         } finally {
             await this.closePage();

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
@@ -6,6 +6,15 @@ import { GlobalLogger, Logger, LoggerEvent, TelemetryMeasurements } from 'logger
 import { IMock, It, Mock, Times } from 'typemoq';
 import { ScanRunnerTelemetryManager } from './scan-runner-telemetry-manager';
 
+class TestableScanRunnerTelemetryManager extends ScanRunnerTelemetryManager {
+    public scanSubmitted: number;
+    public scanStarted: number;
+
+    public constructor(logger: GlobalLogger, getCurrentTimestamp: () => number = Date.now) {
+        super(logger, getCurrentTimestamp);
+    }
+}
+
 describe(ScanRunnerTelemetryManager, () => {
     const scanWaitTimeMillis = 10000;
     const scanExecutionTimeMillis = 15000;
@@ -16,13 +25,13 @@ describe(ScanRunnerTelemetryManager, () => {
     let loggerMock: IMock<GlobalLogger>;
     let getCurrentDateMock: IMock<() => number>;
 
-    let testSubject: ScanRunnerTelemetryManager;
+    let testSubject: TestableScanRunnerTelemetryManager;
 
     beforeEach(() => {
         loggerMock = Mock.ofType<Logger>();
         getCurrentDateMock = Mock.ofInstance(() => null);
 
-        testSubject = new ScanRunnerTelemetryManager(loggerMock.object, getCurrentDateMock.object);
+        testSubject = new TestableScanRunnerTelemetryManager(loggerMock.object, getCurrentDateMock.object);
     });
 
     afterEach(() => {

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
@@ -18,11 +18,11 @@ class TestableScanRunnerTelemetryManager extends ScanRunnerTelemetryManager {
 
 describe(ScanRunnerTelemetryManager, () => {
     const scanId = 'scan id';
-    const scanWaitTimeMillis = 10000;
-    const scanExecutionTimeMillis = 15000;
+    const scanWaitTimeMilliseconds = 10000;
+    const scanExecutionTimeMilliseconds = 15000;
     const scanSubmittedTimestamp = 12345678;
-    const scanStartedTimestamp = scanSubmittedTimestamp + scanWaitTimeMillis;
-    const scanCompletedTimestamp = scanStartedTimestamp + scanExecutionTimeMillis;
+    const scanStartedTimestamp = scanSubmittedTimestamp + scanWaitTimeMilliseconds;
+    const scanCompletedTimestamp = scanStartedTimestamp + scanExecutionTimeMilliseconds;
 
     let loggerMock: IMock<GlobalLogger>;
     let getCurrentDateMock: IMock<() => number>;
@@ -46,7 +46,7 @@ describe(ScanRunnerTelemetryManager, () => {
     it('trackScanStarted', () => {
         const scanRunningMeasurements = { runningScanRequests: 1 };
         const scanStartedMeasurements = {
-            scanWaitTime: scanWaitTimeMillis / 1000,
+            scanWaitTime: scanWaitTimeMilliseconds / 1000,
             startedScanTasks: 1,
         };
         getCurrentDateMock.setup((g) => g()).returns(() => scanStartedTimestamp);
@@ -75,8 +75,8 @@ describe(ScanRunnerTelemetryManager, () => {
     it('trackScanCompleted', () => {
         getCurrentDateMock.setup((g) => g()).returns(() => scanCompletedTimestamp);
         const scanTaskCompletedMeasurements = {
-            scanExecutionTime: scanExecutionTimeMillis / 1000,
-            scanTotalTime: (scanExecutionTimeMillis + scanWaitTimeMillis) / 1000,
+            scanExecutionTime: scanExecutionTimeMilliseconds / 1000,
+            scanTotalTime: (scanExecutionTimeMilliseconds + scanWaitTimeMilliseconds) / 1000,
             completedScanTasks: 1,
         };
         const ScanRequestCompletedMeasurements = { completedScanRequests: 1 };

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
@@ -45,11 +45,17 @@ describe(ScanRunnerTelemetryManager, () => {
         expect(testSubject.scanSubmitted).toBe(scanSubmittedTimestamp);
     });
 
-    it('trackScanFailed', () => {
+    it('trackBrowserScanFailed', () => {
+        setupTrackEvent('BrowserScanFailed', { failedBrowserScans: 1 });
+
+        testSubject.trackBrowserScanFailed();
+    });
+
+    it('trackScanTaskFailed', () => {
         setupTrackEvent('ScanRequestFailed', { failedScanRequests: 1 });
         setupTrackEvent('ScanTaskFailed', { failedScanTasks: 1 });
 
-        testSubject.trackScanFailed();
+        testSubject.trackScanTaskFailed();
     });
 
     it('trackScanCompleted', () => {

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
@@ -35,7 +35,7 @@ describe(ScanRunnerTelemetryManager, () => {
             scanWaitTime: scanWaitTimeMillis / 1000,
             startedScanTasks: 1,
         };
-        getCurrentDateMock.setup(g => g()).returns(() => scanStartedTimestamp);
+        getCurrentDateMock.setup((g) => g()).returns(() => scanStartedTimestamp);
         setupTrackEvent('ScanRequestRunning', scanRunningMeasurements);
         setupTrackEvent('ScanTaskStarted', scanStartedMeasurements);
 
@@ -59,7 +59,7 @@ describe(ScanRunnerTelemetryManager, () => {
     });
 
     it('trackScanCompleted', () => {
-        getCurrentDateMock.setup(g => g()).returns(() => scanCompletedTimestamp);
+        getCurrentDateMock.setup((g) => g()).returns(() => scanCompletedTimestamp);
         const scanTaskCompletedMeasurements = {
             scanExecutionTime: scanExecutionTimeMillis / 1000,
             scanTotalTime: (scanExecutionTimeMillis + scanWaitTimeMillis) / 1000,
@@ -75,20 +75,20 @@ describe(ScanRunnerTelemetryManager, () => {
     });
 
     it('trackScanCompleted does nothing if there is no scan start time set', () => {
-        loggerMock.setup(l => l.trackEvent(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+        loggerMock.setup((l) => l.trackEvent(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
         testSubject.scanSubmitted = scanSubmittedTimestamp;
 
         testSubject.trackScanCompleted();
     });
 
     it('trackScanCompleted does nothing if there is no scan submitted time set', () => {
-        loggerMock.setup(l => l.trackEvent(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+        loggerMock.setup((l) => l.trackEvent(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
         testSubject.scanStarted = scanStartedTimestamp;
 
         testSubject.trackScanCompleted();
     });
 
     function setupTrackEvent(eventName: LoggerEvent, measurements: TelemetryMeasurements[LoggerEvent]): void {
-        loggerMock.setup(l => l.trackEvent(eventName, undefined, measurements)).verifiable();
+        loggerMock.setup((l) => l.trackEvent(eventName, undefined, measurements)).verifiable();
     }
 });

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata';
 
 import { GlobalLogger, Logger, LoggerEvent, TelemetryMeasurements } from 'logger';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { GuidGenerator } from 'common';
 import { ScanRunnerTelemetryManager } from './scan-runner-telemetry-manager';
 
@@ -33,7 +33,7 @@ describe(ScanRunnerTelemetryManager, () => {
     beforeEach(() => {
         loggerMock = Mock.ofType<Logger>();
         getCurrentDateMock = Mock.ofInstance(() => null);
-        guidGeneratorMock = Mock.ofType<GuidGenerator>();
+        guidGeneratorMock = Mock.ofType<GuidGenerator>(GuidGenerator, MockBehavior.Strict);
         guidGeneratorMock.setup((gg) => gg.getGuidTimestamp(scanId)).returns(() => new Date(scanSubmittedTimestamp));
 
         testSubject = new TestableScanRunnerTelemetryManager(loggerMock.object, guidGeneratorMock.object, getCurrentDateMock.object);

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.spec.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { GlobalLogger, Logger, LoggerEvent, TelemetryMeasurements } from 'logger';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { ScanRunnerTelemetryManager } from './scan-runner-telemetry-manager';
+
+describe(ScanRunnerTelemetryManager, () => {
+    const scanWaitTimeMillis = 10000;
+    const scanExecutionTimeMillis = 15000;
+    const scanSubmittedTimestamp = 12345678;
+    const scanStartedTimestamp = scanSubmittedTimestamp + scanWaitTimeMillis;
+    const scanCompletedTimestamp = scanStartedTimestamp + scanExecutionTimeMillis;
+
+    let loggerMock: IMock<GlobalLogger>;
+    let getCurrentDateMock: IMock<() => number>;
+
+    let testSubject: ScanRunnerTelemetryManager;
+
+    beforeEach(() => {
+        loggerMock = Mock.ofType<Logger>();
+        getCurrentDateMock = Mock.ofInstance(() => null);
+
+        testSubject = new ScanRunnerTelemetryManager(loggerMock.object, getCurrentDateMock.object);
+    });
+
+    afterEach(() => {
+        loggerMock.verifyAll();
+    });
+
+    it('trackScanStarted', () => {
+        const scanRunningMeasurements = { runningScanRequests: 1 };
+        const scanStartedMeasurements = {
+            scanWaitTime: scanWaitTimeMillis / 1000,
+            startedScanTasks: 1,
+        };
+        getCurrentDateMock.setup(g => g()).returns(() => scanStartedTimestamp);
+        setupTrackEvent('ScanRequestRunning', scanRunningMeasurements);
+        setupTrackEvent('ScanTaskStarted', scanStartedMeasurements);
+
+        testSubject.trackScanStarted(new Date(scanSubmittedTimestamp));
+
+        expect(testSubject.scanStarted).toBe(scanStartedTimestamp);
+        expect(testSubject.scanSubmitted).toBe(scanSubmittedTimestamp);
+    });
+
+    it('trackScanFailed', () => {
+        setupTrackEvent('ScanRequestFailed', { failedScanRequests: 1 });
+        setupTrackEvent('ScanTaskFailed', { failedScanTasks: 1 });
+
+        testSubject.trackScanFailed();
+    });
+
+    it('trackScanCompleted', () => {
+        getCurrentDateMock.setup(g => g()).returns(() => scanCompletedTimestamp);
+        const scanTaskCompletedMeasurements = {
+            scanExecutionTime: scanExecutionTimeMillis / 1000,
+            scanTotalTime: (scanExecutionTimeMillis + scanWaitTimeMillis) / 1000,
+            completedScanTasks: 1,
+        };
+        const ScanRequestCompletedMeasurements = { completedScanRequests: 1 };
+        setupTrackEvent('ScanTaskCompleted', scanTaskCompletedMeasurements);
+        setupTrackEvent('ScanRequestCompleted', ScanRequestCompletedMeasurements);
+        testSubject.scanSubmitted = scanSubmittedTimestamp;
+        testSubject.scanStarted = scanStartedTimestamp;
+
+        testSubject.trackScanCompleted();
+    });
+
+    it('trackScanCompleted does nothing if there is no scan start time set', () => {
+        loggerMock.setup(l => l.trackEvent(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+        testSubject.scanSubmitted = scanSubmittedTimestamp;
+
+        testSubject.trackScanCompleted();
+    });
+
+    it('trackScanCompleted does nothing if there is no scan submitted time set', () => {
+        loggerMock.setup(l => l.trackEvent(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+        testSubject.scanStarted = scanStartedTimestamp;
+
+        testSubject.trackScanCompleted();
+    });
+
+    function setupTrackEvent(eventName: LoggerEvent, measurements: TelemetryMeasurements[LoggerEvent]): void {
+        loggerMock.setup(l => l.trackEvent(eventName, undefined, measurements)).verifiable();
+    }
+});

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { GuidGenerator } from 'common';
 import { inject, injectable } from 'inversify';
 import { isNil } from 'lodash';
 import { GlobalLogger, ScanTaskCompletedMeasurements } from 'logger';
@@ -12,12 +13,13 @@ export class ScanRunnerTelemetryManager {
 
     public constructor(
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
         private readonly getCurrentTimestamp: () => number = Date.now,
     ) {}
 
-    public trackScanStarted(scanSubmittedTimestamp: Date): void {
+    public trackScanStarted(scanId: string): void {
         this.scanStarted = this.getCurrentTimestamp();
-        this.scanSubmitted = scanSubmittedTimestamp.getTime();
+        this.scanSubmitted = this.guidGenerator.getGuidTimestamp(scanId).getTime();
         this.logger.trackEvent('ScanRequestRunning', undefined, { runningScanRequests: 1 });
         this.logger.trackEvent('ScanTaskStarted', undefined, {
             scanWaitTime: this.millisToSeconds(this.scanStarted - this.scanSubmitted),

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
@@ -25,7 +25,11 @@ export class ScanRunnerTelemetryManager {
         });
     }
 
-    public trackScanFailed(): void {
+    public trackBrowserScanFailed(): void {
+        this.logger.trackEvent('BrowserScanFailed', undefined, { failedBrowserScans: 1 });
+    }
+
+    public trackScanTaskFailed(): void {
         this.logger.trackEvent('ScanRequestFailed', undefined, { failedScanRequests: 1 });
         this.logger.trackEvent('ScanTaskFailed', undefined, { failedScanTasks: 1 });
     }

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { isNil } from 'lodash';
+import { GlobalLogger, ScanTaskCompletedMeasurements } from 'logger';
+
+@injectable()
+export class ScanRunnerTelemetryManager {
+    public scanSubmitted: number;
+    public scanStarted: number;
+
+    public constructor(
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        private readonly getCurrentTimestamp: () => number = Date.now,
+    ) {}
+
+    public trackScanStarted(scanSubmittedTimestamp: Date): void {
+        this.scanStarted = this.getCurrentTimestamp();
+        this.scanSubmitted = scanSubmittedTimestamp.getTime();
+        this.logger.trackEvent('ScanRequestRunning', undefined, { runningScanRequests: 1 });
+        this.logger.trackEvent('ScanTaskStarted', undefined, {
+            scanWaitTime: (this.scanStarted - this.scanSubmitted) / 1000,
+            startedScanTasks: 1,
+        });
+    }
+
+    public trackScanFailed(): void {
+        this.logger.trackEvent('ScanRequestFailed', undefined, { failedScanRequests: 1 });
+        this.logger.trackEvent('ScanTaskFailed', undefined, { failedScanTasks: 1 });
+    }
+
+    public trackScanCompleted(): void {
+        if (isNil(this.scanStarted) || isNil(this.scanSubmitted)) {
+            return;
+        }
+        const scanCompletedTimestamp: number = this.getCurrentTimestamp();
+        const telemetryMeasurements: ScanTaskCompletedMeasurements = {
+            scanExecutionTime: (scanCompletedTimestamp - this.scanStarted) / 1000,
+            scanTotalTime: (scanCompletedTimestamp - this.scanSubmitted) / 1000,
+            completedScanTasks: 1,
+        };
+        this.logger.trackEvent('ScanTaskCompleted', undefined, telemetryMeasurements);
+        this.logger.trackEvent('ScanRequestCompleted', undefined, { completedScanRequests: 1 });
+    }
+}

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
@@ -22,7 +22,7 @@ export class ScanRunnerTelemetryManager {
         this.scanSubmitted = this.guidGenerator.getGuidTimestamp(scanId).getTime();
         this.logger.trackEvent('ScanRequestRunning', undefined, { runningScanRequests: 1 });
         this.logger.trackEvent('ScanTaskStarted', undefined, {
-            scanWaitTime: this.millisToSeconds(this.scanStarted - this.scanSubmitted),
+            scanWaitTime: this.asSeconds(this.scanStarted - this.scanSubmitted),
             startedScanTasks: 1,
         });
     }
@@ -42,15 +42,15 @@ export class ScanRunnerTelemetryManager {
         }
         const scanCompletedTimestamp: number = this.getCurrentTimestamp();
         const telemetryMeasurements: ScanTaskCompletedMeasurements = {
-            scanExecutionTime: this.millisToSeconds(scanCompletedTimestamp - this.scanStarted),
-            scanTotalTime: this.millisToSeconds(scanCompletedTimestamp - this.scanSubmitted),
+            scanExecutionTime: this.asSeconds(scanCompletedTimestamp - this.scanStarted),
+            scanTotalTime: this.asSeconds(scanCompletedTimestamp - this.scanSubmitted),
             completedScanTasks: 1,
         };
         this.logger.trackEvent('ScanTaskCompleted', undefined, telemetryMeasurements);
         this.logger.trackEvent('ScanRequestCompleted', undefined, { completedScanRequests: 1 });
     }
 
-    private millisToSeconds(millis: number): number {
-        return millis / 1000;
+    private asSeconds(milliseconds: number): number {
+        return milliseconds / 1000;
     }
 }

--- a/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
+++ b/packages/web-api-scan-runner/src/scan-runner-telemetry-manager.ts
@@ -7,8 +7,8 @@ import { GlobalLogger, ScanTaskCompletedMeasurements } from 'logger';
 
 @injectable()
 export class ScanRunnerTelemetryManager {
-    public scanSubmitted: number;
-    public scanStarted: number;
+    protected scanSubmitted: number;
+    protected scanStarted: number;
 
     public constructor(
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
@@ -20,7 +20,7 @@ export class ScanRunnerTelemetryManager {
         this.scanSubmitted = scanSubmittedTimestamp.getTime();
         this.logger.trackEvent('ScanRequestRunning', undefined, { runningScanRequests: 1 });
         this.logger.trackEvent('ScanTaskStarted', undefined, {
-            scanWaitTime: (this.scanStarted - this.scanSubmitted) / 1000,
+            scanWaitTime: this.millisToSeconds(this.scanStarted - this.scanSubmitted),
             startedScanTasks: 1,
         });
     }
@@ -40,11 +40,15 @@ export class ScanRunnerTelemetryManager {
         }
         const scanCompletedTimestamp: number = this.getCurrentTimestamp();
         const telemetryMeasurements: ScanTaskCompletedMeasurements = {
-            scanExecutionTime: (scanCompletedTimestamp - this.scanStarted) / 1000,
-            scanTotalTime: (scanCompletedTimestamp - this.scanSubmitted) / 1000,
+            scanExecutionTime: this.millisToSeconds(scanCompletedTimestamp - this.scanStarted),
+            scanTotalTime: this.millisToSeconds(scanCompletedTimestamp - this.scanSubmitted),
             completedScanTasks: 1,
         };
         this.logger.trackEvent('ScanTaskCompleted', undefined, telemetryMeasurements);
         this.logger.trackEvent('ScanRequestCompleted', undefined, { completedScanRequests: 1 });
+    }
+
+    private millisToSeconds(millis: number): number {
+        return millis / 1000;
     }
 }


### PR DESCRIPTION
#### Description of changes

Extract the trackEvent calls in runner.ts to another class, ScanRunnerTelemetryManager. The new class is also responsible for managing the "scan started" and "scan completed" timestamps. This simplifies the Runner unit tests, since it a) removes the need to mock Date.now() calls in runner tests, and b) reduces the number of logger calls to be verified.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
