### PR TITLE
feat(host-browser-service): update webdriver to accept ws-endpoint for puppeteer connection

### DIFF
--- a/packages/cli/src/scanner/ai-scanner.spec.ts
+++ b/packages/cli/src/scanner/ai-scanner.spec.ts
@@ -47,8 +47,7 @@ describe('AIScanner', () => {
     });
 
     function setupNewPageCall(): void {
-        pageMock.setup(async (p) => p.create(It.isObjectWith({ browserExecutablePath: undefined })))
-                .verifiable(Times.once());
+        pageMock.setup(async (p) => p.create(It.isObjectWith({ browserExecutablePath: undefined }))).verifiable(Times.once());
     }
 
     function setupPageCloseCall(): void {

--- a/packages/cli/src/scanner/ai-scanner.spec.ts
+++ b/packages/cli/src/scanner/ai-scanner.spec.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata';
 
 import { AxeResults } from 'axe-core';
 import { AxePuppeteerFactory, AxeScanResults, Page } from 'scanner-global-library';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { AIScanner } from './ai-scanner';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -47,7 +47,8 @@ describe('AIScanner', () => {
     });
 
     function setupNewPageCall(): void {
-        pageMock.setup(async (p) => p.create(undefined)).verifiable(Times.once());
+        pageMock.setup(async (p) => p.create(It.isObjectWith({ browserExecutablePath: undefined })))
+                .verifiable(Times.once());
     }
 
     function setupPageCloseCall(): void {

--- a/packages/cli/src/scanner/ai-scanner.ts
+++ b/packages/cli/src/scanner/ai-scanner.ts
@@ -8,10 +8,10 @@ import { System } from 'common';
 export class AIScanner {
     constructor(@inject(Page) private readonly page: Page) {}
 
-    public async scan(url: string, chromePath?: string, sourcePath?: string): Promise<AxeScanResults> {
+    public async scan(url: string, browserExecutablePath?: string, sourcePath?: string): Promise<AxeScanResults> {
         try {
             console.log(`Starting accessibility scanning of URL ${url}`);
-            await this.page.create(chromePath);
+            await this.page.create({ browserExecutablePath });
             await this.page.navigateToUrl(url);
 
             return await this.page.scanForA11yIssues(sourcePath);

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -244,6 +244,45 @@ describe(Page, () => {
         browserMock.verify(async (o) => o.newPage(), Times.once());
     });
 
+    it('create() with browser url', async () => {
+        browserMock
+            .setup(async (o) => o.newPage())
+            .returns(() => Promise.resolve(puppeteerPageMock.object))
+            .verifiable();
+        webDriverMock
+            .setup(async (m) => m.launch(It.isValue('path')))
+            .returns(() => Promise.resolve(browserMock.object))
+            .verifiable();
+        page.browser = undefined;
+        page.page = undefined;
+
+        await page.create({
+            browserExecutablePath: 'path',
+        });
+
+        browserMock.verify(async (o) => o.newPage(), Times.once());
+    });
+
+    it('create() prioritizes ws endpoint option if provided', async () => {
+        browserMock
+            .setup(async (o) => o.newPage())
+            .returns(() => Promise.resolve(puppeteerPageMock.object))
+            .verifiable();
+        webDriverMock
+            .setup(async (m) => m.connect(It.isValue('ws')))
+            .returns(() => Promise.resolve(browserMock.object))
+            .verifiable();
+        page.browser = undefined;
+        page.page = undefined;
+
+        await page.create({
+            browserExecutablePath: 'path',
+            browserWSEndpoint: 'ws',
+        });
+
+        browserMock.verify(async (o) => o.newPage(), Times.once());
+    });
+
     it('close()', async () => {
         webDriverMock
             .setup(async (o) => o.close())

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -12,6 +12,11 @@ import { WebDriver } from './web-driver';
 import { PageNavigator } from './page-navigator';
 import { BrowserError } from './browser-error';
 
+export interface BrowserStartOptions {
+    browserExecutablePath?: string;
+    browserWSEndpoint?: string;
+}
+
 @injectable()
 export class Page {
     public requestUrl: string;
@@ -33,8 +38,13 @@ export class Page {
         @inject(GlobalLogger) @optional() private readonly logger: GlobalLogger,
     ) {}
 
-    public async create(browserExecutablePath?: string): Promise<void> {
-        this.browser = await this.webDriver.launch(browserExecutablePath);
+    public async create(options?: BrowserStartOptions): Promise<void> {
+        if (options?.browserWSEndpoint !== undefined) {
+            this.browser = await this.webDriver.connect(options.browserWSEndpoint);
+        } else {
+            this.browser = await this.webDriver.launch(options?.browserExecutablePath);
+        }
+
         this.page = await this.browser.newPage();
     }
 

--- a/packages/scanner-global-library/src/puppeteer-options.ts
+++ b/packages/scanner-global-library/src/puppeteer-options.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import Puppeteer from 'puppeteer';
+
+export const defaultBrowserOptions: Puppeteer.BrowserOptions = {
+    defaultViewport: {
+        width: 1920,
+        height: 1080,
+        deviceScaleFactor: 1,
+    },
+};
+
+export const defaultLaunchOptions: Puppeteer.LaunchOptions = {
+    headless: true,
+    args: ['--disable-dev-shm-usage'],
+    ...defaultBrowserOptions,
+};

--- a/packages/scanner-global-library/src/web-driver.spec.ts
+++ b/packages/scanner-global-library/src/web-driver.spec.ts
@@ -72,7 +72,7 @@ describe('WebDriver', () => {
 
     it('should connect to existing puppeteer browser', async () => {
         puppeteerConnectMock
-            .setup(async c => c(It.isObjectWith({ browserWSEndpoint: 'ws'})))
+            .setup(async (c) => c(It.isObjectWith({ browserWSEndpoint: 'ws' })))
             .returns(async () => Promise.resolve(<Puppeteer.Browser>(<unknown>puppeteerBrowserMock)))
             .verifiable(Times.once());
 

--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -3,6 +3,7 @@
 import { inject, injectable, optional } from 'inversify';
 import { GlobalLogger, Logger } from 'logger';
 import Puppeteer from 'puppeteer';
+import { defaultBrowserOptions, defaultLaunchOptions } from './puppeteer-options';
 
 @injectable()
 export class WebDriver {
@@ -13,16 +14,20 @@ export class WebDriver {
         private readonly puppeteer: typeof Puppeteer = Puppeteer,
     ) {}
 
+    public async connect(wsEndpoint: string): Promise<Puppeteer.Browser> {
+        this.browser = await this.puppeteer.connect({
+            browserWSEndpoint: wsEndpoint,
+            ...defaultBrowserOptions,
+        });
+        this.logger?.logInfo('Chromium browser instance connected.');
+
+        return this.browser;
+    }
+
     public async launch(browserExecutablePath?: string): Promise<Puppeteer.Browser> {
         this.browser = await this.puppeteer.launch({
             executablePath: browserExecutablePath,
-            headless: true,
-            args: ['--disable-dev-shm-usage'],
-            defaultViewport: {
-                width: 1920,
-                height: 1080,
-                deviceScaleFactor: 1,
-            },
+            ...defaultLaunchOptions,
         });
         this.logger?.logInfo('Chromium browser instance started.');
 

--- a/packages/web-api-scan-runner/src/runner/ws-endpoint-fetcher.ts
+++ b/packages/web-api-scan-runner/src/runner/ws-endpoint-fetcher.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import got, { Agents, Got, Options } from 'got';
+
+export const fetchWSEndpoint = (): string => {
+    return '';
+};

--- a/packages/web-api-scan-runner/src/runner/ws-endpoint-fetcher.ts
+++ b/packages/web-api-scan-runner/src/runner/ws-endpoint-fetcher.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-import got, { Agents, Got, Options } from 'got';
-
-export const fetchWSEndpoint = (): string => {
-    return '';
-};


### PR DESCRIPTION
#### Details

This PR adds `puppeteer.connect` functionality to inner `webdriver` and `page` classes.

`puppeteer-options` is moved into its own file so that the `host-browser-service` can reuse it eventually.

The coniditional `launch/connect` decision is in `page` for now.

##### Motivation

Enable `web-api-scan-runner` to run scans via `puppeteer.connect` in future PRs

##### Context

This PR only adds new methods & updates existing usages - production behavior should not be changed in this PR. All scans still use `launch`, not `connect` yet.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
