### PR TITLE
fix: pin npm-force-resolutions to v0.0.3

### DIFF
--- a/packages/web-api-scan-runner/docker-image-config/Dockerfile
+++ b/packages/web-api-scan-runner/docker-image-config/Dockerfile
@@ -19,7 +19,7 @@ COPY package.json ./
 
 RUN npm install \
     # Force npm package resolution
-    && npx npm-force-resolutions \
+    && npx npm-force-resolutions@0.0.3 \
     && npm install \
     # Add user so we don't need --no-sandbox.
     # same layer as npm install to keep re-chowned files from using up several hundred MBs more space


### PR DESCRIPTION
#### Details

Force our dockerfile to use npm-force-resolutions v0.0.3 instead of pulling the most recent version from npm

##### Motivation

Version 0.0.4 of npm-force-resolutions contains a bug when running it with npx.  Because we currently don't specify the version of npm-force-resolutions, our docker build started failing shortly after it was published.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
