### PR TITLE
fix: Handle error when message already expired

### DIFF
--- a/packages/azure-services/src/azure-queue/queue.ts
+++ b/packages/azure-services/src/azure-queue/queue.ts
@@ -118,7 +118,11 @@ export class Queue {
     }
 
     private async deleteQueueMessage(queueClient: QueueClient, messageId: string, popReceipt: string): Promise<void> {
-        await queueClient.deleteMessage(messageId, popReceipt);
+        try {
+            await queueClient.deleteMessage(messageId, popReceipt);
+        } catch (error) {
+            this.logger.logError(`Failed to delete message in a queue storage: ${util.inspect(messageId)}. Error: ${util.inspect(error)}`);
+        }
     }
 
     private async getQueueMessages(queueClient: QueueClient, numberOfMessages: number): Promise<DequeuedMessageItem[]> {


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Sometimes when we set the visibility time out to 5 minutes, the task fails and then when we retry, it will be more than 5 mins, so at the end of the second task when we try to delete the message, it will be already expired and deleted so the task will crash and stop all other active runner tasks which cause some scans to be in running status forever.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
