### PR TITLE
fix: keyvault encryption

### DIFF
--- a/packages/resource-deployment/scripts/setup-key-vault.sh
+++ b/packages/resource-deployment/scripts/setup-key-vault.sh
@@ -77,6 +77,12 @@ function createOrRecoverKeyvault() {
     fi
 }
 
+function setAccessPolicies() {
+    az keyvault update --name $keyVault --resourceGroup $resourceGroupName --enabled-for-disk-encryption "true"
+    az keyvault update --name $keyVault --resourceGroup $resourceGroupName --enabled-for-deployment "true"
+    az keyvault update --name $keyVault --resourceGroup $resourceGroupName --enabled-for-template-deployment "true"
+}
+
 function setupKeyVaultResources() {
     echo "Setting up key vault resources using ARM template."
     resources=$(
@@ -123,6 +129,8 @@ fi
 createOrRecoverKeyvault
 
 setupKeyVaultResources
+
+setAccessPolicies
 
 . "${0%/*}/push-secrets-to-key-vault.sh"
 

--- a/packages/resource-deployment/scripts/setup-key-vault.sh
+++ b/packages/resource-deployment/scripts/setup-key-vault.sh
@@ -78,9 +78,9 @@ function createOrRecoverKeyvault() {
 }
 
 function setAccessPolicies() {
-    az keyvault update --name $keyVault --resourceGroup $resourceGroupName --enabled-for-disk-encryption "true"
-    az keyvault update --name $keyVault --resourceGroup $resourceGroupName --enabled-for-deployment "true"
-    az keyvault update --name $keyVault --resourceGroup $resourceGroupName --enabled-for-template-deployment "true"
+    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-disk-encryption "true"
+    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-deployment "true"
+    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-template-deployment "true"
 }
 
 function setupKeyVaultResources() {


### PR DESCRIPTION
#### Details

Enable keyvault encryption in deployment script

##### Motivation

We added keyvault encryption as part of the switch to Windows VMs. Currently, for existing resource groups, encryption must be enabled manually for deployment to succeed.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
