### PR TITLE
feat(host-browser-service): add initial skeleton for host-browser-server package

### DIFF
--- a/.vscode/workspace.code-workspace
+++ b/.vscode/workspace.code-workspace
@@ -81,6 +81,10 @@
             "path": "../packages/health-client"
         },
         {
+            "name": "host-browser-service",
+            "path": "../packages/host-browser-service"
+        },
+        {
             "name": "cli",
             "path": "../packages/cli"
         },

--- a/azure-pipeline/build-artifacts-and-run-tests-job.yaml
+++ b/azure-pipeline/build-artifacts-and-run-tests-job.yaml
@@ -39,6 +39,7 @@ steps:
               e2e-web-apis/dist/**/*
               functional-tests/dist/**/*
               health-client/dist/**/*
+              host-browser-service/dist/**/*
               cli/drop/*
               !**/node_modules/**/*
               !**/.vscode/**/*

--- a/packages/common/src/build-utilities/monorepo-packages.spec.ts
+++ b/packages/common/src/build-utilities/monorepo-packages.spec.ts
@@ -14,6 +14,7 @@ describe('listMonorepoPackageNames', () => {
               "e2e-web-apis",
               "functional-tests",
               "health-client",
+              "host-browser-service",
               "logger",
               "resource-deployment",
               "scanner-global-library",

--- a/packages/host-browser-service/jest.config.js
+++ b/packages/host-browser-service/jest.config.js
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../jest.config.base');
+const package = require('./package');
+
+module.exports = {
+    ...baseConfig,
+    displayName: package.name,
+};

--- a/packages/host-browser-service/package.json
+++ b/packages/host-browser-service/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "host-browser-service",
+    "version": "1.0.0",
+    "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
+    "scripts": {
+        "build": "webpack --config ./webpack.config.js",
+        "cbuild": "npm-run-all --serial clean build",
+        "clean": "rimraf dist",
+        "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
+        "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
+        "test": "jest --coverage --colors"
+    },
+    "repository": "git+https://github.com/Microsoft/accessibility-insights-service.git",
+    "main": "dist/host-browser-service.js",
+    "author": "Microsoft",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Microsoft/accessibility-insights-service/issues"
+    },
+    "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
+    "devDependencies": {
+        "@types/chai": "^4.2.14",
+        "@types/jest": "^26.0.20",
+        "@types/lodash": "^4.14.168",
+        "@types/node": "^12.12.54",
+        "jest": "^26.6.3",
+        "jest-circus": "^26.6.3",
+        "jest-junit": "^12.0.0",
+        "rimraf": "^3.0.2",
+        "ts-jest": "^26.4.4",
+        "typemoq": "^2.1.0",
+        "typescript": "^4.1.3"
+    },
+    "dependencies": {
+        "common": "^1.0.0",
+        "inversify": "^5.0.5",
+        "logger": "1.0.0",
+        "reflect-metadata": "^0.1.13",
+        "scanner-global-library": "1.0.0",
+        "service-library": "1.0.0"
+    }
+}

--- a/packages/host-browser-service/prettier.config.js
+++ b/packages/host-browser-service/prettier.config.js
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../prettier.config');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/packages/host-browser-service/src/browser-server.spec.ts
+++ b/packages/host-browser-service/src/browser-server.spec.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Mock, Times } from 'typemoq';
+import { GlobalLogger } from 'logger';
+import { BrowserServer } from './browser-server';
+
+describe(BrowserServer, () => {
+    it('server logs', () => {
+        const loggerMock = Mock.ofType<GlobalLogger>();
+        const browserServer = new BrowserServer(loggerMock.object);
+        browserServer.run();
+        loggerMock.verify((m) => m.logInfo(`BrowserServer.run() called`), Times.once());
+    });
+});

--- a/packages/host-browser-service/src/browser-server.ts
+++ b/packages/host-browser-service/src/browser-server.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inject, injectable, optional } from 'inversify';
+import { GlobalLogger, Logger } from 'logger';
+
+@injectable()
+export class BrowserServer {
+    constructor(
+        @inject(GlobalLogger) @optional() private readonly logger: Logger,
+    ) {}
+
+    public run(): void {
+        this.logger.logInfo(`BrowserServer.run() called`);
+    }
+}

--- a/packages/host-browser-service/src/browser-server.ts
+++ b/packages/host-browser-service/src/browser-server.ts
@@ -5,9 +5,7 @@ import { GlobalLogger, Logger } from 'logger';
 
 @injectable()
 export class BrowserServer {
-    constructor(
-        @inject(GlobalLogger) @optional() private readonly logger: Logger,
-    ) {}
+    constructor(@inject(GlobalLogger) @optional() private readonly logger: Logger) {}
 
     public run(): void {
         this.logger.logInfo(`BrowserServer.run() called`);

--- a/packages/host-browser-service/src/host-browser-service-entry-point.spec.ts
+++ b/packages/host-browser-service/src/host-browser-service-entry-point.spec.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { BaseTelemetryProperties, GlobalLogger } from 'logger';
+import { IMock, Mock, Times } from 'typemoq';
+import { HostBrowserServiceEntryPoint } from './host-browser-service-entry-point';
+import { BrowserServer } from './browser-server';
+
+class TestableHostBrowserServiceEntryPoint extends HostBrowserServiceEntryPoint {
+    public invokeGetTelemetryBaseProperties(): BaseTelemetryProperties {
+        return this.getTelemetryBaseProperties();
+    }
+
+    public async runCustomAction(container: Container): Promise<void> {
+        return super.runCustomAction(container);
+    }
+}
+
+describe(TestableHostBrowserServiceEntryPoint, () => {
+    let testSubject: TestableHostBrowserServiceEntryPoint;
+    let containerMock: IMock<Container>;
+    let loggerMock: IMock<GlobalLogger>;
+    let browserServerMock: IMock<BrowserServer>;
+
+    beforeEach(() => {
+        containerMock = Mock.ofType(Container);
+        loggerMock = Mock.ofType(GlobalLogger);
+        browserServerMock = Mock.ofType(BrowserServer);
+
+        containerMock.setup((c) => c.get(GlobalLogger)).returns(() => loggerMock.object);
+        containerMock.setup((c) => c.get(BrowserServer)).returns(() => browserServerMock.object);
+
+        testSubject = new TestableHostBrowserServiceEntryPoint(containerMock.object);
+    });
+
+    describe('getTelemetryBaseProperties', () => {
+        it('returns data with source property', () => {
+            expect(testSubject.invokeGetTelemetryBaseProperties()).toEqual({
+                source: 'hostBrowserService',
+            } as BaseTelemetryProperties);
+        });
+    });
+
+    describe('runCustomAction', () => {
+        it('starts browser server', async () => {
+            loggerMock
+                .setup(async (l) => l.setup())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            browserServerMock
+                .setup(async (m) => m.run())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            await testSubject.runCustomAction(containerMock.object);
+        });
+    });
+
+    afterEach(() => {
+        loggerMock.verifyAll();
+        containerMock.verifyAll();
+        browserServerMock.verifyAll();
+    });
+});

--- a/packages/host-browser-service/src/host-browser-service-entry-point.ts
+++ b/packages/host-browser-service/src/host-browser-service-entry-point.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Container } from 'inversify';
+import { BaseTelemetryProperties, GlobalLogger } from 'logger';
+import { ProcessEntryPointBase } from 'service-library';
+import { BrowserServer } from './browser-server';
+
+export class HostBrowserServiceEntryPoint extends ProcessEntryPointBase {
+    protected getTelemetryBaseProperties(): BaseTelemetryProperties {
+        return { source: 'hostBrowserService' };
+    }
+
+    protected async runCustomAction(container: Container): Promise<void> {
+        const logger = container.get(GlobalLogger);
+        await logger.setup();
+
+        const server = container.get(BrowserServer);
+        await server.run();
+    }
+}

--- a/packages/host-browser-service/src/index.ts
+++ b/packages/host-browser-service/src/index.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+import { System } from 'common';
+import { setupHostBrowserServiceContainer } from './setup-host-browser-service-container';
+import { HostBrowserServiceEntryPoint } from './host-browser-service-entry-point';
+
+(async () => {
+    await new HostBrowserServiceEntryPoint(setupHostBrowserServiceContainer()).start();
+})().catch((error) => {
+    console.log(System.serializeError(error));
+    process.exitCode = 1;
+});

--- a/packages/host-browser-service/src/promisable-mock.ts
+++ b/packages/host-browser-service/src/promisable-mock.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IMock } from 'typemoq';
+
+export function getPromisableDynamicMock<T>(mock: IMock<T>): IMock<T> {
+    // workaround for issue https://github.com/florinn/typemoq/issues/70
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.setup((x: any) => x.then).returns(() => undefined);
+
+    return mock;
+}

--- a/packages/host-browser-service/src/setup-host-browser-service-container.ts
+++ b/packages/host-browser-service/src/setup-host-browser-service-container.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { setupRuntimeConfigContainer } from 'common';
+import * as inversify from 'inversify';
+import { registerLoggerToContainer } from 'logger';
+
+export function setupHostBrowserServiceContainer(): inversify.Container {
+    const container = new inversify.Container({ autoBindInjectable: true });
+    setupRuntimeConfigContainer(container);
+    registerLoggerToContainer(container);
+
+    return container;
+}

--- a/packages/host-browser-service/src/setup-host-browser-service.container.spec.ts
+++ b/packages/host-browser-service/src/setup-host-browser-service.container.spec.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import 'reflect-metadata';
+
+import { ServiceConfiguration } from 'common';
+import { setupHostBrowserServiceContainer } from './setup-host-browser-service-container';
+import { BrowserServer } from './browser-server';
+
+describe(setupHostBrowserServiceContainer, () => {
+    it('verify browser server dependencies resolution', () => {
+        const container = setupHostBrowserServiceContainer();
+        expect(container.get(BrowserServer)).toBeDefined();
+    });
+
+    it('resolves singleton dependencies', () => {
+        const container = setupHostBrowserServiceContainer();
+        const serviceConfig = container.get(ServiceConfiguration);
+
+        expect(serviceConfig).toBeInstanceOf(ServiceConfiguration);
+        expect(serviceConfig).toBe(container.get(ServiceConfiguration));
+    });
+});

--- a/packages/host-browser-service/tsconfig.json
+++ b/packages/host-browser-service/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    }
+}

--- a/packages/host-browser-service/webpack.config.js
+++ b/packages/host-browser-service/webpack.config.js
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const path = require('path');
+const webpack = require('webpack');
+
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = (env) => {
+    const version = env ? env.version : 'dev';
+    console.log(`Building for version : ${version}`);
+
+    return {
+        devtool: 'cheap-source-map',
+        entry: {
+            ['host-browser-service']: path.resolve('./src/index.ts'),
+        },
+        mode: 'development',
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    use: [
+                        {
+                            loader: 'ts-loader',
+                            options: {
+                                transpileOnly: true,
+                                experimentalWatchApi: true,
+                            },
+                        },
+                    ],
+                    exclude: ['/node_modules/', /\.(spec|e2e)\.ts$/],
+                },
+                {
+                    test: /\.node$/,
+                    use: [
+                        {
+                            loader: 'node-loader',
+                        },
+                    ],
+                },
+            ],
+        },
+        name: 'host-browser-service',
+        node: {
+            __dirname: false,
+        },
+        output: {
+            path: path.resolve('./dist'),
+            filename: '[name].js',
+            libraryTarget: 'commonjs2',
+        },
+        plugins: [
+            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true }),
+            new webpack.DefinePlugin({
+                __IMAGE_VERSION__: JSON.stringify(version),
+            }),
+            new ForkTsCheckerWebpackPlugin(),
+        ],
+        resolve: {
+            extensions: ['.ts', '.js', '.json'],
+            mainFields: ['main'], //This is fix for this issue https://www.gitmemory.com/issue/bitinn/node-fetch/450/494475397
+        },
+        target: 'node',
+    };
+};


### PR DESCRIPTION
This PR includes initial placeholder/config files to set up the host-browser-server folder.

#### Details

This PR has placeholder functionality to get some config files out of the way. The project is not used and no production behavior should change.

##### Motivation/Context

This package will eventually produce a file that accepts puppeteer.connect() requests from the web-api-scan-runner (in docker) and routes them to new browser connections. The server will run on the host outside the docker container. In this PR, the 'server' does nothing except log that it was run.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
