### PR TITLE
chore: edit deployment scripts to better fit the new Windows VMs

### DIFF
--- a/packages/resource-deployment/scripts/restart-vm-pools.sh
+++ b/packages/resource-deployment/scripts/restart-vm-pools.sh
@@ -36,7 +36,7 @@ function waitForStablePoolNodes() {
     local nodeTypeContentSelector="[?poolId=='$pool']|[0].$nodeType"
 
     echo "Waiting for pool $pool $nodeType nodes to become stable after restart"
-    end=$((SECONDS + 600))
+    end=$((SECONDS + 900))
     printf " - Running .."
     while [ $SECONDS -le $end ]; do
         # Node states https://docs.microsoft.com/en-us/azure/batch/batch-get-resource-counts#node-state-counts

--- a/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
+++ b/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
@@ -60,7 +60,7 @@ waitForNodesToGoIdleByNodeType() {
     local nodeType=$2
 
     local isIdle=false
-    local waitTime=300
+    local waitTime=600
     local nodeTypeContentSelector="[?poolId=='$pool']|[0].$nodeType"
 
     echo "Waiting for $nodeType nodes under $pool to go idle"

--- a/packages/resource-deployment/scripts/setup-key-vault.sh
+++ b/packages/resource-deployment/scripts/setup-key-vault.sh
@@ -78,9 +78,9 @@ function createOrRecoverKeyvault() {
 }
 
 function setAccessPolicies() {
-    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-disk-encryption "true"
-    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-deployment "true"
-    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-template-deployment "true"
+    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-disk-encryption "true" 1>/dev/null
+    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-deployment "true" 1>/dev/null
+    az keyvault update --name $keyVault --resource-group $resourceGroupName --enabled-for-template-deployment "true" 1>/dev/null
 }
 
 function setupKeyVaultResources() {


### PR DESCRIPTION
#### Details

- Increase timeouts for batch nodes to become stable
- Suppress the output of `az keyvault update` in deployment scripts

##### Motivation

- The new Windows VMs start up slower than the old Linux ones, so sometimes a restart times out and causes the deployment pipeline to fail when nothing has actually gone wrong and the restart completes successfully a few minutes later.
- The output of `az keyvault update` is very long and not useful for our purposes, so this will remove the chore of having to scroll past it in deployment logs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
