### PR TITLE
chore: increase timeout for nodes to become idle

### DIFF
--- a/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
+++ b/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
@@ -60,7 +60,7 @@ waitForNodesToGoIdleByNodeType() {
     local nodeType=$2
 
     local isIdle=false
-    local waitTime=600
+    local waitTime=1800
     local nodeTypeContentSelector="[?poolId=='$pool']|[0].$nodeType"
 
     echo "Waiting for $nodeType nodes under $pool to go idle"
@@ -90,11 +90,13 @@ waitForNodesToGoIdleByNodeType() {
         fi
     done
 
-    echo "Currrent $pool pool status for $nodeType:"
-    az batch pool node-counts list --query "$nodeTypeContentSelector" 1>/dev/null
+    echo "Current $pool pool status for $nodeType:"
+    az batch pool node-counts list --query "$nodeTypeContentSelector"
 
     if [[ $isIdle == false ]]; then
         echo "Pool $pool $nodeType nodes did not become idle."
+        az batch pool node-counts list --query "$nodeTypeContentSelector"
+
         enableJobSchedule
         exit 1
     fi


### PR DESCRIPTION
#### Details

Increase timeout for nodes to become idle after disabling job schedules from 10 to 30 minutes, and log node states after the wait either succeeds or fails.

##### Motivation

Recently, many of our builds have been timing out while waiting for nodes to become idle, even when nothing is wrong with the nodes themselves. The increased wait should prevent this from happening so often, and the log statements will give us more information to debug if it does keep happening.

##### Context

The source of this problem is that scan tasks take longer on the new Windows VMs. This means that, during the space of a running task, more new tasks get queued, so some jobs have a lot more tasks than we saw on the old Linux VMs. This means that jobs take longer overall, and continue for longer than expected after the job schedules are disabled, so nodes take longer to become idle. Another solution we may want to explore in the future is to limit the number of tasks per job or stop creating tasks after a certain point, so we don't have so many long-running jobs.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
