### PR TITLE
Chore: Reduce Job Manager Task Restart Time

### DIFF
--- a/packages/service-library/src/batch/batch-task-creator.spec.ts
+++ b/packages/service-library/src/batch/batch-task-creator.spec.ts
@@ -317,7 +317,7 @@ describe(BatchTaskCreator, () => {
 
         loggerMock
             .setup((o) =>
-                o.logInfo(`Performing scheduled job manager termination after ${jobManagerConfig.maxWallClockTimeInHours} hours.`),
+                o.logInfo(`Performing scheduled job manager termination after ${jobManagerConfig.maxWallClockTimeInHours / 2} hours.`),
             )
             .verifiable();
 

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -45,7 +45,7 @@ export abstract class BatchTaskCreator {
         }
 
         this.activeScanMessages = [];
-        const restartAfterTime = moment().add(this.jobManagerConfig.maxWallClockTimeInHours, 'hour').toDate();
+        const restartAfterTime = moment().add(this.jobManagerConfig.maxWallClockTimeInHours / 2.0, 'hour').toDate();
 
         // eslint-disable-next-line no-constant-condition
         while (true) {

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -64,7 +64,7 @@ export abstract class BatchTaskCreator {
 
             if (moment().toDate() >= restartAfterTime) {
                 this.logger.logInfo(
-                    `Performing scheduled job manager termination after ${this.jobManagerConfig.maxWallClockTimeInHours} hours.`,
+                    `Performing scheduled job manager termination after ${this.jobManagerConfig.maxWallClockTimeInHours / 2} hours.`,
                 );
 
                 break;

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -45,7 +45,9 @@ export abstract class BatchTaskCreator {
         }
 
         this.activeScanMessages = [];
-        const restartAfterTime = moment().add(this.jobManagerConfig.maxWallClockTimeInHours / 2.0, 'hour').toDate();
+        const restartAfterTime = moment()
+            .add(this.jobManagerConfig.maxWallClockTimeInHours / 2.0, 'hour')
+            .toDate();
 
         // eslint-disable-next-line no-constant-condition
         while (true) {

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -46,7 +46,7 @@ export abstract class BatchTaskCreator {
 
         this.activeScanMessages = [];
         const restartAfterTime = moment()
-            .add(this.jobManagerConfig.maxWallClockTimeInHours / 2.0, 'hour')
+            .add(this.jobManagerConfig.maxWallClockTimeInHours / 2, 'hour')
             .toDate();
 
         // eslint-disable-next-line no-constant-condition


### PR DESCRIPTION
#### Details
The job manager task timesout sometimes before hitting the code that check for that, and that causes some scans to be pending forever since some of the tasks will be terminated before even starting or while running.
So in this PR we will give some margin to the job manager task and pending runner tasks to end before the max clock wall time expires.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
