### PR TITLE
fix: increase max memory allocated to chromium

### DIFF
--- a/packages/scanner-global-library/src/puppeteer-options.ts
+++ b/packages/scanner-global-library/src/puppeteer-options.ts
@@ -12,6 +12,6 @@ export const defaultBrowserOptions: Puppeteer.BrowserOptions = {
 
 export const defaultLaunchOptions: Puppeteer.LaunchOptions = {
     headless: true,
-    args: ['--disable-dev-shm-usage', '--no-sandbox', '--disable-setuid-sandbox'],
+    args: ['--disable-dev-shm-usage', '--no-sandbox', '--disable-setuid-sandbox', '--js-flags=--max-old-space-size=8192'],
     ...defaultBrowserOptions,
 };


### PR DESCRIPTION
#### Details

Increase the maximum threshold of memory available to Chromium to 8GB.

##### Motivation

For some URLs (ex. https://dotnet.microsoft.com/learn/dotnet/in-browser-tutorial/2), we see a sudden spike in memory use when scanning, which causes chromium to run out of memory and crash when running on the VMs. After this change, we can successfully scan those URLs.

#### Context

The current default memory limit for Chromium is dependent on the specific machine and environment. Our VMs have enough memory available to complete these scans, but it the current defaults prevent enough memory from being allocated to chromium.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
