### PR TITLE
fix: fail windows pool startup on any error

### DIFF
--- a/packages/resource-deployment/scripts/pool-startup/pool-startup.ps1
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup.ps1
@@ -7,6 +7,8 @@ Param(
     [string]$keyvault
 )
 
+$ErrorActionPreference = "Stop"
+
 $global:keyvault = $keyvault
 
 function exitWithUsageInfo {


### PR DESCRIPTION
#### Details

Make powershell pool startup script fail on error

##### Motivation

Currently, our powershell scripts continue execution when a step fails, which means that the start task will show as "succeeded" even if an important step failed. This change will make start task failures more visible to us, and block any scan tasks from running until the start task failures have been corrected.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
