### PR TITLE
refactor: refresh e2e consolidated scan id after each release

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ServiceConfiguration verifies custom config 1`] = `
 Object {
   "availabilityTestConfig": Object {
-    "consolidatedReportId": Object {
+    "consolidatedIdBase": Object {
       "default": "e2e-consolidated-report-id",
       "doc": "The id for the consolidated report",
       "format": "String",
@@ -196,7 +196,7 @@ Object {
 exports[`ServiceConfiguration verifies dev config 1`] = `
 Object {
   "availabilityTestConfig": Object {
-    "consolidatedReportId": Object {
+    "consolidatedIdBase": Object {
       "default": "e2e-consolidated-report-id",
       "doc": "The id for the consolidated report",
       "format": "String",

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -68,7 +68,7 @@ export interface AvailabilityTestConfig {
     maxScanWaitTimeInSeconds: number;
     logQueryTimeRange: string;
     environmentDefinition: string;
-    consolidatedReportId: string;
+    consolidatedIdBase: string;
     scanNotifyApiEndpoint: string;
     scanNotifyFailApiEndpoint: string;
     maxScanCompletionNotificationWaitTimeInSeconds: number;
@@ -275,7 +275,7 @@ export class ServiceConfiguration {
                     default: 'https://www.washington.edu/accesscomputing/AU/before.html',
                     doc: 'Url to scan for availability testing',
                 },
-                consolidatedReportId: {
+                consolidatedIdBase: {
                     format: 'String',
                     default: 'e2e-consolidated-report-id',
                     doc: 'The id for the consolidated report',

--- a/packages/web-api/src/controllers/health-check-controller.spec.ts
+++ b/packages/web-api/src/controllers/health-check-controller.spec.ts
@@ -40,7 +40,7 @@ describe(HealthCheckController, () => {
             urlToScan: 'https://www.bing.com',
             logQueryTimeRange: 'P1D',
             environmentDefinition: 'canary',
-            consolidatedReportId: 'somereportid',
+            consolidatedIdBase: 'somereportid',
             scanNotifyApiEndpoint: '/some-endpoint',
             maxScanCompletionNotificationWaitTimeInSeconds: 30,
             scanNotifyFailApiEndpoint: '/some-fail-endpoint',

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
@@ -11,7 +11,6 @@ import { TestContextData, TestEnvironment, TestGroupName } from 'functional-test
 import { Logger } from 'logger';
 import { ScanRunResultResponse, ScanCompletedNotification } from 'service-library';
 import { IMock, It, Mock, Times } from 'typemoq';
-import * as MockDate from 'mockdate';
 import { OrchestrationSteps } from '../orchestration-steps';
 import { GeneratorExecutor } from '../test-utilities/generator-executor';
 import { MockableLogger } from '../test-utilities/mockable-logger';
@@ -64,7 +63,7 @@ export interface OrchestratorStepsCallCount {
 }
 
 const baseWebApiUrl = 'some-url';
-const dateNow = new Date(1, 2, 3, 4);
+const releaseId = '123';
 
 class OrchestrationStepsStub implements OrchestrationSteps {
     public orchestratorStepsCallCount: OrchestratorStepsCallCount = {
@@ -152,7 +151,7 @@ class OrchestrationStepsStub implements OrchestrationSteps {
         this.orchestratorStepsCallCount.callSubmitScanRequest += 1;
         this.throwExceptionIfExpected();
         expect(url).toBe(this.availabilityTestConfig.urlToScan);
-        const expectedConsolidatedId = `${this.availabilityTestConfig.consolidatedIdBase}-${dateNow.toDateString()}`;
+        const expectedConsolidatedId = `${this.availabilityTestConfig.consolidatedIdBase}-${releaseId}`;
         expect(reportId).toBe(expectedConsolidatedId);
         expect(scanNotifyUrl).toEqual(`${baseWebApiUrl}${this.availabilityTestConfig.scanNotifyFailApiEndpoint}`);
 
@@ -233,7 +232,7 @@ describe('HealthMonitorOrchestrationController', () => {
             })
             .returns(() => orchestratorGeneratorMock.object);
 
-        MockDate.set(dateNow);
+        process.env.RELEASE_VERSION = releaseId;
 
         testSubject = new TestableHealthMonitorOrchestrationController(
             orchestratorStepsStub,

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
@@ -74,7 +74,7 @@ export class HealthMonitorOrchestrationController extends WebController {
             yield* orchestrationSteps.invokeHealthCheckRestApi();
 
             const scanId = yield* orchestrationSteps.invokeSubmitScanRequestRestApi(availabilityTestConfig.urlToScan, scanNotificationUrl);
-            const consolidatedId = `${availabilityTestConfig.consolidatedIdBase}-${new Date().toDateString()}`;
+            const consolidatedId = `${availabilityTestConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`;
             const consolidatedScanId = yield* orchestrationSteps.invokeSubmitConsolidatedScanRequestRestApi(
                 availabilityTestConfig.urlToScan,
                 consolidatedId,

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.ts
@@ -74,9 +74,10 @@ export class HealthMonitorOrchestrationController extends WebController {
             yield* orchestrationSteps.invokeHealthCheckRestApi();
 
             const scanId = yield* orchestrationSteps.invokeSubmitScanRequestRestApi(availabilityTestConfig.urlToScan, scanNotificationUrl);
+            const consolidatedId = `${availabilityTestConfig.consolidatedIdBase}-${new Date().toDateString()}`;
             const consolidatedScanId = yield* orchestrationSteps.invokeSubmitConsolidatedScanRequestRestApi(
                 availabilityTestConfig.urlToScan,
-                availabilityTestConfig.consolidatedReportId,
+                consolidatedId,
                 failScanNotificationUrl,
             );
             testContextData.scanId = scanId;

--- a/packages/web-workers/src/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration-steps.spec.ts
@@ -58,7 +58,7 @@ describe(OrchestrationStepsImpl, () => {
             urlToScan: 'https://www.bing.com',
             logQueryTimeRange: 'P1D',
             environmentDefinition: 'canary',
-            consolidatedReportId: 'somereportid',
+            consolidatedIdBase: 'somereportid',
             maxScanCompletionNotificationWaitTimeInSeconds: 30,
             scanNotifyApiEndpoint: '/scan-notify-api',
             scanNotifyFailApiEndpoint: '/some-fail-endpoint',


### PR DESCRIPTION
#### Details

Instead of always reusing the same id for the consolidated scan e2e test, append the release id to the consolidated id so we use a different id on each release.

##### Motivation

Currently, all e2e tests reuse the same static consolidated id, and therefore the same WebsiteScanResult document. This can be a problem if the structure of WebsiteScanResult changes in a way that is not backwards-compatible with existing documents, as we saw in a recent canary release.

This PR will make sure a new WebsiteScanResult document is created for e2e tests on each release, so that changes to the document structure will not cause e2e tests to fail.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
