### PR TITLE
Chore: Reduce Job Manager Task Restart Time 

### DIFF
--- a/packages/service-library/src/batch/batch-task-creator.spec.ts
+++ b/packages/service-library/src/batch/batch-task-creator.spec.ts
@@ -317,7 +317,7 @@ describe(BatchTaskCreator, () => {
 
         loggerMock
             .setup((o) =>
-                o.logInfo(`Performing scheduled job manager termination after ${jobManagerConfig.maxWallClockTimeInHours / 2} hours.`),
+                o.logInfo(`Performing scheduled job manager termination after ${jobManagerConfig.maxWallClockTimeInHours / 4} hours.`),
             )
             .verifiable();
 

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -46,7 +46,7 @@ export abstract class BatchTaskCreator {
 
         this.activeScanMessages = [];
         const restartAfterTime = moment()
-            .add(this.jobManagerConfig.maxWallClockTimeInHours / 2, 'hour')
+            .add(this.jobManagerConfig.maxWallClockTimeInHours / 4, 'hour')
             .toDate();
 
         // eslint-disable-next-line no-constant-condition
@@ -64,7 +64,7 @@ export abstract class BatchTaskCreator {
 
             if (moment().toDate() >= restartAfterTime) {
                 this.logger.logInfo(
-                    `Performing scheduled job manager termination after ${this.jobManagerConfig.maxWallClockTimeInHours / 2} hours.`,
+                    `Performing scheduled job manager termination after ${this.jobManagerConfig.maxWallClockTimeInHours / 4} hours.`,
                 );
 
                 break;


### PR DESCRIPTION
#### Details

In the deployment, we still fail at restarting VMs task, the reason is sometimes job manager task might take more than half an hour because many jobs were piled up which leads to timeout on waiting for node to be idle, to avoid that we decided to reduce the job manager task restart time.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
