### PR TITLE
chore: increase idle timeout in deployment

### DIFF
--- a/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
+++ b/packages/resource-deployment/scripts/run-command-when-batch-nodes-are-idle.sh
@@ -60,7 +60,7 @@ waitForNodesToGoIdleByNodeType() {
     local nodeType=$2
 
     local isIdle=false
-    local waitTime=1800
+    local waitTime=2700
     local nodeTypeContentSelector="[?poolId=='$pool']|[0].$nodeType"
 
     echo "Waiting for $nodeType nodes under $pool to go idle"


### PR DESCRIPTION
#### Details

This is a follow-up from #1316 - we are noticing cases where the deployment fails because the node took too long to get to the start task when it is created in custom install. Therefore the 'restart VM' step times out. This increases the idle timeout further as a mitigation to allow deployments to pass. Usually the deployment fails because of the timeout but the node does start as expected, just later. It's unclear why the nodes are taking this long in 'starting'.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
