### PR TITLE
fix: use taskSlotsPerNode instead of maxTasksPerNode

### DIFF
--- a/packages/resource-deployment/scripts/delete-pools-if-needed.sh
+++ b/packages/resource-deployment/scripts/delete-pools-if-needed.sh
@@ -96,7 +96,7 @@ function checkIfPoolConfigOutdated() {
         return
     fi
 
-    compareParameterFileToDeployedConfig $poolId "maxTasksPerNode" "${poolPropertyNamePrefix}MaxTasksPerNode"
+    compareParameterFileToDeployedConfig $poolId "taskSlotsPerNode" "${poolPropertyNamePrefix}TaskSlotsPerNode"
     if [[ $poolConfigOutdated == "true" ]]; then
         return
     fi

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -8,7 +8,7 @@
         "onDemandScanRequestPoolVmSize": {
             "value": "standard_d1_v2"
         },
-        "onDemandScanRequestPoolMaxTasksPerNode": {
+        "onDemandScanRequestPoolTaskSlotsPerNode": {
             "value": "4"
         },
         "onDemandUrlScanPoolNodes": {
@@ -17,7 +17,7 @@
         "onDemandUrlScanPoolVmSize": {
             "value": "standard_d11_v2"
         },
-        "onDemandUrlScanPoolMaxTasksPerNode": {
+        "onDemandUrlScanPoolTaskSlotsPerNode": {
             "value": "2"
         }
     }

--- a/packages/resource-deployment/templates/batch-account-prod.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-prod.parameters.json
@@ -8,7 +8,7 @@
         "onDemandScanRequestPoolVmSize": {
             "value": "standard_d11_v2"
         },
-        "onDemandScanRequestPoolMaxTasksPerNode": {
+        "onDemandScanRequestPoolTaskSlotsPerNode": {
             "value": "4"
         },
         "onDemandUrlScanPoolNodes": {
@@ -17,7 +17,7 @@
         "onDemandUrlScanPoolVmSize": {
             "value": "standard_d11_v2"
         },
-        "onDemandUrlScanPoolMaxTasksPerNode": {
+        "onDemandUrlScanPoolTaskSlotsPerNode": {
             "value": "2"
         }
     }

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -72,11 +72,11 @@
                 "description": "vmSize for on-demand-scan-request-pool"
             }
         },
-        "onDemandScanRequestPoolMaxTasksPerNode": {
+        "onDemandScanRequestPoolTaskSlotsPerNode": {
             "defaultValue": "2",
             "type": "string",
             "metadata": {
-                "description": "maxTasksPerNode for on-demand-scan-request-pool"
+                "description": "taskSlotsPerNode for on-demand-scan-request-pool"
             }
         },
         "onDemandUrlScanPoolNodes": {
@@ -93,11 +93,11 @@
                 "description": "vmSize for on-demand-scan-request-pool"
             }
         },
-        "onDemandUrlScanPoolMaxTasksPerNode": {
-            "defaultValue": "2",
+        "onDemandUrlScanPoolTaskSlotsPerNode": {
+            "defaultValue": "4",
             "type": "string",
             "metadata": {
-                "description": "maxTasksPerNode for on-demand-scan-request-pool"
+                "description": "taskSlotsPerNode for on-demand-scan-request-pool"
             }
         }
     },
@@ -131,7 +131,7 @@
             "properties": {
                 "vmSize": "[parameters('onDemandUrlScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
-                "maxTasksPerNode": "[parameters('onDemandUrlScanPoolMaxTasksPerNode')]",
+                "taskSlotsPerNode": "[parameters('onDemandUrlScanPoolTaskSlotsPerNode')]",
                 "taskSchedulingPolicy": {
                     "nodeFillType": "Spread"
                 },
@@ -205,7 +205,7 @@
             "properties": {
                 "vmSize": "[parameters('onDemandScanRequestPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
-                "maxTasksPerNode": "[parameters('onDemandScanRequestPoolMaxTasksPerNode')]",
+                "taskSlotsPerNode": "[parameters('onDemandScanRequestPoolTaskSlotsPerNode')]",
                 "taskSchedulingPolicy": {
                     "nodeFillType": "Spread"
                 },

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -109,7 +109,7 @@
     "resources": [
         {
             "type": "Microsoft.Batch/batchAccounts",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2021-01-01",
             "name": "[parameters('batchAccount')]",
             "location": "[parameters('location')]",
             "properties": {
@@ -125,7 +125,7 @@
         },
         {
             "type": "Microsoft.Batch/batchAccounts/pools",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2021-01-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-url-scan-pool')]",
             "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
@@ -199,7 +199,7 @@
         },
         {
             "type": "Microsoft.Batch/batchAccounts/pools",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2021-01-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-scan-request-pool')]",
             "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {


### PR DESCRIPTION
#### Details

Use taskSlotsPerNode instead of maxTasksPerNode in our deployment scripts

##### Motivation

The updated batch API uses taskSlotsPerNode instead of maxTasksPerNode. In our scripts that check whether the pool config has been updated, maxTasksPerNode is no longer found, so we always detect that the config has changed and the pools need to be deleted. This change will fix that, so that we only recycle pools when needed, which should reduce the usual deployment time.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
