### PR TITLE
Reload website document on write db operation

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -24,7 +24,7 @@ Object {
       "format": "int",
     },
     "maxScanWaitTimeInSeconds": Object {
-      "default": 900,
+      "default": 1800,
       "doc": "Maximum wait time for fetching scan status of the submitted request",
       "format": "int",
     },
@@ -217,7 +217,7 @@ Object {
       "format": "int",
     },
     "maxScanWaitTimeInSeconds": Object {
-      "default": 900,
+      "default": 1800,
       "doc": "Maximum wait time for fetching scan status of the submitted request",
       "format": "int",
     },

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -51,7 +51,7 @@ Object {
   },
   "crawlConfig": Object {
     "urlCrawlLimit": Object {
-      "default": 100,
+      "default": 10,
       "doc": "The max number of URLs that will be discovered for a deep scan",
       "format": "int",
     },
@@ -244,7 +244,7 @@ Object {
   },
   "crawlConfig": Object {
     "urlCrawlLimit": Object {
-      "default": 100,
+      "default": 10,
       "doc": "The max number of URLs that will be discovered for a deep scan",
       "format": "int",
     },

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -52,7 +52,7 @@ Object {
   "crawlConfig": Object {
     "urlCrawlLimit": Object {
       "default": 10,
-      "doc": "The max number of URLs that will be discovered for a deep scan",
+      "doc": "The maximum number of URLs that will be discovered for a deep scan",
       "format": "int",
     },
   },
@@ -245,7 +245,7 @@ Object {
   "crawlConfig": Object {
     "urlCrawlLimit": Object {
       "default": 10,
-      "doc": "The max number of URLs that will be discovered for a deep scan",
+      "doc": "The maximum number of URLs that will be discovered for a deep scan",
       "format": "int",
     },
   },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -319,8 +319,8 @@ export class ServiceConfiguration {
             crawlConfig: {
                 urlCrawlLimit: {
                     format: 'int',
-                    default: 100,
-                    doc: 'The max number of URLs that will be discovered for a deep scan',
+                    default: 10,
+                    doc: 'The maximum number of URLs that will be discovered for a deep scan',
                 },
             },
         };

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -282,7 +282,7 @@ export class ServiceConfiguration {
                 },
                 maxScanWaitTimeInSeconds: {
                     format: 'int',
-                    default: 900,
+                    default: 1800,
                     doc: 'Maximum wait time for fetching scan status of the submitted request',
                 },
                 maxScanCompletionNotificationWaitTimeInSeconds: {

--- a/packages/resource-deployment/runtime-config/runtime-config.ci.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ci.json
@@ -8,7 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-
     "scanConfig": {
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,
@@ -20,8 +19,5 @@
     },
     "availabilityTestConfig": {
         "environmentDefinition": "canary"
-    },
-    "crawlConfig": {
-        "urlCrawlLimit": 100
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -8,7 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-
     "scanConfig": {
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,
@@ -20,8 +19,5 @@
     },
     "availabilityTestConfig": {
         "environmentDefinition": "canary"
-    },
-    "crawlConfig": {
-        "urlCrawlLimit": 100
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -8,7 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 40
     },
-
     "scanConfig": {
         "minLastReferenceSeenInDays": 3,
         "pageRescanIntervalInDays": 3,

--- a/packages/resource-deployment/runtime-config/runtime-config.selftest.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.selftest.json
@@ -19,8 +19,5 @@
     },
     "availabilityTestConfig": {
         "environmentDefinition": "canary"
-    },
-    "crawlConfig": {
-        "urlCrawlLimit": 100
     }
 }

--- a/packages/service-library/src/data-providers/website-scan-result-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-provider.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import 'reflect-metadata';
 
-import { IMock, Mock, It, Times } from 'typemoq';
+import { IMock, Mock, It } from 'typemoq';
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
 import {
     WebsiteScanResult,
@@ -146,65 +146,6 @@ describe(WebsiteScanResultProvider, () => {
         const actualWebsiteScanResult = await websiteScanResultProvider.mergeOrCreate(scanId, websiteScanResult);
 
         expect(actualWebsiteScanResult).toEqual(websiteScanResultBaseDbDocumentCreated);
-    });
-
-    it('merge website documents', () => {
-        const target = {
-            id: websiteScanResultBaseId,
-            knownPages: ['page1'],
-        } as WebsiteScanResult;
-        const source = {
-            id: websiteScanResultBaseId,
-            knownPages: ['page2'],
-        } as Partial<WebsiteScanResult>;
-        const expectedResult = {
-            id: websiteScanResultBaseId,
-            knownPages: ['page1', 'page2'],
-        } as WebsiteScanResult;
-        websiteScanResultAggregatorMock
-            .setup((o) =>
-                o.mergeBaseDocument(
-                    { id: websiteScanResultBaseId, itemType: ItemType.websiteScanResult, partitionKey: undefined },
-                    { id: websiteScanResultBaseId, itemType: ItemType.websiteScanResult, partitionKey: undefined },
-                ),
-            )
-            .returns(() => {
-                return { id: websiteScanResultBaseId };
-            })
-            .verifiable();
-        websiteScanResultAggregatorMock
-            .setup((o) =>
-                o.mergePartDocument(
-                    {
-                        baseId: websiteScanResultBaseId,
-                        id: websiteScanResultPartId,
-                        itemType: ItemType.websiteScanResultPart,
-                        partitionKey: undefined,
-                        scanId: undefined,
-                        knownPages: ['page2'],
-                    },
-                    {
-                        baseId: websiteScanResultBaseId,
-                        id: websiteScanResultPartId,
-                        itemType: ItemType.websiteScanResultPart,
-                        partitionKey: undefined,
-                        scanId: undefined,
-                        knownPages: ['page1'],
-                    },
-                ),
-            )
-            .returns(() => {
-                return { knownPages: ['page1', 'page2'] };
-            })
-            .verifiable();
-        hashGeneratorMock
-            .setup((o) => o.getWebsiteScanResultPartDocumentId(websiteScanResultBaseId, undefined))
-            .returns(() => websiteScanResultPartId)
-            .verifiable(Times.exactly(2));
-
-        const actualResult = websiteScanResultProvider.mergeWith(target, source);
-
-        expect(actualResult).toEqual(expectedResult);
     });
 
     it('read partial website scan result', async () => {

--- a/packages/service-library/src/data-providers/website-scan-result-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-provider.spec.ts
@@ -93,6 +93,24 @@ describe(WebsiteScanResultProvider, () => {
         expect(actualWebsiteScanResult).toEqual(websiteScanResultBaseDbDocumentMerged);
     });
 
+    it('merge website scan result document with db base document and reload', async () => {
+        setupDocumentEntities();
+        setupHashGeneratorMock();
+        setupWebsiteScanResultAggregatorMock('merge');
+        setupPartitionKeyFactoryMock();
+        setupCosmosContainerClientMock('merge');
+        setupRetryHelperMock();
+
+        websiteScanResultProvider.read = jest.fn().mockImplementationOnce(async (websiteScanId: string, readCompleteDocument: boolean) => {
+            return websiteScanId === websiteScanResultBaseId && readCompleteDocument
+                ? Promise.resolve(websiteScanResult)
+                : Promise.reject('Unexpected read() method invocation');
+        });
+
+        const actualWebsiteScanResult = await websiteScanResultProvider.mergeOrCreate(scanId, websiteScanResult, true);
+        expect(actualWebsiteScanResult).toEqual(websiteScanResult);
+    });
+
     it('write website scan result documents in batch', async () => {
         setupDocumentEntities();
         setupHashGeneratorMock();

--- a/packages/service-library/src/data-providers/website-scan-result-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-provider.ts
@@ -69,11 +69,23 @@ export class WebsiteScanResultProvider {
      * Source document properties that resolve to undefined are skipped if a destination document value exists.
      * Will remove all falsey (false, null, 0, "", undefined, and NaN) values from document's array type properties
      */
-    public async mergeOrCreate(scanId: string, websiteScanResult: Partial<WebsiteScanResult>): Promise<WebsiteScanResultBase> {
+    public async mergeOrCreate(
+        scanId: string,
+        websiteScanResult: Partial<WebsiteScanResult>,
+        readCompleteDocument: boolean = false,
+    ): Promise<WebsiteScanResultBase> {
         const dbDocument = this.convertToDbDocument(scanId, websiteScanResult);
 
         return (await this.retryHelper.executeWithRetries(
-            async () => this.mergeOrCreateImpl(dbDocument),
+            async () => {
+                if (readCompleteDocument) {
+                    const baseDocument = await this.mergeOrCreateImpl(dbDocument);
+
+                    return this.read(baseDocument.id, true);
+                } else {
+                    return this.mergeOrCreateImpl(dbDocument);
+                }
+            },
             async (err) =>
                 this.logger.logError(`Failed to update website scan result Cosmos DB document. Retrying on error.`, {
                     baseId: dbDocument?.baseDocument.id,
@@ -105,6 +117,10 @@ export class WebsiteScanResultProvider {
         return { ...baseDocument, ...partDocument };
     }
 
+    /**
+     *
+     * Sets the required storage document properties.
+     */
     public normalizeToDbDocument(websiteScanResult: Partial<WebsiteScanResult>): WebsiteScanResultBase {
         const documentId = this.getWebsiteScanId(websiteScanResult);
         const partitionKey = websiteScanResult.partitionKey ?? this.getPartitionKey(documentId);

--- a/packages/service-library/src/data-providers/website-scan-result-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-provider.ts
@@ -100,24 +100,6 @@ export class WebsiteScanResultProvider {
     }
 
     /**
-     * Merges the `WebsiteScanResult` documents in a memory.
-     */
-    public mergeWith(websiteScanResult: WebsiteScanResult, websiteScanResultUpdate: Partial<WebsiteScanResult>): WebsiteScanResult {
-        const targetDocument = this.convertToDbDocument(undefined, websiteScanResult);
-        const sourceDocument = this.convertToDbDocument(undefined, websiteScanResultUpdate);
-        const baseDocument = this.websiteScanResultAggregator.mergeBaseDocument(
-            sourceDocument.baseDocument,
-            targetDocument.baseDocument,
-        ) as WebsiteScanResultBase;
-        const partDocument = this.websiteScanResultAggregator.mergePartDocument(
-            sourceDocument.partDocument,
-            targetDocument.partDocument,
-        ) as WebsiteScanResultPartModel;
-
-        return { ...baseDocument, ...partDocument };
-    }
-
-    /**
      *
      * Sets the required storage document properties.
      */

--- a/packages/web-api-scan-runner/src/crawl-runner/discovered-url-processor.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/discovered-url-processor.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import _, { isNil } from 'lodash';
+import _ from 'lodash';
 
 export type DiscoveredUrlProcessor = typeof discoveredUrlProcessor;
 
 export function discoveredUrlProcessor(discoveredUrls: string[], urlCrawlLimit: number, knownUrls?: string[]): string[] {
-    let processedUrls = discoveredUrls;
-    if (isNil(discoveredUrls)) {
+    if (_.isNil(discoveredUrls)) {
         return [];
     }
 
-    if (!isNil(knownUrls)) {
+    let processedUrls = discoveredUrls;
+    if (!_.isNil(knownUrls)) {
         processedUrls = removeUrlsFromList(discoveredUrls, knownUrls);
     }
 
@@ -27,7 +27,7 @@ function limitNumUrls(urlList: string[], numUrls: number): string[] {
 }
 
 function getUrlLimit(urlCrawlLimit: number, knownUrls?: string[]): number {
-    const numKnownPages = isNil(knownUrls) ? 0 : knownUrls.length;
+    const numKnownPages = _.isNil(knownUrls) ? 0 : knownUrls.length;
 
     return Math.max(urlCrawlLimit - numKnownPages, 0);
 }

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -213,10 +213,7 @@ function setupUpdateScanResult(): void {
         websiteScanResult = {
             id: 'websiteScanResultId',
         } as WebsiteScanResult;
-        WebsiteScanResultProviderMock.setup((o) => o.mergeOrCreate(scanMetadata.id, It.isValue(updatedWebsiteScanResult)))
-            .returns(() => Promise.resolve(websiteScanResult))
-            .verifiable();
-        WebsiteScanResultProviderMock.setup((o) => o.read(websiteScanRef.id, true))
+        WebsiteScanResultProviderMock.setup((o) => o.mergeOrCreate(scanMetadata.id, It.isValue(updatedWebsiteScanResult), true))
             .returns(() => Promise.resolve(websiteScanResult))
             .verifiable();
     }

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -138,9 +138,7 @@ export class Runner {
                 ],
             };
 
-            this.websiteScanResultProvider.mergeOrCreate(scanMetadata.id, updatedWebsiteScanResult);
-
-            return this.websiteScanResultProvider.read(websiteScanRef.id, true);
+            return this.websiteScanResultProvider.mergeOrCreate(scanMetadata.id, updatedWebsiteScanResult, true);
         }
 
         return undefined;

--- a/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
+++ b/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
@@ -185,12 +185,8 @@ describe(DeepScanner, () => {
             discoveryPatterns: crawlDiscoveryPatterns,
         };
         websiteScanResultProviderMock
-            .setup((o) => o.mergeOrCreate(scanMetadata.id, updatedWebsiteScanResult))
+            .setup((o) => o.mergeOrCreate(scanMetadata.id, updatedWebsiteScanResult, true))
             .returns(() => Promise.resolve(websiteScanResultDbDocument))
-            .verifiable();
-        websiteScanResultProviderMock
-            .setup((o) => o.mergeWith(websiteScanResult, updatedWebsiteScanResult))
-            .returns(() => websiteScanResultDbDocument)
             .verifiable();
     }
 

--- a/packages/web-api-scan-runner/src/scanner/deep-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/deep-scanner.ts
@@ -67,10 +67,7 @@ export class DeepScanner {
             discoveryPatterns: discoveryPatterns,
         };
 
-        await this.websiteScanResultProvider.mergeOrCreate(scanId, websiteScanResultUpdate);
-
-        // merge previously read db document with the current update to avoid full db document read operation
-        return this.websiteScanResultProvider.mergeWith(websiteScanResult, websiteScanResultUpdate);
+        return this.websiteScanResultProvider.mergeOrCreate(scanId, websiteScanResultUpdate, true);
     }
 
     private async readWebsiteScanResult(pageScanResult: OnDemandPageScanResult): Promise<WebsiteScanResult> {

--- a/packages/web-api-scan-runner/src/sender/scan-notification-processor.ts
+++ b/packages/web-api-scan-runner/src/sender/scan-notification-processor.ts
@@ -73,6 +73,7 @@ export class ScanNotificationProcessor {
         if (deepScanCompleted) {
             this.logger.logInfo(`Sending scan completion notification message for a deep scan.`, {
                 deepScanId: websiteScanResult?.deepScanId,
+                scannedPages: websiteScanResult.pageScans.length.toString(),
                 scanNotifyUrl: pageScanResult.notification.scanNotifyUrl,
             });
         }


### PR DESCRIPTION
#### Details

Reload website document on write db operation
Set lower deep scan limit for dev environment 

##### Motivation

Fix deep scan notification event sequence to ensure notification is sent when deep scan completed

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
