### PR TITLE
Fixed deep scan URLs comparison rule

### DIFF
--- a/packages/service-library/src/data-providers/website-scan-result-aggregator.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-aggregator.spec.ts
@@ -74,7 +74,7 @@ describe(WebsiteScanResultAggregator, () => {
 
     it('merge website part document', () => {
         const source = {
-            knownPages: ['new page', 'existing page', null /* should remove falsey value */],
+            knownPages: ['new page', 'existing page', undefined, null /* should remove falsey value */, 'Various Case Page'],
             pageScans: [
                 {
                     url: 'new url',
@@ -96,7 +96,7 @@ describe(WebsiteScanResultAggregator, () => {
             ],
         } as WebsiteScanResultPart;
         const target = {
-            knownPages: ['existing page', 'old page', null /* should remove falsey value */],
+            knownPages: ['existing page', 'old page', null, undefined /* should remove falsey value */, 'various case page'],
             pageScans: [
                 {
                     url: 'existing url',
@@ -113,7 +113,7 @@ describe(WebsiteScanResultAggregator, () => {
             ],
         } as WebsiteScanResultPart;
         const expectedDocument = {
-            knownPages: ['existing page', 'old page', 'new page'],
+            knownPages: ['existing page', 'old page', 'various case page', 'new page'],
             pageScans: [
                 {
                     url: 'existing url',

--- a/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
@@ -46,7 +46,13 @@ export class WebsiteScanResultAggregator {
         });
 
         if (mergedDocument.knownPages !== undefined) {
-            mergedDocument.knownPages = _.uniq(mergedDocument.knownPages);
+            mergedDocument.knownPages = _.uniqWith(mergedDocument.knownPages, (a, b) => {
+                if (a === undefined || b === undefined) {
+                    return false;
+                }
+
+                return a.toLocaleLowerCase() === b.toLocaleLowerCase();
+            });
         }
 
         if (mergedDocument.pageScans !== undefined) {


### PR DESCRIPTION
#### Details

Fixed deep scan URLs comparison rule to handle same URLs with different case

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
