### PR TITLE
fix: close all pages before closing browser to prevent crash

### DIFF
--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -39,7 +39,7 @@ export class WebDriver {
 
     public async close(): Promise<void> {
         if (this.browser !== undefined) {
-            await this.promiseUtils.waitFor(this.browser.close(), this.browserCloseTimeout, async () => {
+            await this.promiseUtils.waitFor(this.tryCloseBrowser(), this.browserCloseTimeout, async () => {
                 this.logger?.logError(`Browser failed to close with timeout of ${this.browserCloseTimeout} ms.`);
                 if (this.browser.process()) {
                     this.logger?.logInfo('Sending kill signal to browser process');
@@ -49,5 +49,11 @@ export class WebDriver {
 
             this.logger?.logInfo('Chromium browser instance stopped.');
         }
+    }
+
+    private async tryCloseBrowser(): Promise<void> {
+        const browserPages = await this.browser.pages();
+        await Promise.all(browserPages.map((p) => p.close()));
+        await this.browser.close();
     }
 }

--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -9,7 +9,7 @@ import { defaultBrowserOptions, defaultLaunchOptions } from './puppeteer-options
 @injectable()
 export class WebDriver {
     public browser: Puppeteer.Browser;
-    private readonly browserCloseTimeout = 180000;
+    private readonly browserCloseTimeout = 60000;
 
     constructor(
         @inject(PromiseUtils) private readonly promiseUtils: PromiseUtils,

--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -51,7 +51,7 @@ export class WebDriver {
         }
     }
 
-    private async tryCloseBrowser(): Promise<void> {
+    private async closeBrowser(): Promise<void> {
         const browserPages = await this.browser.pages();
         await Promise.all(browserPages.map((p) => p.close()));
         await this.browser.close();

--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -39,7 +39,7 @@ export class WebDriver {
 
     public async close(): Promise<void> {
         if (this.browser !== undefined) {
-            await this.promiseUtils.waitFor(this.tryCloseBrowser(), this.browserCloseTimeout, async () => {
+            await this.promiseUtils.waitFor(this.closeBrowser(), this.browserCloseTimeout, async () => {
                 this.logger?.logError(`Browser failed to close with timeout of ${this.browserCloseTimeout} ms.`);
                 if (this.browser.process()) {
                     this.logger?.logInfo('Sending kill signal to browser process');


### PR DESCRIPTION
#### Details

Close all open pages before closing the browser

##### Motivation

Due to a puppeteer issue on Windows 10, browser.close() sometimes causes the browser to crash and attempt to write crash data to protected files, causing a permissions error in the CLI tool and service. Closing all pages before closing the browser is the current workaround for this issue.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
