### PR TITLE
chore: remove az upgrade step in startup script

### DIFF
--- a/packages/resource-deployment/scripts/pool-startup/pool-startup.ps1
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup.ps1
@@ -19,7 +19,7 @@ function exitWithUsageInfo {
 function installBootstrapPackages() {
     Write-Output "Installing az cli"
     Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; rm .\AzureCLI.msi
-    az upgrade
+    az version
 }
 
 


### PR DESCRIPTION
#### Details

This removes `az upgrade` from the Powershell script. The existing MSI installation should handle updates for us ([documentation](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows?tabs=azure-powershell#powershell-command)).

When upgrading 2.19 to 2.20 locally, several iterations of `az upgrade` with `--yes`, or `--show-errors-only` still showed a user dialog that required input to move forward. This causes the agent to wait for start task until we manually reboot it, at which point the update has been installed already.

##### Motivation

Stop nodes from waiting for start task

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
