### PR TITLE
Switch Linux container to use official Node Docker image

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "socket.io": ">=2.4.0",
         "socket.io-parser": ">=3.4.1",
         "marked": ">=1.1.1",
-        "engine.io": ">=4.0.0"
+        "engine.io": ">=4.0.0",
+        "ssri": ">=8.0.1"
     }
 }

--- a/packages/web-api-scan-job-manager/docker-image-config/Dockerfile
+++ b/packages/web-api-scan-job-manager/docker-image-config/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 FROM mcr.microsoft.com/windows:1809-amd64
 
-ENV NODE_VERSION 12.20.2
+ENV NODE_VERSION 12.21.0
 
 USER ContainerAdministrator
 

--- a/packages/web-api-scan-request-sender/docker-image-config/Dockerfile
+++ b/packages/web-api-scan-request-sender/docker-image-config/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-FROM node:12-slim
+FROM node:12.21-slim
 
 # Bundle app source
 COPY . .

--- a/packages/web-api-scan-runner/docker-image-config/Dockerfile
+++ b/packages/web-api-scan-runner/docker-image-config/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 FROM mcr.microsoft.com/windows:1809-amd64
 
-ENV NODE_VERSION 12.20.2
+ENV NODE_VERSION 12.21.0
 
 USER ContainerAdministrator
 RUN powershell Set-ExecutionPolicy RemoteSigned

--- a/packages/web-api-send-notification-job-manager/docker-image-config/Dockerfile
+++ b/packages/web-api-send-notification-job-manager/docker-image-config/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-FROM node:12-slim
+FROM node:12.21-slim
 
 # Bundle app source
 COPY . .

--- a/packages/web-api-send-notification-runner/docker-image-config/Dockerfile
+++ b/packages/web-api-send-notification-runner/docker-image-config/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-FROM node:12-slim
+FROM node:12.21-slim
 
 # Bundle app source
 COPY . .

--- a/yarn.lock
+++ b/yarn.lock
@@ -9179,6 +9179,13 @@ minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
 minizlib@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
@@ -11649,12 +11656,12 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@^6.0.0, ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+ssri@>=8.0.1, ssri@^6.0.0, ssri@^6.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
+  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
-    figgy-pudding "^3.5.1"
+    minipass "^3.1.1"
 
 stack-chain@^1.3.7:
   version "1.3.7"


### PR DESCRIPTION
#### Details

Switch Linux container to use official Node Docker image
Upgrade ssri to fix security vulnerabilities

##### Motivation

The current Linux Docker image is not supported and has missing security patches

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
