### PR TITLE
Add CLI command option aliasing to support lower casing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,13 +3,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import 'reflect-metadata';
+
 // eslint-disable-next-line import/no-unassigned-import
 import './module-name-mapper';
 
 // @ts-ignore
 import * as cheerio from 'cheerio';
 import { isEmpty } from 'lodash';
-import * as yargs from 'yargs';
+import yargs from 'yargs';
 import { System } from 'common';
 import { CliEntryPoint } from './cli-entry-point';
 import { ScanArguments } from './scan-arguments';
@@ -59,6 +60,7 @@ function getScanArguments(): ScanArguments {
                 describe: `Maximum number of pages that the crawler will open. The crawl will stop when this limit is reached. Default is 100.
                            Note that in cases of parallel crawling, the actual number of pages visited might be slightly higher than this value.`,
                 default: 100,
+                alias: 'maxurls',
             },
             restart: {
                 type: 'boolean',
@@ -79,23 +81,34 @@ function getScanArguments(): ScanArguments {
             memoryMBytes: {
                 type: 'number',
                 describe: 'The maximum number of megabytes to be used by the crawler.',
+                alias: 'memorymbytes',
             },
             silentMode: {
                 type: 'boolean',
                 describe: 'Open browser window while crawling when set to true.',
                 default: true,
+                alias: 'silentmode',
             },
             inputFile: {
                 type: 'string',
                 describe: 'List of URLs to crawl in addition to URLs discovered from crawling the provided URL.',
+                alias: 'inputfile',
             },
             inputUrls: {
                 type: 'array',
                 describe: `List of URLs to crawl in addition to URLs discovered from crawling the provided URL, separated by space.`,
+                alias: 'inputurls',
             },
             discoveryPatterns: {
                 type: 'array',
                 describe: `List of RegEx patterns to crawl in addition to the provided URL, separated by space.`,
+                alias: 'discoverypatterns',
+            },
+            debug: {
+                type: 'boolean',
+                describe: 'Enables crawler engine debug mode.',
+                default: false,
+                hidden: true,
             },
         })
         .check((args) => {

--- a/packages/cli/src/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler-parameters-builder.ts
@@ -40,6 +40,7 @@ export class CrawlerParametersBuilder {
             discoveryPatterns: scanArguments.discoveryPatterns,
             chromePath: scanArguments.chromePath,
             axeSourcePath: scanArguments.axeSourcePath,
+            debug: scanArguments.debug,
         };
     }
 

--- a/packages/cli/src/scan-arguments.ts
+++ b/packages/cli/src/scan-arguments.ts
@@ -18,4 +18,5 @@ export interface ScanArguments {
     continue?: boolean;
     chromePath?: string;
     axeSourcePath?: string;
+    debug?: boolean;
 }

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
@@ -17,7 +17,12 @@ import { CrawlerFactory } from './crawler-factory';
    @typescript-eslint/consistent-type-assertions */
 
 describe(PuppeteerCrawlerEngine, () => {
-    const puppeteerDefaultOptions = ['--disable-dev-shm-usage', '--no-sandbox', '--disable-setuid-sandbox'];
+    const puppeteerDefaultOptions = [
+        '--disable-dev-shm-usage',
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--js-flags=--max-old-space-size=8192',
+    ];
     const maxRequestsPerCrawl: number = 100;
     const pageProcessorStub: PageProcessor = {
         pageHandler: () => null,

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
@@ -27,7 +27,12 @@ export class PuppeteerCrawlerEngine {
         this.crawlerConfiguration.setMemoryMBytes(crawlerRunOptions.memoryMBytes);
         this.crawlerConfiguration.setSilentMode(crawlerRunOptions.silentMode);
 
-        const puppeteerDefaultOptions = ['--disable-dev-shm-usage', '--no-sandbox', '--disable-setuid-sandbox'];
+        const puppeteerDefaultOptions = [
+            '--disable-dev-shm-usage',
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            '--js-flags=--max-old-space-size=8192',
+        ];
         const pageProcessor = this.pageProcessorFactory();
         const puppeteerCrawlerOptions: Apify.PuppeteerCrawlerOptions = {
             handlePageTimeoutSecs: 300, // timeout includes all page processing activity (navigation, rendering, accessibility scan, etc.)


### PR DESCRIPTION
#### Details

Add CLI command option aliasing to support lower casing
Added hidden debug option to display chromium instance for web page debugging

##### Motivation

Avoid user confusion over CLI options camel casing

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
