### PR TITLE
fix: add secret recover permissions for azure batch

### DIFF
--- a/packages/resource-deployment/templates/key-vault-create.template.json
+++ b/packages/resource-deployment/templates/key-vault-create.template.json
@@ -49,7 +49,7 @@
                         "tenantId": "[subscription().tenantId]",
                         "objectId": "[parameters('objectId')]",
                         "permissions": {
-                            "secrets": ["delete", "get", "list", "set"]
+                            "secrets": ["delete", "get", "list", "set", "recover"]
                         }
                     }
                 ],


### PR DESCRIPTION
#### Details

Grant the batch service principal "recover" permissions to the keyvault

##### Motivation

This is now [required ](https://docs.microsoft.com/en-us/azure/batch/batch-account-create-portal?WT.mc_id=Portal-Microsoft_Azure_Batch#create-a-key-vault)for user subscription batch accounts to access a keyvault with soft delete enabled. This change will fix current deployment pipeline failures.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
