### PR TITLE
Enable deep scan known pages overlimit

### DIFF
--- a/packages/azure-services/src/azure-batch/pool-load-generator.spec.ts
+++ b/packages/azure-services/src/azure-batch/pool-load-generator.spec.ts
@@ -25,7 +25,7 @@ describe(PoolLoadGenerator, () => {
                 return {
                     activeToRunningTasksRatio: activeToRunningTasksRatio,
                     addTasksIntervalInSeconds: 15,
-                    maxWallClockTimeInHours: 1,
+                    maxWallClockTimeInMinutes: 30,
                 } as JobManagerConfig;
             });
 

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -50,9 +50,14 @@ Object {
     },
   },
   "crawlConfig": Object {
-    "urlCrawlLimit": Object {
+    "deepScanDiscoveryLimit": Object {
+      "default": 5,
+      "doc": "The maximum number of URLs that will be discovered for a deep scan request",
+      "format": "int",
+    },
+    "deepScanUpperLimit": Object {
       "default": 10,
-      "doc": "The maximum number of URLs that will be discovered for a deep scan",
+      "doc": "The maximum number of URLs that will be processed for a deep scan request",
       "format": "int",
     },
   },
@@ -243,9 +248,14 @@ Object {
     },
   },
   "crawlConfig": Object {
-    "urlCrawlLimit": Object {
+    "deepScanDiscoveryLimit": Object {
+      "default": 5,
+      "doc": "The maximum number of URLs that will be discovered for a deep scan request",
+      "format": "int",
+    },
+    "deepScanUpperLimit": Object {
       "default": 10,
-      "doc": "The maximum number of URLs that will be discovered for a deep scan",
+      "doc": "The maximum number of URLs that will be processed for a deep scan request",
       "format": "int",
     },
   },

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -79,9 +79,9 @@ Object {
       "doc": "The time interval at which a job manager adds tasks to the job.",
       "format": "int",
     },
-    "maxWallClockTimeInHours": Object {
-      "default": 1,
-      "doc": "The amount of time the job manager instance will run continuously.",
+    "maxWallClockTimeInMinutes": Object {
+      "default": 30,
+      "doc": "The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
     "scanRunnerTaskImageName": Object {
@@ -119,8 +119,8 @@ Object {
       "format": "int",
     },
     "messageVisibilityTimeoutInSeconds": Object {
-      "default": 600,
-      "doc": "Message visibility timeout in seconds. Must correlate with taskTimeoutInMinutes config value.",
+      "default": 2400,
+      "doc": "Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes and taskConfig.taskTimeoutInMinutes config values.",
       "format": "int",
     },
   },
@@ -191,7 +191,7 @@ Object {
     },
     "taskTimeoutInMinutes": Object {
       "default": 10,
-      "doc": "Timeout value after which the task has to be terminated. Must correlate with messageVisibilityTimeoutInSeconds config value.",
+      "doc": "Timeout value after which the task has to be terminated. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
   },
@@ -277,9 +277,9 @@ Object {
       "doc": "The time interval at which a job manager adds tasks to the job.",
       "format": "int",
     },
-    "maxWallClockTimeInHours": Object {
-      "default": 1,
-      "doc": "The amount of time the job manager instance will run continuously.",
+    "maxWallClockTimeInMinutes": Object {
+      "default": 30,
+      "doc": "The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
     "scanRunnerTaskImageName": Object {
@@ -317,8 +317,8 @@ Object {
       "format": "int",
     },
     "messageVisibilityTimeoutInSeconds": Object {
-      "default": 600,
-      "doc": "Message visibility timeout in seconds. Must correlate with taskTimeoutInMinutes config value.",
+      "default": 2400,
+      "doc": "Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes and taskConfig.taskTimeoutInMinutes config values.",
       "format": "int",
     },
   },
@@ -389,7 +389,7 @@ Object {
     },
     "taskTimeoutInMinutes": Object {
       "default": 10,
-      "doc": "Timeout value after which the task has to be terminated. Must correlate with messageVisibilityTimeoutInSeconds config value.",
+      "doc": "Timeout value after which the task has to be terminated. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
   },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -24,7 +24,7 @@ export interface LogRuntimeConfig {
 export interface JobManagerConfig {
     activeToRunningTasksRatio: number;
     addTasksIntervalInSeconds: number;
-    maxWallClockTimeInHours: number;
+    maxWallClockTimeInMinutes: number;
     sendNotificationTasksCount: number;
     scanRunnerTaskImageName: string;
     sendNotificationTaskImageName: string;
@@ -156,8 +156,9 @@ export class ServiceConfiguration {
                 },
                 messageVisibilityTimeoutInSeconds: {
                     format: 'int',
-                    default: 600,
-                    doc: 'Message visibility timeout in seconds. Must correlate with taskTimeoutInMinutes config value.',
+                    default: (30 + 10) * 60, // maxWallClockTimeInMinutes + taskTimeoutInMinutes
+                    doc:
+                        'Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes and taskConfig.taskTimeoutInMinutes config values.',
                 },
             },
             taskConfig: {
@@ -165,7 +166,7 @@ export class ServiceConfiguration {
                     format: 'int',
                     default: 10,
                     doc:
-                        'Timeout value after which the task has to be terminated. Must correlate with messageVisibilityTimeoutInSeconds config value.',
+                        'Timeout value after which the task has to be terminated. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.',
                 },
                 retentionTimeInDays: {
                     format: 'int',
@@ -191,10 +192,11 @@ export class ServiceConfiguration {
                     default: 20,
                     doc: 'The time interval at which a job manager adds tasks to the job.',
                 },
-                maxWallClockTimeInHours: {
+                maxWallClockTimeInMinutes: {
                     format: 'int',
-                    default: 1,
-                    doc: 'The amount of time the job manager instance will run continuously.',
+                    default: 30,
+                    doc:
+                        'The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.',
                 },
                 sendNotificationTasksCount: {
                     format: 'int',

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -75,7 +75,8 @@ export interface AvailabilityTestConfig {
 }
 
 export interface CrawlConfig {
-    urlCrawlLimit: number;
+    deepScanDiscoveryLimit: number;
+    deepScanUpperLimit: number;
 }
 
 export declare type ResourceType = 'batch' | 'registry';
@@ -317,10 +318,15 @@ export class ServiceConfiguration {
                 },
             },
             crawlConfig: {
-                urlCrawlLimit: {
+                deepScanDiscoveryLimit: {
+                    format: 'int',
+                    default: 5,
+                    doc: 'The maximum number of URLs that will be discovered for a deep scan request',
+                },
+                deepScanUpperLimit: {
                     format: 'int',
                     default: 10,
-                    doc: 'The maximum number of URLs that will be discovered for a deep scan',
+                    doc: 'The maximum number of URLs that will be processed for a deep scan request',
                 },
             },
         };

--- a/packages/crawler/src/apify/apify-resource-creator.ts
+++ b/packages/crawler/src/apify/apify-resource-creator.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 import * as fs from 'fs';
 import Apify from 'apify';
 import { injectable } from 'inversify';
@@ -51,7 +52,7 @@ export class ApifyResourceCreator implements ResourceCreator {
         await this.enqueueLinksExt({
             page: page,
             requestQueue: requestQueue,
-            pseudoUrls: discoveryPatterns,
+            pseudoUrls: discoveryPatterns?.length > 0 ? discoveryPatterns : undefined, // prevents from crawling all links
         });
     }
 

--- a/packages/crawler/src/page-operations/click-element-operation.ts
+++ b/packages/crawler/src/page-operations/click-element-operation.ts
@@ -31,7 +31,7 @@ export class ClickElementOperation {
             page,
             requestQueue,
             selector,
-            pseudoUrls: discoveryPatterns,
+            pseudoUrls: discoveryPatterns?.length > 0 ? discoveryPatterns : undefined, // prevents from crawling all links
             transformRequestFunction: (request: Apify.RequestOptions) => {
                 navigated = true;
                 navigationUrl = request.url;

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -153,7 +153,7 @@ export abstract class PageProcessorBase implements PageProcessor {
         const enqueued = await this.enqueueLinksExt({
             page,
             requestQueue,
-            pseudoUrls: this.discoveryPatterns,
+            pseudoUrls: this.discoveryPatterns?.length > 0 ? this.discoveryPatterns : undefined, // prevents from crawling all links
         });
         console.log(`Discovered ${enqueued.length} links on page ${page.url()}`);
 

--- a/packages/resource-deployment/runtime-config/runtime-config.ci.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ci.json
@@ -8,12 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-    "scanConfig": {
-        "minLastReferenceSeenInDays": 3,
-        "pageRescanIntervalInDays": 3,
-        "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3
-    },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300
     },

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -8,12 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-    "scanConfig": {
-        "minLastReferenceSeenInDays": 3,
-        "pageRescanIntervalInDays": 3,
-        "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3
-    },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300
     },

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -8,12 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 40
     },
-    "scanConfig": {
-        "minLastReferenceSeenInDays": 3,
-        "pageRescanIntervalInDays": 3,
-        "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3
-    },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300
     },

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -21,6 +21,7 @@
         "environmentDefinition": "insider"
     },
     "crawlConfig": {
-        "urlCrawlLimit": 100
+        "deepScanDiscoveryLimit": 100,
+        "deepScanUpperLimit": 3000
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.prod.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.prod.json
@@ -8,12 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 40
     },
-    "scanConfig": {
-        "minLastReferenceSeenInDays": 3,
-        "pageRescanIntervalInDays": 3,
-        "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3
-    },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300
     },

--- a/packages/resource-deployment/runtime-config/runtime-config.prod.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.prod.json
@@ -21,6 +21,7 @@
         "environmentDefinition": "production"
     },
     "crawlConfig": {
-        "urlCrawlLimit": 100
+        "deepScanDiscoveryLimit": 100,
+        "deepScanUpperLimit": 3000
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.selftest.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.selftest.json
@@ -8,12 +8,6 @@
     "queueConfig": {
         "maxQueueSize": 10
     },
-    "scanConfig": {
-        "minLastReferenceSeenInDays": 3,
-        "pageRescanIntervalInDays": 3,
-        "failedPageRescanIntervalInHours": 3,
-        "maxScanRetryCount": 3
-    },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300
     },

--- a/packages/service-library/src/batch/batch-task-creator.spec.ts
+++ b/packages/service-library/src/batch/batch-task-creator.spec.ts
@@ -178,13 +178,13 @@ let systemMock: IMock<typeof System>;
 let batchConfig: BatchConfig;
 let testSubject: TestableBatchTaskCreator;
 let jobManagerConfig: JobManagerConfig;
-let maxWallClockTimeInHours: number;
+let maxWallClockTimeInMinutes: number;
 let poolMetricsInfo: PoolMetricsInfo;
 let queueMessagesGenerator: QueueMessagesGenerator;
 
 describe(BatchTaskCreator, () => {
     beforeEach(() => {
-        maxWallClockTimeInHours = 2;
+        maxWallClockTimeInMinutes = 2;
         batchConfig = {
             accountName: 'account-name',
             accountUrl: '',
@@ -202,7 +202,7 @@ describe(BatchTaskCreator, () => {
         } as typeof System);
 
         jobManagerConfig = {
-            maxWallClockTimeInHours: maxWallClockTimeInHours,
+            maxWallClockTimeInMinutes: maxWallClockTimeInMinutes,
             addTasksIntervalInSeconds: 10,
         } as JobManagerConfig;
         serviceConfigMock.setup((o) => o.getConfigValue('jobManagerConfig')).returns(async () => Promise.resolve(jobManagerConfig));
@@ -308,7 +308,7 @@ describe(BatchTaskCreator, () => {
 
     it('exit manager after scheduled period', async () => {
         jobManagerConfig = {
-            maxWallClockTimeInHours: -1,
+            maxWallClockTimeInMinutes: -1,
         } as JobManagerConfig;
         serviceConfigMock.reset();
         serviceConfigMock.setup((o) => o.getConfigValue('jobManagerConfig')).returns(async () => Promise.resolve(jobManagerConfig));
@@ -317,7 +317,7 @@ describe(BatchTaskCreator, () => {
 
         loggerMock
             .setup((o) =>
-                o.logInfo(`Performing scheduled job manager termination after ${jobManagerConfig.maxWallClockTimeInHours / 4} hours.`),
+                o.logInfo(`Performing scheduled job manager termination after ${jobManagerConfig.maxWallClockTimeInMinutes} minutes.`),
             )
             .verifiable();
 

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 import { Batch, BatchConfig, BatchTask, JobTask, JobTaskState, Message, Queue } from 'azure-services';
 import { JobManagerConfig, QueueRuntimeConfig, ServiceConfiguration, System } from 'common';
 import { inject, injectable } from 'inversify';
@@ -45,9 +46,7 @@ export abstract class BatchTaskCreator {
         }
 
         this.activeScanMessages = [];
-        const restartAfterTime = moment()
-            .add(this.jobManagerConfig.maxWallClockTimeInHours / 4, 'hour')
-            .toDate();
+        const restartAfterTime = moment().add(this.jobManagerConfig.maxWallClockTimeInMinutes, 'minutes').toDate();
 
         // eslint-disable-next-line no-constant-condition
         while (true) {
@@ -64,7 +63,7 @@ export abstract class BatchTaskCreator {
 
             if (moment().toDate() >= restartAfterTime) {
                 this.logger.logInfo(
-                    `Performing scheduled job manager termination after ${this.jobManagerConfig.maxWallClockTimeInHours / 4} hours.`,
+                    `Performing scheduled job manager termination after ${this.jobManagerConfig.maxWallClockTimeInMinutes} minutes.`,
                 );
 
                 break;

--- a/packages/service-library/src/data-providers/website-scan-result-aggregator.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-aggregator.spec.ts
@@ -26,6 +26,7 @@ describe(WebsiteScanResultAggregator, () => {
         const source = {
             deepScanId: '*', // should not be merged with target
             _etag: '*', // should not be merged with target
+            deepScanLimit: 7, // should not be merged with target
             discoveryPatterns: ['new discovery pattern', 'existing discovery pattern', null /* should remove falsey value */],
             reports: [
                 {
@@ -40,6 +41,7 @@ describe(WebsiteScanResultAggregator, () => {
         const target = {
             deepScanId: 'deepScanId',
             _etag: '_etag',
+            deepScanLimit: 11,
             discoveryPatterns: ['existing discovery pattern', 'old discovery pattern'],
             reports: [
                 {
@@ -53,6 +55,7 @@ describe(WebsiteScanResultAggregator, () => {
         const expectedDocument = {
             deepScanId: 'deepScanId',
             _etag: '_etag',
+            deepScanLimit: 11,
             discoveryPatterns: ['existing discovery pattern', 'old discovery pattern', 'new discovery pattern'],
             reports: [
                 {

--- a/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
@@ -12,14 +12,10 @@ export class WebsiteScanResultAggregator {
         sourceDocument: Partial<WebsiteScanResultBase>,
         targetDocument: Partial<WebsiteScanResultBase>,
     ): Partial<WebsiteScanResultBase> {
+        const propertiesToKeep = ['_etag', 'deepScanId', 'deepScanLimit'];
         const mergedDocument = _.mergeWith(targetDocument, sourceDocument, (target, source, key) => {
-            // Preserve the current _etag value
-            if (key === '_etag') {
-                return target;
-            }
-
-            // Preserve original deep scan request scan id
-            if (key === 'deepScanId') {
+            // preserve the targe value if defined
+            if (propertiesToKeep.includes(key)) {
                 return target;
             }
 

--- a/packages/storage-documents/src/website-scan-result.ts
+++ b/packages/storage-documents/src/website-scan-result.ts
@@ -34,6 +34,7 @@ export interface WebsiteScanResultBase extends StorageDocument {
     discoveryPatterns?: string[];
     combinedResultsBlobId?: string;
     reports?: WebsiteScanReport[];
+    deepScanLimit?: number;
     created: string;
 }
 

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.spec.ts
@@ -69,7 +69,7 @@ describe('CrawlRunner', () => {
             baseUrl,
             discoveryPatterns,
             baseCrawlPage: page,
-            maxRequestsPerCrawl: 1,
+            maxRequestsPerCrawl: 1000,
             silentMode: true,
             restartCrawl: true,
             localOutputDir: `${workingDir}/crawler_storage`,

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -55,7 +55,9 @@ export class CrawlRunner {
         const outputDir = `${this.batchConfig.taskWorkingDir}/${this.storageDirName}`;
 
         return {
-            maxRequestsPerCrawl: 1, // the service crawl single page per runner execution
+            // defines maximum number of links to discover on a page
+            // the crawler will open only baseURL page per run
+            maxRequestsPerCrawl: 1000,
             localOutputDir: outputDir,
             silentMode: true,
             restartCrawl: true,

--- a/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/crawl-runner.ts
@@ -5,7 +5,6 @@ import { GlobalLogger } from 'logger';
 import { inject, injectable } from 'inversify';
 import { Crawler, CrawlerRunOptions, crawlerIocTypes } from 'accessibility-insights-crawler';
 import { Page } from 'puppeteer';
-import { ServiceConfiguration } from 'common';
 import { BatchConfig } from 'azure-services';
 
 type CrawlerProvider = () => Promise<Crawler<string[]>>;
@@ -17,22 +16,20 @@ export class CrawlRunner {
     constructor(
         @inject(crawlerIocTypes.CrawlerProvider) private readonly getCrawler: CrawlerProvider,
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
-        @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(BatchConfig) private readonly batchConfig: BatchConfig,
     ) {}
 
     public async run(baseUrl: string, discoveryPatterns: string[], page: Page): Promise<string[] | undefined> {
         const crawler = await this.getCrawler();
         if (crawler == null) {
-            this.logger.logInfo('No crawler provided by crawler provider');
+            this.logger.logInfo('No crawler instance created by crawler provider.');
 
             return undefined;
         }
 
-        this.logger.logInfo('Starting web page crawling');
+        this.logger.logInfo('Starting web page crawling.');
 
-        let retVal: string[] | undefined;
-
+        let result: string[] | undefined;
         try {
             const commonOptions = await this.getCommonCrawlOptions();
             const crawlerRunOptions: CrawlerRunOptions = {
@@ -42,24 +39,23 @@ export class CrawlRunner {
                 ...commonOptions,
             };
 
-            retVal = await crawler.crawl(crawlerRunOptions);
+            result = await crawler.crawl(crawlerRunOptions);
         } catch (ex) {
-            this.logger.logError('Failure while crawling web page', { error: JSON.stringify(ex) });
+            this.logger.logError('Failure while crawling web page.', { error: JSON.stringify(ex) });
 
             return undefined;
         }
 
-        this.logger.logInfo(`Web page crawling completed successfully. Found ${retVal ? retVal.length : 0} urls.`);
+        this.logger.logInfo(`Web page crawling completed successfully. Found ${result ? result.length : 0} urls.`);
 
-        return retVal;
+        return result;
     }
 
     private async getCommonCrawlOptions(): Promise<Partial<CrawlerRunOptions>> {
-        const urlCrawlLimit = (await this.serviceConfig.getConfigValue('crawlConfig')).urlCrawlLimit;
         const outputDir = `${this.batchConfig.taskWorkingDir}/${this.storageDirName}`;
 
         return {
-            maxRequestsPerCrawl: urlCrawlLimit,
+            maxRequestsPerCrawl: 1, // the service crawl single page per runner execution
             localOutputDir: outputDir,
             silentMode: true,
             restartCrawl: true,

--- a/packages/web-api-scan-runner/src/crawl-runner/discovered-url-processor.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/discovered-url-processor.spec.ts
@@ -18,17 +18,17 @@ describe(discoveredUrlProcessor, () => {
     });
 
     it('limits the number of urls according to config and count of knownUrls', () => {
-        const urlCrawlLimit = 3;
+        const deepScanDiscoveryLimit = 3;
 
-        const processedUrls = discoveredUrlProcessor(urlsList, urlCrawlLimit, ['some url']);
+        const processedUrls = discoveredUrlProcessor(urlsList, deepScanDiscoveryLimit, ['some url']);
 
         expect(processedUrls.length).toBe(2);
     });
 
     it('filters and applies limit in correct order', () => {
-        const urlCrawlLimit = knownUrls.length + 1;
+        const deepScanDiscoveryLimit = knownUrls.length + 1;
 
-        const processedUrls = discoveredUrlProcessor(urlsList, urlCrawlLimit, knownUrls);
+        const processedUrls = discoveredUrlProcessor(urlsList, deepScanDiscoveryLimit, knownUrls);
 
         expect(processedUrls.length).toBe(1);
         expect(knownUrls).not.toContain(processedUrls[0]);
@@ -40,10 +40,10 @@ describe(discoveredUrlProcessor, () => {
         expect(processedUrls).toEqual(urlsList);
     });
 
-    it('handles knownUrls.length > urlCrawlLimit', () => {
-        const urlCrawlLimit = knownUrls.length - 1;
+    it('handles knownUrls.length > deepScanDiscoveryLimit', () => {
+        const deepScanDiscoveryLimit = knownUrls.length - 1;
 
-        const processedUrls = discoveredUrlProcessor(urlsList, urlCrawlLimit, knownUrls);
+        const processedUrls = discoveredUrlProcessor(urlsList, deepScanDiscoveryLimit, knownUrls);
 
         expect(processedUrls.length).toBe(0);
     });

--- a/packages/web-api-scan-runner/src/crawl-runner/discovered-url-processor.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/discovered-url-processor.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 export type DiscoveredUrlProcessor = typeof discoveredUrlProcessor;
 
-export function discoveredUrlProcessor(discoveredUrls: string[], urlCrawlLimit: number, knownUrls?: string[]): string[] {
+export function discoveredUrlProcessor(discoveredUrls: string[], deepScanDiscoveryLimit: number, knownUrls?: string[]): string[] {
     if (_.isNil(discoveredUrls)) {
         return [];
     }
@@ -15,7 +15,7 @@ export function discoveredUrlProcessor(discoveredUrls: string[], urlCrawlLimit: 
         processedUrls = removeUrlsFromList(discoveredUrls, knownUrls);
     }
 
-    return limitNumUrls(processedUrls, getUrlLimit(urlCrawlLimit, knownUrls));
+    return limitNumUrls(processedUrls, getUrlLimit(deepScanDiscoveryLimit, knownUrls));
 }
 
 function removeUrlsFromList(urlList: string[], removeUrls: string[]): string[] {
@@ -26,8 +26,8 @@ function limitNumUrls(urlList: string[], numUrls: number): string[] {
     return _.take(urlList, numUrls);
 }
 
-function getUrlLimit(urlCrawlLimit: number, knownUrls?: string[]): number {
+function getUrlLimit(deepScanDiscoveryLimit: number, knownUrls?: string[]): number {
     const numKnownPages = _.isNil(knownUrls) ? 0 : knownUrls.length;
 
-    return Math.max(urlCrawlLimit - numKnownPages, 0);
+    return Math.max(deepScanDiscoveryLimit - numKnownPages, 0);
 }

--- a/packages/web-api-scan-runner/src/crawl-runner/scan-feed-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/scan-feed-generator.spec.ts
@@ -134,7 +134,7 @@ function createScanRequests(urls: string[]): ScanRunBatchRequest[] {
 
 function setupRetryHelperMock(times: number = 1): void {
     retryHelperMock
-        .setup(async (o) => o.executeWithRetries(It.isAny(), It.isAny(), 2, 1000))
+        .setup(async (o) => o.executeWithRetries(It.isAny(), It.isAny(), 5, 1000))
         .returns(async (action: () => Promise<void>, errorHandler: (err: Error) => Promise<void>, maxRetries: number) => {
             return action();
         })

--- a/packages/web-api-scan-runner/src/crawl-runner/scan-feed-generator.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/scan-feed-generator.ts
@@ -10,7 +10,7 @@ import { GuidGenerator, RetryHelper, System } from 'common';
 
 @injectable()
 export class ScanFeedGenerator {
-    private readonly maxRetryCount = 2;
+    private readonly maxRetryCount = 5;
 
     constructor(
         @inject(ScanDataProvider) private readonly scanDataProvider: ScanDataProvider,

--- a/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
+++ b/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
@@ -16,33 +16,32 @@ import { CrawlRunner } from '../crawl-runner/crawl-runner';
 import { ScanFeedGenerator } from '../crawl-runner/scan-feed-generator';
 import { DeepScanner } from './deep-scanner';
 
+const url = 'test url';
+const puppeteerPageStub = {} as Puppeteer.Page;
+const websiteScanResultId = 'websiteScanResult id';
+const discoveredUrls = ['discoveredUrl1', 'discoveredUrl2'];
+const processedUrls = ['processedUrl1', 'processedUrl2'];
+const discoveryPatterns = ['discovery pattern'];
+const crawlBaseUrl = 'base url';
+const deepScanId = 'deepScanId';
+
+let deepScanDiscoveryLimit: number;
+let loggerMock: IMock<GlobalLogger>;
+let crawlRunnerMock: IMock<CrawlRunner>;
+let websiteScanResultProviderMock: IMock<WebsiteScanResultProvider>;
+let serviceConfigMock: IMock<ServiceConfiguration>;
+let urlProcessorMock: IMock<DiscoveredUrlProcessor>;
+let discoveryPatternGeneratorMock: IMock<DiscoveryPatternFactory>;
+let pageMock: IMock<Page>;
+let scanFeedGeneratorMock: IMock<ScanFeedGenerator>;
+let scanMetadata: ScanMetadata;
+let pageScanResult: OnDemandPageScanResult;
+let websiteScanResult: WebsiteScanResult;
+let websiteScanResultDbDocument: WebsiteScanResult;
+let testSubject: DeepScanner;
+let updatedWebsiteScanResult: Partial<WebsiteScanResult>;
+
 describe(DeepScanner, () => {
-    const url = 'test url';
-    const urlCrawlLimit = 5;
-    const crawlConfig = { urlCrawlLimit } as CrawlConfig;
-    const puppeteerPageStub = {} as Puppeteer.Page;
-    const websiteScanResultId = 'websiteScanResult id';
-    const knownPages = ['knownUrl1', 'knownUrl2'];
-    const discoveredUrls = ['discoveredUrl1', 'discoveredUrl2'];
-    const processedUrls = ['processedUrl1', 'processedUrl2'];
-    const discoveryPatterns = ['discovery pattern'];
-    const crawlBaseUrl = 'base url';
-    const deepScanId = 'deepScanId';
-
-    let loggerMock: IMock<GlobalLogger>;
-    let crawlRunnerMock: IMock<CrawlRunner>;
-    let websiteScanResultProviderMock: IMock<WebsiteScanResultProvider>;
-    let serviceConfigMock: IMock<ServiceConfiguration>;
-    let urlProcessorMock: IMock<DiscoveredUrlProcessor>;
-    let discoveryPatternGeneratorMock: IMock<DiscoveryPatternFactory>;
-    let pageMock: IMock<Page>;
-    let scanFeedGeneratorMock: IMock<ScanFeedGenerator>;
-    let scanMetadata: ScanMetadata;
-    let pageScanResult: OnDemandPageScanResult;
-    let websiteScanResult: WebsiteScanResult;
-    let websiteScanResultDbDocument: WebsiteScanResult;
-    let testSubject: DeepScanner;
-
     beforeEach(() => {
         loggerMock = Mock.ofType<GlobalLogger>();
         crawlRunnerMock = Mock.ofType<CrawlRunner>();
@@ -53,24 +52,32 @@ describe(DeepScanner, () => {
         pageMock = Mock.ofType<Page>();
         scanFeedGeneratorMock = Mock.ofType<ScanFeedGenerator>();
 
-        serviceConfigMock.setup((sc) => sc.getConfigValue('crawlConfig')).returns(() => Promise.resolve(crawlConfig));
+        deepScanDiscoveryLimit = 3;
+        serviceConfigMock
+            .setup((sc) => sc.getConfigValue('crawlConfig'))
+            .returns(() => Promise.resolve({ deepScanDiscoveryLimit } as CrawlConfig));
         pageMock.setup((p) => p.currentPage).returns(() => puppeteerPageStub);
         scanMetadata = {
-            url: url,
+            url,
             deepScan: true,
             id: 'scan id',
         };
         pageScanResult = {
-            url: url,
+            url,
             websiteScanRefs: [
                 { id: 'some id', scanGroupType: 'consolidated-scan-report' },
                 { id: websiteScanResultId, scanGroupType: 'deep-scan' },
             ],
         } as OnDemandPageScanResult;
+        updatedWebsiteScanResult = {
+            id: websiteScanResultId,
+            knownPages: processedUrls,
+            discoveryPatterns,
+        };
         websiteScanResult = {
             id: websiteScanResultId,
-            knownPages: knownPages,
-            discoveryPatterns: discoveryPatterns,
+            knownPages: ['page1', 'page2'],
+            discoveryPatterns,
             baseUrl: crawlBaseUrl,
             deepScanId,
         } as WebsiteScanResult;
@@ -99,9 +106,26 @@ describe(DeepScanner, () => {
         scanFeedGeneratorMock.verifyAll();
     });
 
+    it('continue deep scan for all given known pages', async () => {
+        websiteScanResult.knownPages = [];
+        for (let i = 0; i < deepScanDiscoveryLimit + 2; i++) {
+            websiteScanResult.knownPages.push(`page${i}`);
+        }
+        websiteScanResult.deepScanLimit = websiteScanResult.knownPages.length + 1;
+
+        setupReadWebsiteScanResult();
+        setupLoggerProperties();
+        setupCrawl(discoveryPatterns);
+        setupProcessUrls(websiteScanResult.deepScanLimit);
+        setupUpdateWebsiteScanResult(discoveryPatterns);
+        setupScanFeedGeneratorMock();
+
+        await testSubject.runDeepScan(scanMetadata, pageScanResult, pageMock.object);
+    });
+
     it('skip deep scan if maximum discovered pages limit was reached', async () => {
         websiteScanResult.knownPages = [];
-        for (let i = 0; i < urlCrawlLimit + 1; i++) {
+        for (let i = 0; i < deepScanDiscoveryLimit + 1; i++) {
             websiteScanResult.knownPages.push(`i`);
         }
         setupReadWebsiteScanResult();
@@ -109,8 +133,8 @@ describe(DeepScanner, () => {
         loggerMock
             .setup((o) =>
                 o.logInfo('The website deep scan completed since maximum discovered pages limit was reached.', {
-                    discoveredUrlsTotal: (urlCrawlLimit + 1).toString(),
-                    discoveredUrlsLimit: urlCrawlLimit.toString(),
+                    discoveredUrlsTotal: (deepScanDiscoveryLimit + 1).toString(),
+                    discoveredUrlsLimit: deepScanDiscoveryLimit.toString(),
                 }),
             )
             .verifiable();
@@ -153,53 +177,49 @@ describe(DeepScanner, () => {
 
         await testSubject.runDeepScan(scanMetadata, pageScanResult, pageMock.object);
     });
-
-    function setupScanFeedGeneratorMock(): void {
-        scanFeedGeneratorMock
-            .setup((o) => o.queueDiscoveredPages(It.isValue(websiteScanResultDbDocument), It.isValue(pageScanResult)))
-            .verifiable();
-    }
-
-    function setupReadWebsiteScanResult(): void {
-        websiteScanResultProviderMock.setup((w) => w.read(websiteScanResultId, true)).returns(() => Promise.resolve(websiteScanResult));
-    }
-
-    function setupCrawl(crawlDiscoveryPatterns: string[]): void {
-        crawlRunnerMock
-            .setup((c) => c.run(url, crawlDiscoveryPatterns, puppeteerPageStub))
-            .returns(() => Promise.resolve(discoveredUrls))
-            .verifiable();
-    }
-
-    function setupProcessUrls(): void {
-        urlProcessorMock
-            .setup((u) => u(discoveredUrls, urlCrawlLimit, knownPages))
-            .returns(() => processedUrls)
-            .verifiable();
-    }
-
-    function setupUpdateWebsiteScanResult(crawlDiscoveryPatterns: string[]): void {
-        const updatedWebsiteScanResult: Partial<WebsiteScanResult> = {
-            id: websiteScanResultId,
-            knownPages: processedUrls,
-            discoveryPatterns: crawlDiscoveryPatterns,
-        };
-        websiteScanResultProviderMock
-            .setup((o) => o.mergeOrCreate(scanMetadata.id, updatedWebsiteScanResult, true))
-            .returns(() => Promise.resolve(websiteScanResultDbDocument))
-            .verifiable();
-    }
-
-    function setupLoggerProperties(): void {
-        loggerMock
-            .setup((l) =>
-                l.setCommonProperties(
-                    It.isValue({
-                        websiteScanId: websiteScanResultId,
-                        deepScanId,
-                    }),
-                ),
-            )
-            .verifiable();
-    }
 });
+
+function setupScanFeedGeneratorMock(): void {
+    scanFeedGeneratorMock
+        .setup((o) => o.queueDiscoveredPages(It.isValue(websiteScanResultDbDocument), It.isValue(pageScanResult)))
+        .verifiable();
+}
+
+function setupReadWebsiteScanResult(): void {
+    websiteScanResultProviderMock.setup((w) => w.read(websiteScanResultId, true)).returns(() => Promise.resolve(websiteScanResult));
+}
+
+function setupCrawl(crawlDiscoveryPatterns: string[]): void {
+    crawlRunnerMock
+        .setup((c) => c.run(url, It.isValue(crawlDiscoveryPatterns), puppeteerPageStub))
+        .returns(() => Promise.resolve(discoveredUrls))
+        .verifiable();
+}
+
+function setupProcessUrls(deepScanLimit: number = deepScanDiscoveryLimit): void {
+    urlProcessorMock
+        .setup((u) => u(discoveredUrls, deepScanLimit, websiteScanResult.knownPages))
+        .returns(() => processedUrls)
+        .verifiable();
+}
+
+function setupUpdateWebsiteScanResult(crawlDiscoveryPatterns: string[]): void {
+    updatedWebsiteScanResult.discoveryPatterns = crawlDiscoveryPatterns;
+    websiteScanResultProviderMock
+        .setup((o) => o.mergeOrCreate(scanMetadata.id, It.isValue(updatedWebsiteScanResult), true))
+        .returns(() => Promise.resolve(websiteScanResultDbDocument))
+        .verifiable();
+}
+
+function setupLoggerProperties(): void {
+    loggerMock
+        .setup((l) =>
+            l.setCommonProperties(
+                It.isValue({
+                    websiteScanId: websiteScanResultId,
+                    deepScanId,
+                }),
+            ),
+        )
+        .verifiable();
+}

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -158,7 +158,7 @@ export class ScanBatchRequestFeedController extends WebController {
             const consolidatedGroup = request.reportGroups.find((group) => group.consolidatedId !== undefined);
             if (consolidatedGroup) {
                 const websiteScanRequest: Partial<WebsiteScanResult> = {
-                    baseUrl: request.site.baseUrl,
+                    baseUrl: request.site?.baseUrl,
                     scanGroupId: consolidatedGroup.consolidatedId,
                     // the deep scan id will be saved only when new db document is created
                     deepScanId: request.deepScan ? request.scanId : undefined,
@@ -170,8 +170,8 @@ export class ScanBatchRequestFeedController extends WebController {
                             timestamp: new Date().toJSON(),
                         },
                     ],
-                    knownPages: request.site.knownPages,
-                    discoveryPatterns: request.site.discoveryPatterns,
+                    knownPages: request.site?.knownPages,
+                    discoveryPatterns: request.site?.discoveryPatterns?.length > 0 ? request.site.discoveryPatterns : undefined,
                     created: new Date().toJSON(),
                 };
 


### PR DESCRIPTION
#### Details

Enable deep scan known pages overlimit to include all seeded pages.
Fixed scan request message queue timeout

##### Motivation

Deep scan request can contain overlimit list of the known pages. The request should process all seeded known pages even count is over deep scan limit.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
