### PR TITLE
refactor(deep-scan-e2e-tests): Combine scan request methods

### DIFF
--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -17,7 +17,7 @@ export * from './web-api/scan-notification-error-codes';
 export { HttpResponse } from './web-api/http-response';
 export { ScanBatchRequest } from './web-api/api-contracts/scan-batch-request';
 export * from './web-api/api-contracts/scan-result-response';
-export { ScanRunRequest } from './web-api/api-contracts/scan-run-request';
+export * from './web-api/api-contracts/scan-run-request';
 export { ScanRunResponse } from './web-api/api-contracts/scan-run-response';
 export * from './web-api/api-contracts/health-report';
 export { BatchPoolLoadSnapshotProvider } from './data-providers/batch-pool-load-snapshot-provider';

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -55,7 +55,7 @@ export class A11yServiceClient {
             scanRequestData.reportGroups = [{ consolidatedId: options.consolidatedId }];
             scanRequestData.site = {
                 baseUrl: scanUrl,
-                ...options?.deepScanOptions,
+                ...options.deepScanOptions,
             };
         }
 

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -6,6 +6,7 @@ import { injectable } from 'inversify';
 import { Logger } from 'logger';
 import { HealthReport, ScanResultResponse, ScanRunRequest, ScanRunResponse } from 'service-library';
 import { A11yServiceCredential } from './a11y-service-credential';
+import { PostScanRequestOptions } from './request-options';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -42,43 +43,26 @@ export class A11yServiceClient {
         });
     }
 
-    public async postScanUrl(scanUrl: string, priority?: number): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
-        const scanRequestData: ScanRunRequest = { url: scanUrl };
-
-        return this.postScanUrlWithRequest(scanRequestData, priority);
-    }
-
-    public async postScanUrlWithNotifyUrl(
-        scanUrl: string,
-        scanNotificationUrl: string,
-        priority?: number,
-    ): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
-        const scanRequestData: ScanRunRequest = { url: scanUrl, scanNotifyUrl: scanNotificationUrl };
-
-        return this.postScanUrlWithRequest(scanRequestData, priority);
-    }
-
-    public async postConsolidatedScan(
-        scanUrl: string,
-        reportId: string,
-        scanNotificationUrl: string,
-        priority?: number,
-    ): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
+    public async postScanUrl(scanUrl: string, options?: PostScanRequestOptions): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
         const scanRequestData: ScanRunRequest = {
             url: scanUrl,
-            site: { baseUrl: scanUrl },
-            reportGroups: [{ consolidatedId: reportId }],
-            scanNotifyUrl: scanNotificationUrl,
+            scanNotifyUrl: options?.scanNotificationUrl,
+            priority: options?.priority || 0,
+            deepScan: options?.deepScan,
         };
 
-        return this.postScanUrlWithRequest(scanRequestData, priority);
+        if (options?.consolidatedId) {
+            scanRequestData.reportGroups = [{ consolidatedId: options.consolidatedId }];
+            scanRequestData.site = {
+                baseUrl: scanUrl,
+                ...options?.deepScanOptions,
+            };
+        }
+
+        return this.postScanUrlWithRequest(scanRequestData);
     }
 
-    private async postScanUrlWithRequest(
-        scanRequestData: ScanRunRequest,
-        priority: number,
-    ): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
-        scanRequestData.priority = priority || 0;
+    private async postScanUrlWithRequest(scanRequestData: ScanRunRequest): Promise<ResponseWithBodyType<ScanRunResponse[]>> {
         const requestUrl: string = `${this.requestBaseUrl}/scans`;
         const options: Options = { json: [scanRequestData] };
 

--- a/packages/web-api-client/src/index.ts
+++ b/packages/web-api-client/src/index.ts
@@ -3,3 +3,4 @@
 export { A11yServiceClient } from './a11y-service-client';
 export { A11yServiceCredential } from './a11y-service-credential';
 export { A11yServiceClientProvider, a11yServiceClientTypeNames } from './a11y-service-client-types';
+export { PostScanRequestOptions, DeepScanOptions } from './request-options';

--- a/packages/web-api-client/src/request-options.ts
+++ b/packages/web-api-client/src/request-options.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type PostScanRequestOptions = {
+    priority?: number;
+    scanNotificationUrl?: string;
+    consolidatedId?: string;
+    deepScan?: boolean;
+    deepScanOptions?: DeepScanOptions;
+};
+
+export type DeepScanOptions = {
+    knownPages?: string[];
+    discoveryPatterns?: string[];
+};

--- a/packages/web-workers/src/contracts/activity-actions.ts
+++ b/packages/web-workers/src/contracts/activity-actions.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 export enum ActivityAction {
     createScanRequest = 'createScanRequest',
-    createConsolidatedScanRequest = 'createConsolidatedScanRequest',
     getScanResult = 'getScanResult',
     getScanResultBatch = 'getScanResultBatch',
     getScanReport = 'getScanReport',

--- a/packages/web-workers/src/controllers/activity-request-data.ts
+++ b/packages/web-workers/src/controllers/activity-request-data.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { TestContextData, TestEnvironment, TestGroupName } from 'functional-tests';
 import { AvailabilityTelemetry } from 'logger';
+import { PostScanRequestOptions } from 'web-api-client';
 
 export interface ActivityRequestData {
     activityName: string;
@@ -10,12 +11,7 @@ export interface ActivityRequestData {
 
 export interface CreateScanRequestData {
     scanUrl: string;
-    priority: number;
-    notifyScanUrl?: string;
-}
-
-export interface CreateConsolidatedScanRequestData extends CreateScanRequestData {
-    reportId: string;
+    scanOptions: PostScanRequestOptions;
 }
 
 export interface GetScanResultData {

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.spec.ts
@@ -86,9 +86,10 @@ describe(HealthMonitorClientController, () => {
         it('handles createScanRequest', async () => {
             const scanUrl = 'scan-url';
             const priority = 1;
-            const notifyScanUrl = 'some-notify-url';
+            const scanNotifyUrl = 'some-notify-url';
+            const scanOptions = { scanNotificationUrl: scanNotifyUrl, priority };
             webApiClientMock
-                .setup(async (w) => w.postScanUrlWithNotifyUrl(scanUrl, notifyScanUrl, priority))
+                .setup(async (w) => w.postScanUrl(scanUrl, scanOptions))
                 .returns(async () => Promise.resolve(expectedResponse))
                 .verifiable(Times.once());
 
@@ -96,32 +97,7 @@ describe(HealthMonitorClientController, () => {
                 activityName: ActivityAction.createScanRequest,
                 data: {
                     scanUrl: scanUrl,
-                    priority: priority,
-                    notifyScanUrl: notifyScanUrl,
-                },
-            };
-            const result = await testSubject.invoke(context, args);
-            expect(result).toEqual(jsonResponse);
-        });
-
-        it('handles createConsolidatedScanRequest', async () => {
-            const scanUrl = 'scan-url';
-            const reportIdStub = 'some-report-id';
-            const priority = 1;
-            const notifyScanUrl = 'some-notify-url';
-
-            webApiClientMock
-                .setup(async (w) => w.postConsolidatedScan(scanUrl, reportIdStub, notifyScanUrl, priority))
-                .returns(async () => Promise.resolve(expectedResponse))
-                .verifiable(Times.once());
-
-            const args: ActivityRequestData = {
-                activityName: ActivityAction.createConsolidatedScanRequest,
-                data: {
-                    scanUrl: scanUrl,
-                    priority: priority,
-                    reportId: reportIdStub,
-                    notifyScanUrl: notifyScanUrl,
+                    scanOptions: scanOptions,
                 },
             };
             const result = await testSubject.invoke(context, args);

--- a/packages/web-workers/src/controllers/health-monitor-client-controller.ts
+++ b/packages/web-workers/src/controllers/health-monitor-client-controller.ts
@@ -14,7 +14,6 @@ import {
     GetScanResultData,
     RunFunctionalTestGroupData,
     TrackAvailabilityData,
-    CreateConsolidatedScanRequestData,
 } from './activity-request-data';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
@@ -42,7 +41,6 @@ export class HealthMonitorClientController extends WebController {
 
         this.activityCallbacks = {
             [ActivityAction.createScanRequest]: this.createScanRequest,
-            [ActivityAction.createConsolidatedScanRequest]: this.createConsolidatedScanRequest,
             [ActivityAction.getScanResult]: this.getScanResult,
             [ActivityAction.getScanReport]: this.getScanReport,
             [ActivityAction.getHealthStatus]: this.getHealthStatus,
@@ -71,16 +69,7 @@ export class HealthMonitorClientController extends WebController {
 
     private readonly createScanRequest = async (data: CreateScanRequestData): Promise<SerializableResponse<ScanRunResponse[]>> => {
         const webApiClient = await this.webApiClientProvider();
-        const response = await webApiClient.postScanUrlWithNotifyUrl(data.scanUrl, data.notifyScanUrl, data.priority);
-
-        return this.serializeResponse(response);
-    };
-
-    private readonly createConsolidatedScanRequest = async (
-        data: CreateConsolidatedScanRequestData,
-    ): Promise<SerializableResponse<ScanRunResponse[]>> => {
-        const webApiClient = await this.webApiClientProvider();
-        const response = await webApiClient.postConsolidatedScan(data.scanUrl, data.reportId, data.notifyScanUrl, data.priority);
+        const response = await webApiClient.postScanUrl(data.scanUrl, data.scanOptions);
 
         return this.serializeResponse(response);
     };

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
@@ -19,16 +19,20 @@ describe('E2EScanScenarioDefinitions', () => {
     it('creates request options appropriately from given configs', () => {
         process.env.RELEASE_VERSION = 'test-release-version';
         const definitions = E2EScanFactories.map((factory) => factory(availabilityConfig, webConfig));
-        const requestOptions = definitions.map((d) => d.requestOptions);
+        const requestOptions = definitions.map((d) => d.scanRequestDef);
         expect(requestOptions).toEqual([
             {
-                urlToScan: 'url-to-scan',
-                scanNotificationUrl: 'base-url/scan-notify-api-endpoint',
+                url: 'url-to-scan',
+                options: {
+                    scanNotificationUrl: 'base-url/scan-notify-api-endpoint',
+                },
             },
             {
-                urlToScan: 'url-to-scan',
-                scanNotificationUrl: 'base-url/scan-notify-fail-api-endpoint',
-                consolidatedId: 'consolidated-id-base-test-release-version',
+                url: 'url-to-scan',
+                options: {
+                    scanNotificationUrl: 'base-url/scan-notify-fail-api-endpoint',
+                    consolidatedId: 'consolidated-id-base-test-release-version',
+                },
             },
         ]);
     });

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { AvailabilityTestConfig } from 'common';
+import { PostScanRequestOptions } from 'web-api-client';
 import { WebApiConfig } from '../controllers/web-api-config';
 import { E2ETestGroupNames } from '../e2e-test-group-names';
 
@@ -9,9 +10,11 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
     // Simple scan with notification
     (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
         return {
-            requestOptions: {
-                urlToScan: availabilityConfig.urlToScan,
-                scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
+            scanRequestDef: {
+                url: availabilityConfig.urlToScan,
+                options: {
+                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
+                },
             },
             testGroups: {
                 postScanSubmissionTests: ['PostScan', 'ScanStatus'],
@@ -24,10 +27,12 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
     // Consolidated scan with failed notification
     (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
         return {
-            requestOptions: {
-                urlToScan: availabilityConfig.urlToScan,
-                scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyFailApiEndpoint}`,
-                consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
+            scanRequestDef: {
+                url: availabilityConfig.urlToScan,
+                options: {
+                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyFailApiEndpoint}`,
+                    consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
+                },
             },
             testGroups: {
                 postScanSubmissionTests: [],
@@ -39,14 +44,13 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
     },
 ];
 
-export type ScanRequestOptions = {
-    urlToScan: string;
-    scanNotificationUrl?: string;
-    consolidatedId?: string;
+export type ScanRequestDefinition = {
+    url: string;
+    options?: PostScanRequestOptions;
 };
 
 export type E2EScanScenarioDefinition = {
-    requestOptions: ScanRequestOptions;
+    scanRequestDef: ScanRequestDefinition;
     testGroups: Partial<E2ETestGroupNames>;
 };
 

--- a/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.spec.ts
@@ -8,7 +8,7 @@ import { E2ETestGroupNames } from '../e2e-test-group-names';
 import { OrchestrationSteps, OrchestrationStepsImpl } from '../orchestration-steps';
 import { GeneratorExecutor } from '../test-utilities/generator-executor';
 import { generatorStub } from '../test-utilities/generator-function';
-import { E2EScanScenarioDefinition, ScanRequestOptions } from './e2e-scan-scenario-definitions';
+import { E2EScanScenarioDefinition, ScanRequestDefinition } from './e2e-scan-scenario-definitions';
 import { SingleScanScenario } from './single-scan-scenario';
 
 class TestableSingleScanScenario extends SingleScanScenario {
@@ -24,9 +24,11 @@ describe(SingleScanScenario, () => {
     const url = 'url';
     const scanId = 'scan id';
     const reportId = 'report id';
-    const scanRequestOptions: ScanRequestOptions = {
-        urlToScan: url,
-        scanNotificationUrl: 'scan-notify-url',
+    const scanRequestDef: ScanRequestDefinition = {
+        url: url,
+        options: {
+            scanNotificationUrl: 'scan-notify-url',
+        },
     };
     const testGroupNames: Partial<E2ETestGroupNames> = {
         postScanSubmissionTests: ['PostScan'],
@@ -35,7 +37,7 @@ describe(SingleScanScenario, () => {
         postScanCompletionNotificationTests: ['ScanCompletionNotification'],
     };
     const testDefinition: E2EScanScenarioDefinition = {
-        requestOptions: scanRequestOptions,
+        scanRequestDef: scanRequestDef,
         testGroups: testGroupNames,
     };
 
@@ -57,7 +59,7 @@ describe(SingleScanScenario, () => {
             scanId: scanId,
         };
         orchestrationStepsMock
-            .setup((o) => o.invokeSubmitScanRequestRestApi(scanRequestOptions))
+            .setup((o) => o.invokeSubmitScanRequestRestApi(url, scanRequestDef.options))
             .returns(() => generatorStub(scanId))
             .verifiable();
         orchestrationStepsMock

--- a/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.ts
@@ -14,12 +14,13 @@ export class SingleScanScenario implements E2EScanScenario {
 
     constructor(private readonly orchestrationSteps: OrchestrationSteps, public readonly testDefinition: E2EScanScenarioDefinition) {
         this.testContextData = {
-            scanUrl: this.testDefinition.requestOptions.urlToScan,
+            scanUrl: this.testDefinition.scanRequestDef.url,
         };
     }
 
     public *submitScanPhase(): Generator<Task | TaskSet, void, SerializableResponse & void> {
-        this.testContextData.scanId = yield* this.orchestrationSteps.invokeSubmitScanRequestRestApi(this.testDefinition.requestOptions);
+        const requestDef = this.testDefinition.scanRequestDef;
+        this.testContextData.scanId = yield* this.orchestrationSteps.invokeSubmitScanRequestRestApi(requestDef.url, requestDef.options);
 
         yield* this.orchestrationSteps.runFunctionalTestGroups(
             this.testContextData,


### PR DESCRIPTION
#### Details

Combine scan request methods in A11yServiceClient, HealthMonitorClientController, and OrchestrationSteps into one scan request code path that takes an "options" object with optional settings (such as notification url, deepScan parameters, etc.)

##### Motivation

Currently, we have multiple code paths for different variations on scan requests (in A11yServiceClient, we have postScanUrl, postScanUrlWithNotifyUrl, and postConsolidatedScan). Since we will need to enable deep scan requests on the client in order to run E2E tests, continuing this pattern would create many more code paths that all call the same basic code with different parameters. There will also be some overlap in the options that we will need to allow in different scenarios (for instance, we want to run single scans with and without a notificationUrl, and also deep scans with and without a notificationUrl).

To simplify the interface and keep the number of code paths from growing uncontrollably, this PR will combine those code paths into one. The new, combined postScanUrl method submits a scan request based on an arbitrary combination of optional parameters. This will also make it easier to write new E2E test definitions, since we will be able to specify the request options for any scan scenario and simply pass that object along to the A11yServiceClient.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1830746
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
