### PR TITLE
feat(deep-scan-e2e-tests): waitForDeepScanCompletion

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -18,6 +18,11 @@ Object {
       "doc": "The Application Insights query time range",
       "format": [Function],
     },
+    "maxDeepScanWaitTimeInSeconds": Object {
+      "default": 3600,
+      "doc": "Maximum wait time for deep scan to complete",
+      "format": "int",
+    },
     "maxScanCompletionNotificationWaitTimeInSeconds": Object {
       "default": 600,
       "doc": "Maximum wait time for scan notification request to complete",
@@ -44,7 +49,7 @@ Object {
       "format": "int",
     },
     "urlToScan": Object {
-      "default": "https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-04-06/index.html",
+      "default": "https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-04-06/",
       "doc": "Url to scan for availability testing",
       "format": "String",
     },
@@ -216,6 +221,11 @@ Object {
       "doc": "The Application Insights query time range",
       "format": [Function],
     },
+    "maxDeepScanWaitTimeInSeconds": Object {
+      "default": 3600,
+      "doc": "Maximum wait time for deep scan to complete",
+      "format": "int",
+    },
     "maxScanCompletionNotificationWaitTimeInSeconds": Object {
       "default": 600,
       "doc": "Maximum wait time for scan notification request to complete",
@@ -242,7 +252,7 @@ Object {
       "format": "int",
     },
     "urlToScan": Object {
-      "default": "https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-04-06/index.html",
+      "default": "https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-04-06/",
       "doc": "Url to scan for availability testing",
       "format": "String",
     },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -72,6 +72,7 @@ export interface AvailabilityTestConfig {
     scanNotifyApiEndpoint: string;
     scanNotifyFailApiEndpoint: string;
     maxScanCompletionNotificationWaitTimeInSeconds: number;
+    maxDeepScanWaitTimeInSeconds: number;
 }
 
 export interface CrawlConfig {
@@ -275,7 +276,7 @@ export class ServiceConfiguration {
             availabilityTestConfig: {
                 urlToScan: {
                     format: 'String',
-                    default: 'https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-04-06/index.html',
+                    default: 'https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-04-06/',
                     doc: 'Url to scan for availability testing',
                 },
                 consolidatedIdBase: {
@@ -292,6 +293,11 @@ export class ServiceConfiguration {
                     format: 'int',
                     default: 600,
                     doc: 'Maximum wait time for scan notification request to complete',
+                },
+                maxDeepScanWaitTimeInSeconds: {
+                    format: 'int',
+                    default: 3600,
+                    doc: 'Maximum wait time for deep scan to complete',
                 },
                 scanWaitIntervalInSeconds: {
                     format: 'int',

--- a/packages/web-api/src/controllers/health-check-controller.spec.ts
+++ b/packages/web-api/src/controllers/health-check-controller.spec.ts
@@ -44,6 +44,7 @@ describe(HealthCheckController, () => {
             scanNotifyApiEndpoint: '/some-endpoint',
             maxScanCompletionNotificationWaitTimeInSeconds: 30,
             scanNotifyFailApiEndpoint: '/some-fail-endpoint',
+            maxDeepScanWaitTimeInSeconds: 40,
         };
 
         serviceConfigurationMock = Mock.ofType<ServiceConfiguration>();

--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
@@ -42,6 +42,7 @@ describe('HealthMonitorOrchestrationController', () => {
         scanNotifyApiEndpoint: '/some-endpoint',
         maxScanCompletionNotificationWaitTimeInSeconds: 30,
         scanNotifyFailApiEndpoint: '/some-fail-endpoint',
+        maxDeepScanWaitTimeInSeconds: 40,
     };
     const contextStub = ({
         bindingData: {},

--- a/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.spec.ts
@@ -87,7 +87,7 @@ describe(SingleScanScenario, () => {
         testSubject.testContextData = testContextData;
 
         orchestrationStepsMock
-            .setup((o) => o.waitForScanRequestCompletion(scanId))
+            .setup((o) => o.waitForBaseScanCompletion(scanId))
             .returns(() => generatorStub(scanRunStatus))
             .verifiable();
         orchestrationStepsMock

--- a/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/single-scan-scenario.ts
@@ -31,7 +31,7 @@ export class SingleScanScenario implements E2EScanScenario {
     }
 
     public *waitForScanCompletionPhase(): Generator<Task | TaskSet, void, SerializableResponse & void> {
-        const scanRunStatus = yield* this.orchestrationSteps.waitForScanRequestCompletion(this.testContextData.scanId);
+        const scanRunStatus = yield* this.orchestrationSteps.waitForBaseScanCompletion(this.testContextData.scanId);
         yield* this.orchestrationSteps.runFunctionalTestGroups(
             this.testContextData,
             this.testDefinition.testGroups.postScanCompletionTests,

--- a/packages/web-workers/src/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration-steps.spec.ts
@@ -611,7 +611,7 @@ describe(OrchestrationStepsImpl, () => {
 
                 setupVerifyTrackActivityCall(false, {
                     activityName: 'waitForScanCompletionNotification',
-                    requestResponse: JSON.stringify(response.body.notification),
+                    requestResponse: JSON.stringify(response),
                     currentUtcDateTime: nextTime3.toDate().toUTCString(),
                 });
 

--- a/packages/web-workers/src/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration-steps.spec.ts
@@ -63,6 +63,7 @@ describe(OrchestrationStepsImpl, () => {
             maxScanCompletionNotificationWaitTimeInSeconds: 30,
             scanNotifyApiEndpoint: '/scan-notify-api',
             scanNotifyFailApiEndpoint: '/some-fail-endpoint',
+            maxDeepScanWaitTimeInSeconds: 40,
         };
 
         loggerMock = Mock.ofType(MockableLogger);
@@ -332,141 +333,6 @@ describe(OrchestrationStepsImpl, () => {
         });
     });
 
-    describe('waitForScanRequestCompletion', () => {
-        let generatorExecutor: GeneratorExecutor;
-        let activityRequestData: ActivityRequestData;
-        let nextTime1: moment.Moment;
-        let nextTime2: moment.Moment;
-        let nextTime3: moment.Moment;
-
-        beforeEach(() => {
-            generatorExecutor = new GeneratorExecutor<string>(testSubject.waitForBaseScanCompletion(scanId));
-
-            availabilityTestConfig.scanWaitIntervalInSeconds = 10;
-            availabilityTestConfig.maxScanWaitTimeInSeconds = 10 * 2 + 1;
-            nextTime1 = moment.utc(currentUtcDateTime).add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
-            nextTime2 = nextTime1.clone().add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
-            nextTime3 = nextTime2.clone().add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
-
-            activityRequestData = {
-                activityName: ActivityAction.getScanResult,
-                data: {
-                    scanId: scanId,
-                },
-            };
-        });
-
-        it('times out if not completed by max time', async () => {
-            setupCreateTimer(nextTime1);
-            setupCreateTimer(nextTime2);
-            setupCreateTimer(nextTime3);
-
-            const response: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(200, {
-                scanId: scanId,
-                run: {
-                    state: 'queued',
-                },
-            } as ScanRunResultResponse);
-
-            orchestrationContext
-                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
-                .returns(() => response as any)
-                .verifiable(Times.atLeast(2));
-
-            setupVerifyTrackActivityCall(false, {
-                activityName: 'waitForBaseScanCompletion',
-                requestResponse: JSON.stringify(response),
-                currentUtcDateTime: nextTime3.toDate().toUTCString(),
-            });
-
-            expect(() => generatorExecutor.runTillEnd()).toThrowError();
-        });
-
-        it.each(['pass', 'fail'])(
-            'completes if the scan completed with scanResult %s before max time',
-            async (completedScanScate: ScanState) => {
-                const response: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(200, {
-                    scanId: scanId,
-                    run: {
-                        state: 'queued',
-                    },
-                    scanResult: {
-                        state: 'pending',
-                    },
-                } as ScanRunResultResponse);
-
-                setupCreateTimer(nextTime1);
-                setupCreateTimer(nextTime2, () => {
-                    response.body.scanResult.state = completedScanScate;
-                });
-                setupCreateTimerNeverCalled(nextTime3);
-
-                orchestrationContext
-                    .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
-                    .returns(() => response as any)
-                    .verifiable(Times.atLeast(2));
-
-                setupTrackActivityNeverCalled();
-
-                generatorExecutor.runTillEnd();
-            },
-        );
-
-        it('throws if the scan failed before max time', async () => {
-            let response: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(200, {
-                scanId: scanId,
-                run: {
-                    state: 'queued',
-                },
-            } as ScanRunResultResponse);
-            const failedResponse: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(200, {
-                scanId: scanId,
-                run: {
-                    state: 'failed',
-                },
-            } as ScanRunResultResponse);
-
-            setupCreateTimer(nextTime1);
-            setupCreateTimer(nextTime2, () => {
-                response = failedResponse;
-            });
-            setupCreateTimerNeverCalled(nextTime3);
-
-            orchestrationContext
-                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
-                .returns(() => response as any)
-                .verifiable(Times.atLeast(2));
-
-            setupVerifyTrackActivityCall(false, {
-                activityName: 'waitForBaseScanCompletion',
-                requestResponse: JSON.stringify(failedResponse),
-                currentUtcDateTime: nextTime2.toDate().toUTCString(),
-            });
-
-            expect(() => generatorExecutor.runTillEnd()).toThrowError();
-        });
-
-        test.each([199, 400])('throws if the scan api returns with failure status code %o', async (statusCode: number) => {
-            const response: SerializableResponse = createSerializableResponse(statusCode);
-
-            setupCreateTimer(nextTime1);
-            setupCreateTimerNeverCalled(nextTime2);
-
-            orchestrationContext
-                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
-                .returns(() => response as any)
-                .verifiable(Times.atLeast(1));
-
-            setupVerifyTrackActivityCall(false, {
-                activityName: 'getScanResult',
-                requestResponse: JSON.stringify(response),
-                currentUtcDateTime: nextTime1.toDate().toUTCString(),
-            });
-
-            expect(() => generatorExecutor.runTillEnd()).toThrowError();
-        });
-    });
-
     describe('run functional test groups', () => {
         const testContextData: TestContextData = {
             scanUrl: 'scan url',
@@ -570,22 +436,20 @@ describe(OrchestrationStepsImpl, () => {
         });
     });
 
-    describe('waitForScanCompletionNotification', () => {
+    describe('Wait', () => {
         let generatorExecutor: GeneratorExecutor;
         let activityRequestData: ActivityRequestData;
         let nextTime1: moment.Moment;
         let nextTime2: moment.Moment;
         let nextTime3: moment.Moment;
-        let response: SerializableResponse<ScanRunResultResponse>;
+
+        const scanWaitInterval = 10;
 
         beforeEach(() => {
-            generatorExecutor = new GeneratorExecutor<string>(testSubject.waitForScanCompletionNotification(scanId));
-
-            availabilityTestConfig.scanWaitIntervalInSeconds = 10;
-            availabilityTestConfig.maxScanCompletionNotificationWaitTimeInSeconds = 10 * 2 + 1;
-            nextTime1 = moment.utc(currentUtcDateTime).add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
-            nextTime2 = nextTime1.clone().add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
-            nextTime3 = nextTime2.clone().add(availabilityTestConfig.scanWaitIntervalInSeconds, 'seconds');
+            availabilityTestConfig.scanWaitIntervalInSeconds = scanWaitInterval;
+            nextTime1 = moment.utc(currentUtcDateTime).add(scanWaitInterval, 'seconds');
+            nextTime2 = nextTime1.clone().add(scanWaitInterval, 'seconds');
+            nextTime3 = nextTime2.clone().add(scanWaitInterval, 'seconds');
 
             activityRequestData = {
                 activityName: ActivityAction.getScanResult,
@@ -593,60 +457,225 @@ describe(OrchestrationStepsImpl, () => {
                     scanId: scanId,
                 },
             };
-
-            response = createSerializableResponse<ScanRunResultResponse>(200, {
-                scanId: scanId,
-                notification: {
-                    state: 'pending',
-                },
-            } as ScanRunResultResponse);
         });
 
-        it.each(['pending', 'sending', 'queued'])(
-            'times out if not completed with state %s by max time',
-            async (incompleteState: NotificationState) => {
-                response.body.notification.state = incompleteState;
-                setupCreateTimer(nextTime1);
-                setupCreateTimer(nextTime2);
-                setupCreateTimer(nextTime3);
+        describe('WaitForBaseScanCompletion', () => {
+            let initialResponse: SerializableResponse<ScanRunResultResponse>;
 
-                orchestrationContext
-                    .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
-                    .returns(() => response as any)
-                    .verifiable(Times.atLeast(2));
+            beforeEach(() => {
+                generatorExecutor = new GeneratorExecutor<string>(testSubject.waitForBaseScanCompletion(scanId));
+                availabilityTestConfig.maxScanWaitTimeInSeconds = scanWaitInterval * 2 + 1;
 
-                setupVerifyTrackActivityCall(false, {
-                    activityName: 'waitForScanCompletionNotification',
-                    requestResponse: JSON.stringify(response),
-                    currentUtcDateTime: nextTime3.toDate().toUTCString(),
-                });
+                initialResponse = createSerializableResponse<ScanRunResultResponse>(200, {
+                    scanId: scanId,
+                    run: {
+                        state: 'queued',
+                    },
+                    scanResult: {
+                        state: 'pending',
+                    },
+                } as ScanRunResultResponse);
+            });
+
+            it('times out if not completed by max time', async () => {
+                setupWaitWithTimeout(initialResponse, 'waitForBaseScanCompletion');
 
                 expect(() => generatorExecutor.runTillEnd()).toThrowError();
-            },
-        );
+            });
 
-        it.each(['sent', 'sendFailed', 'queueFailed'])(
-            'completes if the scan completed with state %s before max time',
-            async (completedState: NotificationState) => {
-                setupCreateTimer(nextTime1);
-                setupCreateTimer(nextTime2, () => {
-                    response.body.notification.state = completedState;
-                });
-                setupCreateTimerNeverCalled(nextTime3);
+            it.each(['pass', 'fail'])(
+                'completes if the scan completed with scanResult %s before max time',
+                async (completedScanState: ScanState) => {
+                    const finalResponse: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(
+                        200,
+                        {
+                            scanId: scanId,
+                            run: {
+                                state: 'pending',
+                            },
+                            scanResult: {
+                                state: completedScanState,
+                            },
+                        } as ScanRunResultResponse,
+                    );
 
-                orchestrationContext
-                    .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
-                    .returns(() => response as any)
-                    .verifiable(Times.atLeast(2));
+                    setupWaitWithCompletion(initialResponse, finalResponse, 'waitForBaseScanCompletion', true);
 
-                setupTrackActivityNeverCalled();
+                    generatorExecutor.runTillEnd();
+                },
+            );
+
+            it('throws if the scan run failed before max time', async () => {
+                const failedResponse: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(200, {
+                    scanId: scanId,
+                    run: {
+                        state: 'failed',
+                    },
+                } as ScanRunResultResponse);
+
+                setupWaitWithCompletion(initialResponse, failedResponse, 'waitForBaseScanCompletion', false);
+
+                expect(() => generatorExecutor.runTillEnd()).toThrowError();
+            });
+
+            test.each([199, 400])('throws if the scan api returns with failure status code %o', async (statusCode: number) => {
+                setupWaitWithErrorResponse(statusCode);
+
+                expect(() => generatorExecutor.runTillEnd()).toThrowError();
+            });
+        });
+
+        describe('waitForScanCompletionNotification', () => {
+            let initialResponse: SerializableResponse<ScanRunResultResponse>;
+
+            beforeEach(() => {
+                generatorExecutor = new GeneratorExecutor<string>(testSubject.waitForScanCompletionNotification(scanId));
+                availabilityTestConfig.maxScanCompletionNotificationWaitTimeInSeconds = scanWaitInterval * 2 + 1;
+
+                initialResponse = createSerializableResponse<ScanRunResultResponse>(200, {
+                    scanId: scanId,
+                    notification: {
+                        state: 'pending',
+                    },
+                } as ScanRunResultResponse);
+            });
+
+            it.each(['pending', 'sending', 'queued'])(
+                'times out if not completed with state %s by max time',
+                async (incompleteState: NotificationState) => {
+                    initialResponse.body.notification.state = incompleteState;
+                    setupWaitWithTimeout(initialResponse, 'waitForScanCompletionNotification');
+
+                    expect(() => generatorExecutor.runTillEnd()).toThrowError();
+                },
+            );
+
+            it.each(['sent', 'sendFailed', 'queueFailed'])(
+                'completes if the scan completed with state %s before max time',
+                async (completedState: NotificationState) => {
+                    const finalResponse = createSerializableResponse<ScanRunResultResponse>(200, {
+                        scanId: scanId,
+                        notification: {
+                            state: completedState,
+                        },
+                    } as ScanRunResultResponse);
+
+                    setupWaitWithCompletion(initialResponse, finalResponse, 'waitForScanCompletionNotification', true);
+
+                    generatorExecutor.runTillEnd();
+                },
+            );
+
+            test.each([199, 400])('throws if the scan api returns with failure status code %o', async (statusCode: number) => {
+                setupWaitWithErrorResponse(statusCode);
+
+                expect(() => generatorExecutor.runTillEnd()).toThrowError();
+            });
+        });
+
+        describe('WaitForDeepScanCompletion', () => {
+            let initialResponse: SerializableResponse<ScanRunResultResponse>;
+
+            beforeEach(() => {
+                generatorExecutor = new GeneratorExecutor<string>(testSubject.waitForDeepScanCompletion(scanId));
+                availabilityTestConfig.maxDeepScanWaitTimeInSeconds = scanWaitInterval * 2 + 1;
+
+                initialResponse = createSerializableResponse<ScanRunResultResponse>(200, {
+                    scanId: scanId,
+                    run: {
+                        state: 'queued',
+                    },
+                } as ScanRunResultResponse);
+            });
+
+            it('times out if not completed by max time', async () => {
+                setupWaitWithTimeout(initialResponse, 'waitForDeepScanCompletion');
+
+                expect(() => generatorExecutor.runTillEnd()).toThrowError();
+            });
+
+            it('completes if the deep scan completed before max time', async () => {
+                const finalResponse: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(200, {
+                    scanId: scanId,
+                    run: {
+                        state: 'completed',
+                    },
+                } as ScanRunResultResponse);
+
+                setupWaitWithCompletion(initialResponse, finalResponse, 'waitForDeepScanCompletion', true);
 
                 generatorExecutor.runTillEnd();
-            },
-        );
+            });
 
-        test.each([199, 400])('throws if the scan api returns with failure status code %o', async (statusCode: number) => {
-            response = createSerializableResponse(statusCode);
+            it('throws if the deep scan failed before max time', async () => {
+                const failedResponse: SerializableResponse<ScanRunResultResponse> = createSerializableResponse<ScanRunResultResponse>(200, {
+                    scanId: scanId,
+                    run: {
+                        state: 'failed',
+                    },
+                } as ScanRunResultResponse);
+
+                setupWaitWithCompletion(initialResponse, failedResponse, 'waitForDeepScanCompletion', false);
+
+                expect(() => generatorExecutor.runTillEnd()).toThrowError();
+            });
+
+            test.each([199, 400])('throws if the scan api returns with failure status code %o', async (statusCode: number) => {
+                setupWaitWithErrorResponse(statusCode);
+
+                expect(() => generatorExecutor.runTillEnd()).toThrowError();
+            });
+        });
+
+        function setupWaitWithTimeout(response: SerializableResponse<ScanRunResultResponse>, activityName: string): void {
+            setupCreateTimer(nextTime1);
+            setupCreateTimer(nextTime2);
+            setupCreateTimer(nextTime3);
+
+            orchestrationContext
+                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
+                .returns(() => response as any)
+                .verifiable(Times.atLeast(2));
+
+            setupVerifyTrackActivityCall(false, {
+                activityName: activityName,
+                requestResponse: JSON.stringify(response),
+                currentUtcDateTime: nextTime3.toDate().toUTCString(),
+            });
+        }
+
+        function setupWaitWithCompletion(
+            initialResponse: SerializableResponse<ScanRunResultResponse>,
+            completedResponse: SerializableResponse<ScanRunResultResponse>,
+            activityName: string,
+            shouldSucceed: boolean,
+        ): void {
+            let response = initialResponse;
+
+            setupCreateTimer(nextTime1);
+            setupCreateTimer(nextTime2, () => {
+                response = completedResponse;
+            });
+            setupCreateTimerNeverCalled(nextTime3);
+
+            orchestrationContext
+                .setup((oc) => oc.callActivity(OrchestrationStepsImpl.activityTriggerFuncName, activityRequestData))
+                .returns(() => response as any)
+                .verifiable(Times.atLeast(2));
+
+            if (shouldSucceed) {
+                setupTrackActivityNeverCalled();
+            } else {
+                setupVerifyTrackActivityCall(false, {
+                    activityName: activityName,
+                    requestResponse: JSON.stringify(completedResponse),
+                    currentUtcDateTime: nextTime2.toDate().toUTCString(),
+                });
+            }
+        }
+
+        function setupWaitWithErrorResponse(statusCode: number): void {
+            const response: SerializableResponse = createSerializableResponse(statusCode);
 
             setupCreateTimer(nextTime1);
             setupCreateTimerNeverCalled(nextTime2);
@@ -661,28 +690,26 @@ describe(OrchestrationStepsImpl, () => {
                 requestResponse: JSON.stringify(response),
                 currentUtcDateTime: nextTime1.toDate().toUTCString(),
             });
+        }
 
-            expect(() => generatorExecutor.runTillEnd()).toThrowError();
-        });
+        function setupCreateTimer(fireTime: moment.Moment, callback?: () => void): void {
+            orchestrationContext
+                .setup((oc) => oc.createTimer(fireTime.toDate()))
+                .returns(() => {
+                    currentUtcDateTime = fireTime.toDate();
+                    if (!isNil(callback)) {
+                        callback();
+                    }
+
+                    return undefined;
+                })
+                .verifiable(Times.once());
+        }
+
+        function setupCreateTimerNeverCalled(fireTime: moment.Moment): void {
+            orchestrationContext.setup((oc) => oc.createTimer(fireTime.toDate())).verifiable(Times.never());
+        }
     });
-
-    function setupCreateTimer(fireTime: moment.Moment, callback?: () => void): void {
-        orchestrationContext
-            .setup((oc) => oc.createTimer(fireTime.toDate()))
-            .returns(() => {
-                currentUtcDateTime = fireTime.toDate();
-                if (!isNil(callback)) {
-                    callback();
-                }
-
-                return undefined;
-            })
-            .verifiable(Times.once());
-    }
-
-    function setupCreateTimerNeverCalled(fireTime: moment.Moment): void {
-        orchestrationContext.setup((oc) => oc.createTimer(fireTime.toDate())).verifiable(Times.never());
-    }
 
     function createSerializableResponse<T>(statusCode: number, data?: T): SerializableResponse<T> {
         return ({


### PR DESCRIPTION
#### Details

Add a `waitForDeepScanCompletion` method to `OrchestrationSteps`. This PR also includes some refactoring to reduce duplicated code in the `waitFor` functions in `OrchestrationSteps`, and in the unit tests for this code.

##### Motivation

To run E2E tests for deepScans, the orchestrator will need to be able to wait until the full deepScan has been completed.

##### Context

Possible future work may include separating `waitFor` into a separate object, which would significantly simplify the `OrchestrationSteps` unit tests. Because `waitFor` depends on other code in `OrchestrationSteps,` that change would likely need to be part of a larger refactor of `OrchestrationSteps`, and is deferred for now.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: Fixes #1793077
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
