### PR TITLE
feat(deep-scan-e2e-tests): add functional test groups for deep-scan

### DIFF
--- a/packages/functional-tests/src/functional-test-group-types.ts
+++ b/packages/functional-tests/src/functional-test-group-types.ts
@@ -4,6 +4,8 @@ import { GuidGenerator } from 'common';
 import { OnDemandPageScanRunResultProvider } from 'service-library';
 import { A11yServiceClient } from 'web-api-client';
 import { ConsolidatedScanReportsTestGroup } from './test-groups/consolidated-scan-reports-test-group';
+import { DeepScanPostCompletionTestGroup } from './test-groups/deep-scan-post-completion-test-group';
+import { DeepScanReportsTestGroup } from './test-groups/deep-scan-reports-test-group';
 import { FailedScanNotificationTestGroup } from './test-groups/failed-scan-notification-test-group';
 import { FinalizerTestGroup } from './test-groups/finalizer-test-group';
 import { FunctionalTestGroup } from './test-groups/functional-test-group';
@@ -23,6 +25,8 @@ export type TestGroupName =
     | 'ConsolidatedScanReports'
     | 'ScanCompletionNotification'
     | 'FailedScanNotification'
+    | 'DeepScanPostCompletion'
+    | 'DeepScanReports'
     | 'Finalizer';
 
 export type TestGroupConstructor = new (
@@ -40,5 +44,7 @@ export const functionalTestGroupTypes: { [key in TestGroupName]: TestGroupConstr
     ConsolidatedScanReports: ConsolidatedScanReportsTestGroup,
     ScanCompletionNotification: ScanCompletionNotificationTestGroup,
     FailedScanNotification: FailedScanNotificationTestGroup,
+    DeepScanPostCompletion: DeepScanPostCompletionTestGroup,
+    DeepScanReports: DeepScanReportsTestGroup,
     Finalizer: FinalizerTestGroup,
 };

--- a/packages/functional-tests/src/test-group-data.ts
+++ b/packages/functional-tests/src/test-group-data.ts
@@ -9,4 +9,5 @@ export interface TestGroupData {
 export interface TestContextData {
     scanUrl: string;
     scanId?: string;
+    expectedCrawledUrls?: string[];
 }

--- a/packages/functional-tests/src/test-groups/deep-scan-post-completion-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-post-completion-test-group.ts
@@ -12,23 +12,23 @@ import { FunctionalTestGroup } from './functional-test-group';
 export class DeepScanPostCompletionTestGroup extends FunctionalTestGroup {
     @test(TestEnvironment.all)
     public async testGetScanStatus(): Promise<void> {
-        const response =
-            await this.a11yServiceClient.getScanStatus(this.testContextData.scanId) as ResponseWithBodyType<ScanRunResultResponse>;
+        const response = (await this.a11yServiceClient.getScanStatus(
+            this.testContextData.scanId,
+        )) as ResponseWithBodyType<ScanRunResultResponse>;
 
         this.ensureResponseSuccessStatusCode(response);
         expect(response.body.scanId, 'Get Scan Response should return the Scan ID that we queried').to.be.equal(
             this.testContextData.scanId,
         );
 
-        const crawledUrls = response.body.deepScanResult.map(r => r.url);
-        expect(crawledUrls, 'response should include expected crawled URLs').to.be.equal(
-            this.testContextData.expectedCrawledUrls,
-        );
+        const crawledUrls = response.body.deepScanResult.map((r) => r.url);
+        expect(crawledUrls, 'response should include expected crawled URLs').to.be.equal(this.testContextData.expectedCrawledUrls);
 
-        const crawledUrlStates = response.body.deepScanResult.map(r => r.scanRunState);
-        const doneScanning = crawledUrlStates.every(s => s === 'completed' || s === 'failed');
+        const crawledUrlStates = response.body.deepScanResult.map((r) => r.scanRunState);
+        const doneScanning = crawledUrlStates.every((s) => s === 'completed' || s === 'failed');
         const allowedOverallStates: RunState[] = doneScanning ? ['completed', 'failed'] : ['accepted', 'pending', 'queued', 'running'];
-        expect(response.body.run.state, 'overall scan state should be consistent with individual URL states').to.be.oneOf(allowedOverallStates);
+        expect(response.body.run.state, 'overall scan state should be consistent with individual URL states').to.be.oneOf(
+            allowedOverallStates,
+        );
     }
 }
-

--- a/packages/functional-tests/src/test-groups/deep-scan-post-completion-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-post-completion-test-group.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { expect } from 'chai';
+import { ResponseWithBodyType } from 'common';
+import { RunState, ScanRunResultResponse } from 'service-library';
+import { TestEnvironment } from '../common-types';
+import { test } from '../test-decorator';
+import { FunctionalTestGroup } from './functional-test-group';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+export class DeepScanPostCompletionTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async testGetScanStatus(): Promise<void> {
+        const response =
+            await this.a11yServiceClient.getScanStatus(this.testContextData.scanId) as ResponseWithBodyType<ScanRunResultResponse>;
+
+        this.ensureResponseSuccessStatusCode(response);
+        expect(response.body.scanId, 'Get Scan Response should return the Scan ID that we queried').to.be.equal(
+            this.testContextData.scanId,
+        );
+
+        const crawledUrls = response.body.deepScanResult.map(r => r.url);
+        expect(crawledUrls, 'response should include expected crawled URLs').to.be.equal(
+            this.testContextData.expectedCrawledUrls,
+        );
+
+        const crawledUrlStates = response.body.deepScanResult.map(r => r.scanRunState);
+        const doneScanning = crawledUrlStates.every(s => s === 'completed' || s === 'failed');
+        const allowedOverallStates: RunState[] = doneScanning ? ['completed', 'failed'] : ['accepted', 'pending', 'queued', 'running'];
+        expect(response.body.run.state, 'overall scan state should be consistent with individual URL states').to.be.oneOf(allowedOverallStates);
+    }
+}
+

--- a/packages/functional-tests/src/test-groups/deep-scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-reports-test-group.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { expect } from 'chai';
+import { ResponseWithBodyType } from 'common';
+import { DeepScanResultItem, ScanRunResultResponse } from 'service-library';
+import { TestEnvironment } from '../common-types';
+import { test } from '../test-decorator';
+import { FunctionalTestGroup } from './functional-test-group';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+export class DeepScanReportsTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async testGetReports(): Promise<void> {
+        const response =
+            await this.a11yServiceClient.getScanStatus(this.testContextData.scanId) as ResponseWithBodyType<ScanRunResultResponse>;
+
+        await Promise.all(
+            response.body.deepScanResult.map(async (item: DeepScanResultItem) => {
+                const crawledResponse =
+                    await this.a11yServiceClient.getScanStatus(item.scanId) as ResponseWithBodyType<ScanRunResultResponse>;
+
+                const htmlReportId = crawledResponse.body.reports.find(r => r.format === 'html').reportId;
+                const reportResponse = await this.a11yServiceClient.getScanReport(this.testContextData.scanId, htmlReportId);
+
+                this.ensureResponseSuccessStatusCode(response);
+                expect(reportResponse.body, 'can retrieve individual HTML report for each deep scan crawled URL').to.not.be.undefined;
+            }),
+        );
+    }
+}

--- a/packages/functional-tests/src/test-groups/deep-scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-reports-test-group.ts
@@ -12,15 +12,17 @@ import { FunctionalTestGroup } from './functional-test-group';
 export class DeepScanReportsTestGroup extends FunctionalTestGroup {
     @test(TestEnvironment.all)
     public async testGetReports(): Promise<void> {
-        const response =
-            await this.a11yServiceClient.getScanStatus(this.testContextData.scanId) as ResponseWithBodyType<ScanRunResultResponse>;
+        const response = (await this.a11yServiceClient.getScanStatus(
+            this.testContextData.scanId,
+        )) as ResponseWithBodyType<ScanRunResultResponse>;
 
         await Promise.all(
             response.body.deepScanResult.map(async (item: DeepScanResultItem) => {
-                const crawledResponse =
-                    await this.a11yServiceClient.getScanStatus(item.scanId) as ResponseWithBodyType<ScanRunResultResponse>;
+                const crawledResponse = (await this.a11yServiceClient.getScanStatus(
+                    item.scanId,
+                )) as ResponseWithBodyType<ScanRunResultResponse>;
 
-                const htmlReportId = crawledResponse.body.reports.find(r => r.format === 'html').reportId;
+                const htmlReportId = crawledResponse.body.reports.find((r) => r.format === 'html').reportId;
                 const reportResponse = await this.a11yServiceClient.getScanReport(this.testContextData.scanId, htmlReportId);
 
                 this.ensureResponseSuccessStatusCode(response);

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -42,69 +42,6 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             },
         };
     },
-    // deep scan is true, with completion notification
-    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
-        return {
-            scanRequestDef: {
-                url: availabilityConfig.urlToScan,
-                options: {
-                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
-                    consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
-                    deepScan: true,
-                },
-            },
-            testGroups: {
-                postScanSubmissionTests: [],
-                postScanCompletionTests: ['DeepScanPostCompletion'],
-                scanReportTests: ['DeepScanReports'], // ConsolidatedScanReports?
-                postScanCompletionNotificationTests: [],
-            },
-        };
-    },
-    // deep scan is true, with completion notification, known urls
-    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
-        return {
-            scanRequestDef: {
-                url: availabilityConfig.urlToScan,
-                options: {
-                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
-                    consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
-                    deepScan: true,
-                    deepScanOptions: {
-                        knownPages: ['some-page'],
-                    },
-                },
-            },
-            testGroups: {
-                postScanSubmissionTests: [],
-                postScanCompletionTests: ['DeepScanPostCompletion'],
-                scanReportTests: ['DeepScanReports'], // ConsolidatedScanReports?
-                postScanCompletionNotificationTests: [],
-            },
-        };
-    },
-    // deep scan is true, with completion notification, discovery patterns
-    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
-        return {
-            scanRequestDef: {
-                url: availabilityConfig.urlToScan,
-                options: {
-                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
-                    consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
-                    deepScan: true,
-                    deepScanOptions: {
-                        discoveryPatterns: ['some-pattern'],
-                    },
-                },
-            },
-            testGroups: {
-                postScanSubmissionTests: [],
-                postScanCompletionTests: ['DeepScanPostCompletion'],
-                scanReportTests: ['DeepScanReports'], // ConsolidatedScanReports?
-                postScanCompletionNotificationTests: [],
-            },
-        };
-    },
 ];
 
 export type ScanRequestDefinition = {

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -42,6 +42,69 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             },
         };
     },
+    // deep scan is true, with completion notification
+    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
+        return {
+            scanRequestDef: {
+                url: availabilityConfig.urlToScan,
+                options: {
+                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
+                    consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
+                    deepScan: true,
+                },
+            },
+            testGroups: {
+                postScanSubmissionTests: [],
+                postScanCompletionTests: ['DeepScanPostCompletion'],
+                scanReportTests: ['DeepScanReports'], // ConsolidatedScanReports?
+                postScanCompletionNotificationTests: [],
+            },
+        };
+    },
+    // deep scan is true, with completion notification, known urls
+    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
+        return {
+            scanRequestDef: {
+                url: availabilityConfig.urlToScan,
+                options: {
+                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
+                    consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
+                    deepScan: true,
+                    deepScanOptions: {
+                        knownPages: ['some-page'],
+                    },
+                },
+            },
+            testGroups: {
+                postScanSubmissionTests: [],
+                postScanCompletionTests: ['DeepScanPostCompletion'],
+                scanReportTests: ['DeepScanReports'], // ConsolidatedScanReports?
+                postScanCompletionNotificationTests: [],
+            },
+        };
+    },
+    // deep scan is true, with completion notification, discovery patterns
+    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
+        return {
+            scanRequestDef: {
+                url: availabilityConfig.urlToScan,
+                options: {
+                    scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
+                    consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}`,
+                    deepScan: true,
+                    deepScanOptions: {
+                        discoveryPatterns: ['some-pattern'],
+                    },
+                },
+            },
+            testGroups: {
+                postScanSubmissionTests: [],
+                postScanCompletionTests: ['DeepScanPostCompletion'],
+                scanReportTests: ['DeepScanReports'], // ConsolidatedScanReports?
+                postScanCompletionNotificationTests: [],
+            },
+        };
+    },
 ];
 
 export type ScanRequestDefinition = {


### PR DESCRIPTION
#### Details

This PR adds some functional test groups for the deep-scan scenarios. These are not exercised yet, so this PR has no net behavior on the e2e test suite. We're just getting these files in ahead of time to simplify future reviews / testing.

##### Motivation

These functional test groups will be driven from the e2e-scan-scenario orchestrators in future PRs. This enables us to check whether each deep scan request:
- ends up crawling the expected set of URLs
- provides access to a report for each URL (consolidated will be checked using existing consolidated report test group)
- maintains an overall scan status that's consistent with individual URL scan states

##### Context

We thought about whether `expectedCrawledUrls?: string[];` should be provided other ways. Some alternatives include using snapshots, adding test group constructor args, etc. We decided to use the TestContextData for now to keep things simple. This is consistent with how the TestContextData looked before this feature - e.g. it had fields like consolidatedId, reportID that a subset of all functional tests required.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
