### PR TITLE
feat(deep-scan-e2e-tests): e2e test error handling

### DIFF
--- a/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
+++ b/packages/web-workers/src/controllers/health-monitor-orchestration-controller.spec.ts
@@ -98,7 +98,7 @@ describe('HealthMonitorOrchestrationController', () => {
 
             orchestrationStepsMock
                 .setup((m) => m.logTestRunStart(allTestIdentifiers))
-                .returns(generatorStub)
+                .returns((_) => generatorStub())
                 .verifiable();
             orchestrationStepsMock
                 .setup((m) => m.invokeHealthCheckRestApi())

--- a/packages/web-workers/src/e2e-test-scenarios/scan-scenario-driver.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/scan-scenario-driver.spec.ts
@@ -3,9 +3,8 @@
 
 import 'reflect-metadata';
 
-import { TestContextData } from 'functional-tests';
-import { ScanCompletedNotification, ScanRunResultResponse } from 'service-library';
-import { Mock, IMock, MockBehavior, It, Times } from 'typemoq';
+import { TestContextData, TestGroupName } from 'functional-tests';
+import { Mock, IMock, It } from 'typemoq';
 import { PostScanRequestOptions } from 'web-api-client';
 import { E2ETestGroupNames } from '../e2e-test-group-names';
 import { OrchestrationSteps, OrchestrationStepsImpl } from '../orchestration-steps';
@@ -14,8 +13,11 @@ import { generatorStub } from '../test-utilities/generator-function';
 import { E2EScanScenarioDefinition } from './e2e-scan-scenario-definitions';
 import { ScanScenarioDriver } from './scan-scenario-driver';
 
+/* eslint-disable @typescript-eslint/tslint/config */
+
 class TestableSingleScanScenario extends ScanScenarioDriver {
     public testContextData: TestContextData;
+    public encounteredError: boolean;
 
     constructor(orchestrationSteps: OrchestrationSteps, testDefinition: E2EScanScenarioDefinition) {
         super(orchestrationSteps, testDefinition);
@@ -24,9 +26,18 @@ class TestableSingleScanScenario extends ScanScenarioDriver {
 
 describe(ScanScenarioDriver, () => {
     let orchestrationStepsMock: IMock<OrchestrationStepsImpl>;
+
+    // Callback mocks to check whether or the generators created by
+    // OrchestrationSteps were actually executed
+    let testsRunCallback: jest.Mock;
+    let scanSubmissionCallback: jest.Mock;
+    let scanWaitCallback: jest.Mock;
+    let scanNotificationCallback: jest.Mock;
+    let deepScanWaitCallback: jest.Mock;
+    let trackScanSucceededCallback: jest.Mock;
+
     const scanUrl = 'url';
     const scanId = 'scan id';
-    const reportId = 'report id';
     const testGroupNames: Partial<E2ETestGroupNames> = {
         postScanSubmissionTests: ['PostScan'],
         postScanCompletionTests: ['SingleScanPostCompletion'],
@@ -36,6 +47,7 @@ describe(ScanScenarioDriver, () => {
     };
     const scanOptions: PostScanRequestOptions = {};
     const scenarioName = 'TestScenario';
+    let testError: Error;
 
     let testDefinition: E2EScanScenarioDefinition;
 
@@ -50,8 +62,10 @@ describe(ScanScenarioDriver, () => {
             },
             scanOptions,
         };
+        testError = new Error('test error');
 
-        orchestrationStepsMock = Mock.ofType(OrchestrationStepsImpl, MockBehavior.Strict);
+        orchestrationStepsMock = Mock.ofType<OrchestrationStepsImpl>();
+        setupAllGeneratorCallbacks();
 
         testSubject = new TestableSingleScanScenario(orchestrationStepsMock.object, testDefinition);
     });
@@ -60,132 +74,238 @@ describe(ScanScenarioDriver, () => {
         orchestrationStepsMock.verifyAll();
     });
 
-    it('submitScanPhase', () => {
+    describe('submitScanPhase', () => {
         const expectedTestContextData: TestContextData = {
             scanUrl,
             scanId: scanId,
         };
-        orchestrationStepsMock
-            .setup((o) => o.invokeSubmitScanRequestRestApi(scanUrl, scanOptions))
-            .returns(() => generatorStub(scanId))
-            .verifiable();
-        orchestrationStepsMock
-            .setup((o) => o.runFunctionalTestGroups(scenarioName, expectedTestContextData, testGroupNames.postScanSubmissionTests))
-            .returns(generatorStub)
-            .verifiable();
-        orchestrationStepsMock
-            .setup((o) => o.validateScanRequestSubmissionState(scanId))
-            .returns(generatorStub)
-            .verifiable();
 
-        const generatorExecutor = new GeneratorExecutor(testSubject.submitScanPhase());
-        generatorExecutor.runTillEnd();
+        it('submits scan and runs tests', () => {
+            orchestrationStepsMock.setup((o) => o.invokeSubmitScanRequestRestApi(scanUrl, scanOptions)).verifiable();
+            orchestrationStepsMock
+                .setup((o) => o.runFunctionalTestGroups(scenarioName, expectedTestContextData, testGroupNames.postScanSubmissionTests))
+                .verifiable();
+
+            const generatorExecutor = new GeneratorExecutor(testSubject.submitScanPhase());
+            generatorExecutor.runTillEnd();
+
+            expect(scanSubmissionCallback).toHaveBeenCalled();
+            expect(testsRunCallback).toHaveBeenCalled();
+        });
+
+        it('Runs tests if scan submission throws', () => {
+            scanSubmissionCallback.mockImplementation(() => {
+                throw testError;
+            });
+            orchestrationStepsMock.setup((o) => o.invokeSubmitScanRequestRestApi(scanUrl, scanOptions)).verifiable();
+            orchestrationStepsMock
+                .setup((o) => o.runFunctionalTestGroups(scenarioName, { scanUrl }, testGroupNames.postScanSubmissionTests))
+                .verifiable();
+
+            const generatorExecutor = new GeneratorExecutor(testSubject.submitScanPhase());
+            generatorExecutor.runTillEnd();
+
+            expect(testsRunCallback).toHaveBeenCalled();
+            expect(testSubject.encounteredError).toBeTruthy();
+        });
     });
 
-    it('waitForScanCompletionPhase', () => {
-        const scanRunStatus = {
-            reports: [{ reportId: reportId }],
-        } as ScanRunResultResponse;
+    describe('waitForScanCompletionPhase', () => {
+        const testContextData: TestContextData = {
+            scanUrl,
+            scanId: scanId,
+        };
+        let expectedTests: TestGroupName[];
+
+        beforeEach(() => {
+            expectedTests = testGroupNames.postScanCompletionTests.concat(testGroupNames.scanReportTests);
+            testSubject.testContextData = testContextData;
+        });
+
+        it('waits for completion and runs tests', () => {
+            orchestrationStepsMock.setup((o) => o.waitForBaseScanCompletion(scanId)).verifiable();
+            orchestrationStepsMock.setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, expectedTests)).verifiable();
+
+            const generatorExecutor = new GeneratorExecutor(testSubject.waitForScanCompletionPhase());
+            generatorExecutor.runTillEnd();
+
+            expect(scanWaitCallback).toHaveBeenCalled();
+            expect(testsRunCallback).toHaveBeenCalled();
+        });
+
+        it('Runs tests if wait throws', () => {
+            scanWaitCallback.mockImplementation(() => {
+                throw testError;
+            });
+            orchestrationStepsMock.setup((o) => o.waitForBaseScanCompletion(scanId)).verifiable();
+            orchestrationStepsMock.setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, expectedTests)).verifiable();
+
+            const generatorExecutor = new GeneratorExecutor(testSubject.waitForScanCompletionPhase());
+            generatorExecutor.runTillEnd();
+
+            expect(testsRunCallback).toHaveBeenCalled();
+            expect(testSubject.encounteredError).toBeTruthy();
+        });
+
+        it('Does not wait if there was a previous error', () => {
+            testSubject.encounteredError = true;
+            orchestrationStepsMock.setup((o) => o.waitForBaseScanCompletion(It.isAny())).verifiable();
+            orchestrationStepsMock.setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, expectedTests)).verifiable();
+
+            const generatorExecutor = new GeneratorExecutor(testSubject.waitForScanCompletionPhase());
+            generatorExecutor.runTillEnd();
+
+            expect(scanWaitCallback).toBeCalledTimes(0);
+            expect(testsRunCallback).toHaveBeenCalled();
+        });
+    });
+
+    describe('afterScanCompletionPhase', () => {
         const testContextData: TestContextData = {
             scanUrl,
             scanId: scanId,
         };
 
-        testSubject.testContextData = testContextData;
+        beforeEach(() => {
+            testSubject.testContextData = testContextData;
+        });
 
-        orchestrationStepsMock
-            .setup((o) => o.waitForBaseScanCompletion(scanId))
-            .returns(() => generatorStub(scanRunStatus))
-            .verifiable();
-        orchestrationStepsMock
-            .setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, testGroupNames.postScanCompletionTests))
-            .returns(generatorStub)
-            .verifiable();
-        orchestrationStepsMock
-            .setup((o) => o.invokeGetScanReportRestApi(scanId, reportId))
-            .returns(generatorStub)
-            .verifiable();
-        orchestrationStepsMock
-            .setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, testGroupNames.scanReportTests))
-            .returns(generatorStub)
-            .verifiable();
+        describe('with no scan request options', () => {
+            it('tracks request completed if scan succeeded', () => {
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
 
-        const generatorExecutor = new GeneratorExecutor(testSubject.waitForScanCompletionPhase());
-        generatorExecutor.runTillEnd();
+                expect(deepScanWaitCallback).toHaveBeenCalledTimes(0);
+                expect(scanNotificationCallback).toHaveBeenCalledTimes(0);
+                expect(trackScanSucceededCallback).toHaveBeenCalled();
+            });
+
+            it('does not track request completed if a previous step caused an error', () => {
+                testSubject.encounteredError = true;
+
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
+
+                expect(trackScanSucceededCallback).toHaveBeenCalledTimes(0);
+            });
+        });
+
+        describe('with scan notification url', () => {
+            beforeEach(() => {
+                testDefinition.scanOptions = {
+                    scanNotificationUrl: 'scan-notify-url',
+                };
+                orchestrationStepsMock.setup((o) => o.waitForScanCompletionNotification(scanId)).verifiable();
+                orchestrationStepsMock
+                    .setup((o) =>
+                        o.runFunctionalTestGroups(scenarioName, testContextData, testGroupNames.postScanCompletionNotificationTests),
+                    )
+                    .verifiable();
+            });
+
+            it('runs tests and tracks request completed if notification succeeds', () => {
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
+
+                expect(deepScanWaitCallback).toHaveBeenCalledTimes(0);
+                expect(scanNotificationCallback).toHaveBeenCalled();
+                expect(testsRunCallback).toHaveBeenCalled();
+                expect(trackScanSucceededCallback).toHaveBeenCalled();
+            });
+
+            it('runs tests and does not track request completed if notification errors', () => {
+                scanNotificationCallback.mockImplementation(() => {
+                    throw testError;
+                });
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
+
+                expect(deepScanWaitCallback).toHaveBeenCalledTimes(0);
+                expect(scanNotificationCallback).toHaveBeenCalled();
+                expect(testsRunCallback).toHaveBeenCalled();
+                expect(trackScanSucceededCallback).toHaveBeenCalledTimes(0);
+            });
+
+            it('does not wait for notification if there was a previous error', () => {
+                testSubject.encounteredError = true;
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
+
+                expect(deepScanWaitCallback).toHaveBeenCalledTimes(0);
+                expect(scanNotificationCallback).toHaveBeenCalledTimes(0);
+                expect(testsRunCallback).toHaveBeenCalled();
+                expect(trackScanSucceededCallback).toHaveBeenCalledTimes(0);
+            });
+        });
+
+        describe('with deepScan=true', () => {
+            beforeEach(() => {
+                testDefinition.scanOptions = {
+                    deepScan: true,
+                };
+                orchestrationStepsMock.setup((o) => o.waitForDeepScanCompletion(scanId)).verifiable();
+                orchestrationStepsMock
+                    .setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, testGroupNames.postDeepScanCompletionTests))
+                    .verifiable();
+            });
+
+            it('runs tests and tracks request completed if deep scan wait succeeds', () => {
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
+
+                expect(deepScanWaitCallback).toHaveBeenCalled();
+                expect(scanNotificationCallback).toHaveBeenCalledTimes(0);
+                expect(testsRunCallback).toHaveBeenCalled();
+                expect(trackScanSucceededCallback).toHaveBeenCalled();
+            });
+
+            it('runs tests and does not track request completed if deep scan wait throws', () => {
+                deepScanWaitCallback.mockImplementation(() => {
+                    throw testError;
+                });
+
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
+
+                expect(deepScanWaitCallback).toHaveBeenCalled();
+                expect(scanNotificationCallback).toHaveBeenCalledTimes(0);
+                expect(testsRunCallback).toHaveBeenCalled();
+                expect(trackScanSucceededCallback).toHaveBeenCalledTimes(0);
+            });
+
+            it('runs tests but does not wait for deep scan if there was a previous error', () => {
+                testSubject.encounteredError = true;
+
+                const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
+                generatorExecutor.runTillEnd();
+
+                expect(deepScanWaitCallback).toHaveBeenCalledTimes(0);
+                expect(scanNotificationCallback).toHaveBeenCalledTimes(0);
+                expect(testsRunCallback).toHaveBeenCalled();
+                expect(trackScanSucceededCallback).toHaveBeenCalledTimes(0);
+            });
+        });
     });
 
-    describe('afterScanCompletionPhase', () => {
-        it('with scan notification url', () => {
-            testDefinition.scanOptions = {
-                scanNotificationUrl: 'scan-notify-url',
-            };
+    function setupAllGeneratorCallbacks(): void {
+        testsRunCallback = jest.fn();
+        scanSubmissionCallback = jest.fn();
+        scanWaitCallback = jest.fn();
+        scanNotificationCallback = jest.fn();
+        deepScanWaitCallback = jest.fn();
+        trackScanSucceededCallback = jest.fn();
 
-            const scanCompletedNotification = {} as ScanCompletedNotification;
-            const testContextData: TestContextData = {
-                scanUrl,
-                scanId: scanId,
-            };
-
-            testSubject.testContextData = testContextData;
-
-            orchestrationStepsMock
-                .setup((o) => o.waitForScanCompletionNotification(scanId))
-                .returns(() => generatorStub(scanCompletedNotification))
-                .verifiable();
-            orchestrationStepsMock
-                .setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, testGroupNames.postScanCompletionNotificationTests))
-                .returns(generatorStub)
-                .verifiable();
-            orchestrationStepsMock
-                .setup((o) => o.trackScanRequestCompleted())
-                .returns(generatorStub)
-                .verifiable();
-
-            const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
-            generatorExecutor.runTillEnd();
-        });
-
-        it('with no scan request options', () => {
-            orchestrationStepsMock
-                .setup((o) => o.runFunctionalTestGroups(It.isAny(), It.isAny(), It.isAny()))
-                .returns(generatorStub)
-                .verifiable(Times.never());
-            orchestrationStepsMock
-                .setup((o) => o.trackScanRequestCompleted())
-                .returns(generatorStub)
-                .verifiable();
-
-            const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
-            generatorExecutor.runTillEnd();
-        });
-
-        it('with deepScan=true', () => {
-            testDefinition.scanOptions = {
-                deepScan: true,
-            };
-
-            const testContextData: TestContextData = {
-                scanUrl,
-                scanId: scanId,
-            };
-
-            testSubject.testContextData = testContextData;
-
-            orchestrationStepsMock
-                .setup((o) => o.waitForDeepScanCompletion(scanId))
-                .returns(generatorStub)
-                .verifiable();
-            orchestrationStepsMock
-                .setup((o) => o.runFunctionalTestGroups(scenarioName, testContextData, testGroupNames.postDeepScanCompletionTests))
-                .returns(generatorStub)
-                .verifiable();
-            orchestrationStepsMock
-                .setup((o) => o.trackScanRequestCompleted())
-                .returns(generatorStub)
-                .verifiable();
-
-            const generatorExecutor = new GeneratorExecutor(testSubject.afterScanCompletedPhase());
-            generatorExecutor.runTillEnd();
-        });
-    });
+        orchestrationStepsMock
+            .setup((o) => o.runFunctionalTestGroups(scenarioName, It.isAny(), It.isAny()))
+            .returns(() => generatorStub(testsRunCallback));
+        orchestrationStepsMock
+            .setup((o) => o.invokeSubmitScanRequestRestApi(It.isAny(), It.isAny()))
+            .returns(() => generatorStub(scanSubmissionCallback, scanId));
+        orchestrationStepsMock.setup((o) => o.waitForBaseScanCompletion(It.isAny())).returns(() => generatorStub(scanWaitCallback));
+        orchestrationStepsMock
+            .setup((o) => o.waitForScanCompletionNotification(It.isAny()))
+            .returns(() => generatorStub(scanNotificationCallback));
+        orchestrationStepsMock.setup((o) => o.waitForDeepScanCompletion(It.isAny())).returns(() => generatorStub(deepScanWaitCallback));
+        orchestrationStepsMock.setup((o) => o.trackScanRequestCompleted()).returns(() => generatorStub(trackScanSucceededCallback));
+    }
 });

--- a/packages/web-workers/src/e2e-test-scenarios/scan-scenario-driver.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/scan-scenario-driver.ts
@@ -5,6 +5,7 @@ import { SerializableResponse } from 'common';
 // eslint-disable-next-line import/no-internal-modules
 import { Task, TaskSet } from 'durable-functions/lib/src/classes';
 import { TestContextData, TestGroupName } from 'functional-tests';
+import _ from 'lodash';
 import { OrchestrationSteps } from '../orchestration-steps';
 import { E2EScanScenario } from './e2e-scan-scenario';
 import { E2EScanScenarioDefinition } from './e2e-scan-scenario-definitions';
@@ -22,10 +23,10 @@ export class ScanScenarioDriver implements E2EScanScenario {
     }
 
     public *waitForScanCompletionPhase(): Generator<Task | TaskSet, void, SerializableResponse & void> {
-        yield* this.skipIfError(
-            this.orchestrationSteps.waitForBaseScanCompletion(this.testContextData.scanId),
-            this.testDefinition.testGroups.postScanCompletionTests.concat(this.testDefinition.testGroups.scanReportTests),
+        const testsToRun = _.compact(
+            [].concat(this.testDefinition.testGroups.postScanCompletionTests, this.testDefinition.testGroups.scanReportTests),
         );
+        yield* this.skipIfError(this.orchestrationSteps.waitForBaseScanCompletion(this.testContextData.scanId), testsToRun);
     }
 
     public *afterScanCompletedPhase(): Generator<Task | TaskSet, void, SerializableResponse & void> {

--- a/packages/web-workers/src/test-utilities/generator-function.ts
+++ b/packages/web-workers/src/test-utilities/generator-function.ts
@@ -2,9 +2,16 @@
 // Licensed under the MIT License.
 
 export function* generatorStub<YieldType, ReturnType, NextType = unknown>(
+    callback: () => void = () => null,
     returnValue?: ReturnType,
 ): Generator<YieldType, ReturnType, NextType> {
     yield undefined;
+    callback();
 
     return returnValue;
+}
+
+export function* errorGeneratorStub<YieldType, ReturnType, NextType = unknown>(error: Error): Generator<YieldType, ReturnType, NextType> {
+    yield undefined;
+    throw error;
 }


### PR DESCRIPTION
#### Details

Improve E2E test error handling so that if one scan scenario throws an exception, the rest can continue running.

This PR also includes some improvements to the ScanScenarioDriver unit tests, which verify that all the generators created from OrchestrationSteps were executed, instead of just checking that they were initialized.

##### Motivation

This will give us more accurate E2E results on the dashboard. Currently, if an exception is thrown midway through a run, we get a lot of incomplete results on the dashboard, which tells us nothing about which scenario or tests failed.

##### Context

Note that even if a request fails for a scan scenario, the rest of the tests associated with that scenario still need to run. This is because the health check API endpoint looks for the Finalizer test group and checks that no tests in that run failed, but it does not detect tests that didnt run because of an exception

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: #1835954
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
