### PR TITLE
feat(deep-scan-e2e-tests): add deep scan status consistency & notification e2e tests

### DIFF
--- a/packages/functional-tests/src/functional-test-group-types.ts
+++ b/packages/functional-tests/src/functional-test-group-types.ts
@@ -6,6 +6,7 @@ import { A11yServiceClient } from 'web-api-client';
 import { ConsolidatedScanReportsTestGroup } from './test-groups/consolidated-scan-reports-test-group';
 import { DeepScanPostCompletionTestGroup } from './test-groups/deep-scan-post-completion-test-group';
 import { DeepScanReportsTestGroup } from './test-groups/deep-scan-reports-test-group';
+import { DeepScanStatusConsistencyTestGroup } from './test-groups/deep-scan-status-consistency-test-group';
 import { FailedScanNotificationTestGroup } from './test-groups/failed-scan-notification-test-group';
 import { FinalizerTestGroup } from './test-groups/finalizer-test-group';
 import { FunctionalTestGroup } from './test-groups/functional-test-group';
@@ -27,6 +28,7 @@ export type TestGroupName =
     | 'FailedScanNotification'
     | 'DeepScanPostCompletion'
     | 'DeepScanReports'
+    | 'DeepScanStatusConsistency'
     | 'Finalizer';
 
 export type TestGroupConstructor = new (
@@ -46,5 +48,6 @@ export const functionalTestGroupTypes: { [key in TestGroupName]: TestGroupConstr
     FailedScanNotification: FailedScanNotificationTestGroup,
     DeepScanPostCompletion: DeepScanPostCompletionTestGroup,
     DeepScanReports: DeepScanReportsTestGroup,
+    DeepScanStatusConsistency: DeepScanStatusConsistencyTestGroup,
     Finalizer: FinalizerTestGroup,
 };

--- a/packages/functional-tests/src/functional-test-group-types.ts
+++ b/packages/functional-tests/src/functional-test-group-types.ts
@@ -16,6 +16,7 @@ import { SingleScanPostCompletionTestGroup } from './test-groups/single-scan-pos
 import { ScanQueuingTestGroup } from './test-groups/scan-queuing-test-group';
 import { ScanReportTestGroup } from './test-groups/scan-reports-test-group';
 import { ScanStatusTestGroup } from './test-groups/scan-status-test-group';
+import { DeepScanPreCompletionNotificationTestGroup } from './test-groups/deep-scan-pre-completion-notification-test-group';
 
 export type TestGroupName =
     | 'PostScan'
@@ -26,6 +27,7 @@ export type TestGroupName =
     | 'ConsolidatedScanReports'
     | 'ScanCompletionNotification'
     | 'FailedScanNotification'
+    | 'DeepScanPreCompletionNotification'
     | 'DeepScanPostCompletion'
     | 'DeepScanReports'
     | 'DeepScanStatusConsistency'
@@ -46,6 +48,7 @@ export const functionalTestGroupTypes: { [key in TestGroupName]: TestGroupConstr
     ConsolidatedScanReports: ConsolidatedScanReportsTestGroup,
     ScanCompletionNotification: ScanCompletionNotificationTestGroup,
     FailedScanNotification: FailedScanNotificationTestGroup,
+    DeepScanPreCompletionNotification: DeepScanPreCompletionNotificationTestGroup,
     DeepScanPostCompletion: DeepScanPostCompletionTestGroup,
     DeepScanReports: DeepScanReportsTestGroup,
     DeepScanStatusConsistency: DeepScanStatusConsistencyTestGroup,

--- a/packages/functional-tests/src/test-groups/deep-scan-post-completion-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-post-completion-test-group.ts
@@ -3,7 +3,7 @@
 import { expect, use } from 'chai';
 import * as deepEqualInAnyGroup from 'deep-equal-in-any-order';
 import { ResponseWithBodyType } from 'common';
-import { RunState, ScanRunResultResponse } from 'service-library';
+import { ScanRunResultResponse } from 'service-library';
 import { TestEnvironment } from '../common-types';
 import { test } from '../test-decorator';
 import { FunctionalTestGroup } from './functional-test-group';
@@ -30,11 +30,8 @@ export class DeepScanPostCompletionTestGroup extends FunctionalTestGroup {
             `response should include expected crawled URLs for scan ID ${this.testContextData.scanId}`,
         ).to.deep.equalInAnyOrder(this.testContextData.expectedCrawledUrls);
 
-        const crawledUrlStates = response.body.deepScanResult.map((r) => r.scanRunState);
-        const doneScanning = crawledUrlStates.every((s) => s === 'completed' || s === 'failed');
-        const allowedOverallStates: RunState[] = doneScanning ? ['completed', 'failed'] : ['accepted', 'pending', 'queued', 'running'];
-        expect(response.body.run.state, 'overall scan state should be consistent with individual URL states').to.be.oneOf(
-            allowedOverallStates,
-        );
+        const scansCompleted = response.body.deepScanResult.map((r) => r.scanRunState).every((s) => s === 'completed');
+        expect(scansCompleted, 'overall scan state matches individual states').to.equal(response.body.run.state === 'completed');
+        expect(scansCompleted, 'all crawled URL scans should be completed').true;
     }
 }

--- a/packages/functional-tests/src/test-groups/deep-scan-pre-completion-notification-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-pre-completion-notification-test-group.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { expect } from 'chai';
+import { ResponseWithBodyType } from 'common';
+import { ScanRunResultResponse } from 'service-library';
+import { TestEnvironment } from '../common-types';
+import { test } from '../test-decorator';
+import { FunctionalTestGroup } from './functional-test-group';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+export class DeepScanPreCompletionNotificationTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async testScanNotification(): Promise<void> {
+        const response = (await this.a11yServiceClient.getScanStatus(
+            this.testContextData.scanId,
+        )) as ResponseWithBodyType<ScanRunResultResponse>;
+
+        this.ensureResponseSuccessStatusCode(response);
+        expect(response.body.notification, 'Deep scan result should contain a notification field').to.not.be.undefined;
+
+        const crawledUrlStates = response.body.deepScanResult.map((r) => r.scanRunState);
+        const doneScanning = crawledUrlStates.every((s) => s === 'completed' || s === 'failed');
+        const notificationSent = ['sent', 'sendFailed'].includes(response.body.notification.state);
+        expect(notificationSent, 'Deep scan notification should not be sent until all scans complete').to.equal(doneScanning);
+    }
+}

--- a/packages/functional-tests/src/test-groups/deep-scan-status-consistency-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-status-consistency-test-group.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { expect } from 'chai';
+import { ResponseWithBodyType } from 'common';
+import { RunState, ScanRunResultResponse } from 'service-library';
+import { TestEnvironment } from '../common-types';
+import { test } from '../test-decorator';
+import { FunctionalTestGroup } from './functional-test-group';
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+export class DeepScanStatusConsistencyTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async testConsistentStatus(): Promise<void> {
+        const response = (await this.a11yServiceClient.getScanStatus(
+            this.testContextData.scanId,
+        )) as ResponseWithBodyType<ScanRunResultResponse>;
+
+        this.ensureResponseSuccessStatusCode(response);
+
+        const crawledUrlStates = response.body.deepScanResult.map((r) => r.scanRunState);
+        const doneScanning = crawledUrlStates.every((s) => s === 'completed' || s === 'failed');
+        const allowedOverallStates: RunState[] = doneScanning ? ['completed', 'failed'] : ['accepted', 'pending', 'queued', 'running'];
+        expect(response.body.run.state, 'overall scan state should be consistent with individual URL states').to.be.oneOf(
+            allowedOverallStates,
+        );
+    }
+}

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
@@ -31,6 +31,7 @@ describe('E2EScanScenarioDefinitions', () => {
             },
             {
                 deepScan: true,
+                scanNotificationUrl: 'base-url/scan-notify-fail-api-endpoint',
                 consolidatedId: `consolidated-id-base-test-release-version-deepScan-${fakeDate.getTime()}`,
             },
             {

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
@@ -31,7 +31,7 @@ describe('E2EScanScenarioDefinitions', () => {
             },
             {
                 deepScan: true,
-                scanNotificationUrl: 'base-url/scan-notify-fail-api-endpoint',
+                scanNotificationUrl: 'base-url/scan-notify-api-endpoint',
                 consolidatedId: `consolidated-id-base-test-release-version-deepScan-${fakeDate.getTime()}`,
             },
             {

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -50,6 +50,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             readableName: 'DeepScan',
             scanOptions: {
                 deepScan: true,
+                scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyFailApiEndpoint}`,
                 consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}-deepScan-${Date.now()}`,
             },
             initialTestContextData: {
@@ -57,8 +58,18 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
                 expectedCrawledUrls: [baseUrl, `${baseUrl}linked1/`, `${baseUrl}linked2/`, `${baseUrl}linked1/inner-page.html`],
             },
             testGroups: {
+<<<<<<< HEAD
                 postScanCompletionTests: ['DeepScanStatusConsistency'],
                 postDeepScanCompletionTests: ['DeepScanPostCompletion', 'DeepScanReports', 'ConsolidatedScanReports'],
+=======
+                postDeepScanCompletionTests: [
+                    'DeepScanPostCompletion',
+                    'DeepScanReports',
+                    'ConsolidatedScanReports',
+                    'DeepScanPreCompletionNotification',
+                ],
+                postScanCompletionNotificationTests: ['ScanCompletionNotification'],
+>>>>>>> e24d0eaeb045770b974a8b6c1d5ca440903a2c84
             },
         };
     },

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -58,10 +58,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
                 expectedCrawledUrls: [baseUrl, `${baseUrl}linked1/`, `${baseUrl}linked2/`, `${baseUrl}linked1/inner-page.html`],
             },
             testGroups: {
-<<<<<<< HEAD
                 postScanCompletionTests: ['DeepScanStatusConsistency'],
-                postDeepScanCompletionTests: ['DeepScanPostCompletion', 'DeepScanReports', 'ConsolidatedScanReports'],
-=======
                 postDeepScanCompletionTests: [
                     'DeepScanPostCompletion',
                     'DeepScanReports',
@@ -69,7 +66,6 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
                     'DeepScanPreCompletionNotification',
                 ],
                 postScanCompletionNotificationTests: ['ScanCompletionNotification'],
->>>>>>> e24d0eaeb045770b974a8b6c1d5ca440903a2c84
             },
         };
     },

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -50,7 +50,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             readableName: 'DeepScan',
             scanOptions: {
                 deepScan: true,
-                scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyFailApiEndpoint}`,
+                scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
                 consolidatedId: `${availabilityConfig.consolidatedIdBase}-${process.env.RELEASE_VERSION}-deepScan-${Date.now()}`,
             },
             initialTestContextData: {

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -57,6 +57,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
                 expectedCrawledUrls: [baseUrl, `${baseUrl}linked1/`, `${baseUrl}linked2/`, `${baseUrl}linked1/inner-page.html`],
             },
             testGroups: {
+                postScanCompletionTests: ['DeepScanStatusConsistency'],
                 postDeepScanCompletionTests: ['DeepScanPostCompletion', 'DeepScanReports', 'ConsolidatedScanReports'],
             },
         };
@@ -85,6 +86,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
                 ],
             },
             testGroups: {
+                postScanCompletionTests: ['DeepScanStatusConsistency'],
                 postDeepScanCompletionTests: ['DeepScanPostCompletion', 'DeepScanReports', 'ConsolidatedScanReports'],
             },
         };
@@ -108,6 +110,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
                 expectedCrawledUrls: [baseUrl, `${baseUrl}linked1/`, `${baseUrl}linked1/inner-page.html`],
             },
             testGroups: {
+                postScanCompletionTests: ['DeepScanStatusConsistency'],
                 postDeepScanCompletionTests: ['DeepScanPostCompletion', 'DeepScanReports', 'ConsolidatedScanReports'],
             },
         };


### PR DESCRIPTION
#### Details

This PR reflects paired work with @pownkel and adds two e2e deep scan changes:
- we check that the overall scan state is consistent with individual scan states; e.g. the overall state should be completed iff the individual states are completed
- we check that deep scan notifications are deferred until all individual URLs are crawled

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
