### PR TITLE
fix: deep scan notification e2e test

### DIFF
--- a/packages/functional-tests/src/test-groups/deep-scan-pre-completion-notification-test-group.ts
+++ b/packages/functional-tests/src/test-groups/deep-scan-pre-completion-notification-test-group.ts
@@ -22,6 +22,8 @@ export class DeepScanPreCompletionNotificationTestGroup extends FunctionalTestGr
         const crawledUrlStates = response.body.deepScanResult.map((r) => r.scanRunState);
         const doneScanning = crawledUrlStates.every((s) => s === 'completed' || s === 'failed');
         const notificationSent = ['sent', 'sendFailed'].includes(response.body.notification.state);
-        expect(notificationSent, 'Deep scan notification should not be sent until all scans complete').to.equal(doneScanning);
+        if (notificationSent) {
+            expect(doneScanning, 'Deep scan notification should not be sent until all scans complete').to.be.true;
+        }
     }
 }

--- a/packages/health-client/src/health-checker.ts
+++ b/packages/health-client/src/health-checker.ts
@@ -19,7 +19,7 @@ type Argv = {
     baseUrl: string;
 };
 
-const testTimeoutInMinutes = 60;
+const testTimeoutInMinutes = 75;
 const argv: Argv = yargs.argv as any;
 
 (async () => {


### PR DESCRIPTION
#### Details

- Fix failing deep scan notification E2E test
- increase timeout for E2E tests in deployment pipeline

##### Motivation

Fix pipeline failures

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
