### PR TITLE
fix: update NavigationError processing to capture more specific errors

### DIFF
--- a/packages/scanner-global-library/src/navigation-error-mappings.ts
+++ b/packages/scanner-global-library/src/navigation-error-mappings.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BrowserErrorTypes } from './browser-error';
+
+export const errorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = {
+    UrlNavigationTimeout: ['Navigation timeout', 'net::ERR_CONNECTION_TIMED_OUT'],
+    SslError: [
+        'net::ERR_CERT_AUTHORITY_INVALID',
+        'net::ERR_CERT_DATE_INVALID',
+        'net::HTTP2_INADEQUATE_TRANSPORT_SECURITY',
+        'net::ERR_CERT_COMMON_NAME_INVALID',
+        'SSL_ERROR_UNKNOWN',
+    ],
+    ResourceLoadFailure: ['net::ERR_CONNECTION_REFUSED', 'NS_ERROR_CONNECTION_REFUSED'],
+    InvalidUrl: ['Cannot navigate to invalid URL', 'Invalid url'],
+    EmptyPage: ['net::ERR_ABORTED', 'NS_BINDING_ABORTED'],
+    UrlNotResolved: ['net::ERR_NAME_NOT_RESOLVED'],
+};

--- a/packages/scanner-global-library/src/navigation-error-mappings.ts
+++ b/packages/scanner-global-library/src/navigation-error-mappings.ts
@@ -7,7 +7,7 @@ export const errorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = {
     SslError: [
         'net::ERR_CERT_AUTHORITY_INVALID',
         'net::ERR_CERT_DATE_INVALID',
-        'net::HTTP2_INADEQUATE_TRANSPORT_SECURITY',
+        'net::ERR_HTTP2_INADEQUATE_TRANSPORT_SECURITY',
         'net::ERR_CERT_COMMON_NAME_INVALID',
         'SSL_ERROR_UNKNOWN',
     ],

--- a/packages/scanner-global-library/src/navigation-error-patterns.ts
+++ b/packages/scanner-global-library/src/navigation-error-patterns.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { BrowserErrorTypes } from './browser-error';
 
-export const errorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = {
+export const navigationErrorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = {
     UrlNavigationTimeout: ['Navigation timeout', 'net::ERR_CONNECTION_TIMED_OUT'],
     SslError: [
         'net::ERR_CERT_AUTHORITY_INVALID',

--- a/packages/scanner-global-library/src/page-response-processor.ts
+++ b/packages/scanner-global-library/src/page-response-processor.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 import { injectable } from 'inversify';
 import { Response } from 'puppeteer';
-import { BrowserError } from './browser-error';
+import { BrowserError, BrowserErrorTypes } from './browser-error';
+import { errorPatterns } from './navigation-error-mappings';
 
 @injectable()
 export class PageResponseProcessor {
+    constructor(private readonly navigationErrorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = errorPatterns) {}
     public getResponseError(response: Response, error: Error = new Error()): BrowserError {
         if (!response.ok()) {
             return {
@@ -31,28 +33,15 @@ export class PageResponseProcessor {
     }
 
     public getNavigationError(error: Error): BrowserError {
-        const errorMessage = error.message;
-        const browserError: BrowserError = {
-            errorType: 'NavigationError',
-            message: errorMessage,
+        const matchingErrorType = Object.keys(this.navigationErrorPatterns)
+            .map((k) => k as BrowserErrorTypes)
+            .find((errorType) => this.navigationErrorPatterns[errorType].some((errorPattern) => error.message.includes(errorPattern)));
+
+        return {
+            errorType: matchingErrorType ?? 'NavigationError',
+            message: error.message,
             stack: error.stack,
         };
-
-        if (/TimeoutError: Navigation Timeout Exceeded:/i.test(errorMessage)) {
-            browserError.errorType = 'UrlNavigationTimeout';
-        } else if (errorMessage.includes('net::ERR_CERT_AUTHORITY_INVALID') || errorMessage.includes('SSL_ERROR_UNKNOWN')) {
-            browserError.errorType = 'SslError';
-        } else if (errorMessage.includes('net::ERR_CONNECTION_REFUSED') || errorMessage.includes('NS_ERROR_CONNECTION_REFUSED')) {
-            browserError.errorType = 'ResourceLoadFailure';
-        } else if (errorMessage.includes('Cannot navigate to invalid URL') || errorMessage.includes('Invalid url')) {
-            browserError.errorType = 'InvalidUrl';
-        } else if (errorMessage.includes('net::ERR_ABORTED') || errorMessage.includes('NS_BINDING_ABORTED')) {
-            browserError.errorType = 'EmptyPage';
-        } else if (errorMessage.includes('net::ERR_NAME_NOT_RESOLVED')) {
-            browserError.errorType = 'UrlNotResolved';
-        }
-
-        return browserError;
     }
 
     private isHtmlContentType(response: Response): boolean {

--- a/packages/scanner-global-library/src/page-response-processor.ts
+++ b/packages/scanner-global-library/src/page-response-processor.ts
@@ -3,7 +3,7 @@
 import { injectable } from 'inversify';
 import { Response } from 'puppeteer';
 import { BrowserError, BrowserErrorTypes } from './browser-error';
-import { errorPatterns } from './navigation-error-mappings';
+import { navigationErrorPatterns as errorPatterns } from './navigation-error-patterns';
 
 @injectable()
 export class PageResponseProcessor {


### PR DESCRIPTION
#### Details

This PR updates our navigation-error processing so that more URLs fall into specific buckets like `UrlNavigationTimeout` or `SslError` rather than the catch-all `NavigationError`.

PR parts:
- small refactor of navigation-error mappings into separate file
- adding more error signatures like `net::ERR_CERT_AUTHORITY_INVALID` based on what we saw last WCP run
- update `Navigation timeout` string because of puppeteer update ([original code](https://github.com/puppeteer/puppeteer/blob/3773229ac276a84a4de113e74290abc3bbf60499/lib/LifecycleWatcher.js#L140), [new code](https://github.com/puppeteer/puppeteer/blob/18143b3573e3e9e637ae43c3f757bed8b752634f/src/common/LifecycleWatcher.ts#L194))
- Tested in Azure resource group with affected URLs from last month

##### Motivation

Specific failure cases help the user understand why we couldn't scan their website. Otherwise we need to check logs to get the root error.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
