### PR TITLE
feat(duplicate-id): treat duplicate-id rule as best-practice to match web

### DIFF
--- a/packages/scanner-global-library/src/factories/rule-exclusion.ts
+++ b/packages/scanner-global-library/src/factories/rule-exclusion.ts
@@ -10,6 +10,7 @@ export class RuleExclusion {
         'aria-dialog-name',
         'aria-treeitem-name',
         'css-orientation-lock',
+        'duplicate-id',
         'empty-heading',
         'focus-order-semantics',
         'form-field-multiple-labels',


### PR DESCRIPTION
#### Details

This change keeps the service's ruleset in sync with web's. Web will start treating duplicate-id as a best-practice/non-violation as of issue https://github.com/microsoft/accessibility-insights-web/issues/4102 / PR https://github.com/microsoft/accessibility-insights-web/pull/4127 .

##### Motivation

See https://github.com/microsoft/accessibility-insights-web/issues/4102

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: https://github.com/microsoft/accessibility-insights-web/issues/4102
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
