### PR TITLE
feat(gh-action-crawling): expose cli input validation objects from accessibility-insights-scan package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,7 @@ import { System } from 'common';
 import { CliEntryPoint } from './cli-entry-point';
 import { ScanArguments } from './scan-arguments';
 import { setupCliContainer } from './setup-cli-container';
-import { validateCrawlArguments } from './validate-crawl-arguments';
+import { validateScanArguments } from './validate-scan-arguments';
 
 (async () => {
     const scanArguments = getScanArguments();
@@ -112,7 +112,7 @@ function getScanArguments(): ScanArguments {
             },
         })
         .check((args) => {
-            validateCrawlArguments(args as ScanArguments);
+            validateScanArguments(args as ScanArguments);
 
             return true;
         })

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,12 +9,12 @@ import './module-name-mapper';
 
 // @ts-ignore
 import * as cheerio from 'cheerio';
-import { isEmpty } from 'lodash';
 import yargs from 'yargs';
 import { System } from 'common';
 import { CliEntryPoint } from './cli-entry-point';
 import { ScanArguments } from './scan-arguments';
 import { setupCliContainer } from './setup-cli-container';
+import { validateCrawlArguments } from './validate-crawl-arguments';
 
 (async () => {
     const scanArguments = getScanArguments();
@@ -112,17 +112,7 @@ function getScanArguments(): ScanArguments {
             },
         })
         .check((args) => {
-            if (args.crawl && isEmpty(args.url)) {
-                throw new Error('The --url option is required for website crawling.');
-            }
-
-            if (isEmpty(args.url) && isEmpty(args.inputFile) && isEmpty(args.inputUrls)) {
-                throw new Error('Provide at least --url, --inputFile, or  --inputUrls option.');
-            }
-
-            if (args.restart === true && args.continue === true) {
-                throw new Error('Options --restart and --continue are mutually exclusive.');
-            }
+            validateCrawlArguments(args as ScanArguments);
 
             return true;
         })

--- a/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
@@ -5,8 +5,8 @@ import 'reflect-metadata';
 import fs from 'fs';
 import { IMock, Mock } from 'typemoq';
 import { Url } from 'common';
+import { ScanArguments } from '../scan-arguments';
 import { CrawlerParametersBuilder } from './crawler-parameters-builder';
-import { ScanArguments } from './scan-arguments';
 
 let fileSystemMock: IMock<typeof fs>;
 let crawlerParametersBuilder: CrawlerParametersBuilder;

--- a/packages/cli/src/crawler/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { injectable } from 'inversify';
 import { Url } from 'common';
 import { CrawlerRunOptions } from 'accessibility-insights-crawler';
-import { ScanArguments } from './scan-arguments';
+import { ScanArguments } from '../scan-arguments';
 
 @injectable()
 export class CrawlerParametersBuilder {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,4 +14,4 @@ export { setupCliContainer } from './setup-cli-container';
 export { AICombinedReportDataConverter } from './converter/ai-data-converter';
 export { CrawlerParametersBuilder } from './crawler-parameters-builder';
 export { ScanArguments } from './scan-arguments';
-export { validateCrawlArguments } from './validate-crawl-arguments';
+export { validateScanArguments } from './validate-scan-arguments';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,8 +10,8 @@ export class cheerioModule {}
 
 export { AIScanner } from './scanner/ai-scanner';
 export { AICrawler } from './crawler/ai-crawler';
+export { CrawlerParametersBuilder } from './crawler/crawler-parameters-builder';
 export { setupCliContainer } from './setup-cli-container';
 export { AICombinedReportDataConverter } from './converter/ai-data-converter';
-export { CrawlerParametersBuilder } from './crawler-parameters-builder';
 export { ScanArguments } from './scan-arguments';
 export { validateScanArguments } from './validate-scan-arguments';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,3 +12,6 @@ export { AIScanner } from './scanner/ai-scanner';
 export { AICrawler } from './crawler/ai-crawler';
 export { setupCliContainer } from './setup-cli-container';
 export { AICombinedReportDataConverter } from './converter/ai-data-converter';
+export { CrawlerParametersBuilder } from './crawler-parameters-builder';
+export { ScanArguments } from './scan-arguments';
+export { validateCrawlArguments } from './validate-crawl-arguments';

--- a/packages/cli/src/runner/crawler-command-runner.spec.ts
+++ b/packages/cli/src/runner/crawler-command-runner.spec.ts
@@ -8,7 +8,7 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ScanArguments } from '../scan-arguments';
 import { ConsolidatedReportGenerator } from '../report/consolidated-report-generator';
-import { CrawlerParametersBuilder } from '../crawler-parameters-builder';
+import { CrawlerParametersBuilder } from '../crawler/crawler-parameters-builder';
 import { AICrawler } from '../crawler/ai-crawler';
 import { CrawlerCommandRunner } from './crawler-command-runner';
 

--- a/packages/cli/src/runner/crawler-command-runner.ts
+++ b/packages/cli/src/runner/crawler-command-runner.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ScanArguments } from '../scan-arguments';
 import { ConsolidatedReportGenerator } from '../report/consolidated-report-generator';
-import { CrawlerParametersBuilder } from '../crawler-parameters-builder';
+import { CrawlerParametersBuilder } from '../crawler/crawler-parameters-builder';
 import { AICrawler } from '../crawler/ai-crawler';
 import { CommandRunner } from './command-runner';
 

--- a/packages/cli/src/validate-crawl-arguments.ts
+++ b/packages/cli/src/validate-crawl-arguments.ts
@@ -1,0 +1,16 @@
+import { isEmpty } from 'lodash';
+import { ScanArguments } from './scan-arguments';
+
+export function validateCrawlArguments(args: ScanArguments): void {
+    if (args.crawl && isEmpty(args.url)) {
+        throw new Error('The --url option is required for website crawling.');
+    }
+
+    if (isEmpty(args.url) && isEmpty(args.inputFile) && isEmpty(args.inputUrls)) {
+        throw new Error('Provide at least --url, --inputFile, or  --inputUrls option.');
+    }
+
+    if (args.restart === true && args.continue === true) {
+        throw new Error('Options --restart and --continue are mutually exclusive.');
+    }
+}

--- a/packages/cli/src/validate-scan-arguments.ts
+++ b/packages/cli/src/validate-scan-arguments.ts
@@ -1,7 +1,7 @@
 import { isEmpty } from 'lodash';
 import { ScanArguments } from './scan-arguments';
 
-export function validateCrawlArguments(args: ScanArguments): void {
+export function validateScanArguments(args: ScanArguments): void {
     if (args.crawl && isEmpty(args.url)) {
         throw new Error('The --url option is required for website crawling.');
     }


### PR DESCRIPTION
#### Details

This PR exposes a `validateScanArguments` function and `CrawlerParametersBuilder` so we can use them to validate the action inputs in https://github.com/microsoft/accessibility-insights-action/pull/564. 

I moved `crawler-parameter-builder` to the `crawler` folder so the output directory of the package makes more sense:

```
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----         4/29/2021   4:08 PM                converter
d-----         4/29/2021   4:08 PM                crawler
d-----         4/29/2021   4:08 PM                scan-result-providers
d-----         4/29/2021   4:08 PM                scanner
-a----         4/29/2021   4:09 PM         310860 ai-scan-cli.js
-a----         4/29/2021   4:09 PM         313448 ai-scan-cli.js.map
-a----         4/29/2021   4:08 PM          12202 browser-imports.js
-a----         4/29/2021   4:09 PM          17125 index.d.ts
-a----         4/29/2021   4:08 PM         274828 index.js
-a----         4/29/2021   4:08 PM         277043 index.js.map
-a----         4/29/2021   4:08 PM            468 scan-arguments.d.ts
-a----         4/29/2021   4:08 PM            139 setup-cli-container.d.
                                                  ts
-a----         4/29/2021   4:08 PM            126 validate-scan-argument
                                                  s.d.ts
```

##### Motivation

We can reuse this code in the action

##### Context

I tested that `node .\ai-scan-cli.js` still shows error with missing arguments.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
