### PR TITLE
Compare encoded URLs after page scan

### DIFF
--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -109,7 +109,8 @@ export class Page {
 
         if (
             this.navigationResponse.request().redirectChain().length > 0 ||
-            (this.requestUrl !== undefined && this.requestUrl !== axeResults.url)
+            // comparison of encode normalized Urls is preferable
+            (this.requestUrl !== undefined && encodeURI(this.requestUrl) !== axeResults.url)
         ) {
             this.logger?.logWarn(`Scanning performed on redirected page`, { redirectedUrl: axeResults.url });
             scanResults.scannedUrl = axeResults.url;


### PR DESCRIPTION
#### Details

Encode scan request URL before comparison with axe scanned URL to avoid false positive redirection error.

##### Motivation

Fix customer issue.

##### Context

False positive redirection error when scanning URLs with culture specific chars.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
