### PR TITLE
chore: remove soft delete keyvault flag

### DIFF
--- a/packages/resource-deployment/scripts/delete-pools-if-needed.sh
+++ b/packages/resource-deployment/scripts/delete-pools-if-needed.sh
@@ -8,7 +8,6 @@ set -eo pipefail
 export resourceGroupName
 export batchAccountName
 export keyVault
-export enableSoftDeleteOnKeyVault
 export pools
 
 kernelName=$(uname -s 2>/dev/null) || true

--- a/packages/resource-deployment/scripts/install-parallel.sh
+++ b/packages/resource-deployment/scripts/install-parallel.sh
@@ -23,12 +23,11 @@ export webApiAdClientId
 export webApiAdClientSecret
 export releaseVersion
 export templatesFolder="${0%/*}/../templates/"
-export enableSoftDeleteOnKeyVault=true
 export dropPools=false
 
 exitWithUsageInfo() {
     echo "
-Usage: $0 -e <environment> -l <Azure region> -o <organisation name> -p <publisher email> -r <resource group> -s <subscription name or id> -c <client id> -t <client secret> -v <release version> -k <enable soft delete for Azure Key Vault> [-d <pass \"true\" to force pools to drop>]
+Usage: $0 -e <environment> -l <Azure region> -o <organisation name> -p <publisher email> -r <resource group> -s <subscription name or id> -c <client id> -t <client secret> -v <release version> [-d <pass \"true\" to force pools to drop>]
 where:
 
 Resource group - The name of the resource group that everything will be deployed in.
@@ -94,7 +93,7 @@ function onExit() {
 trap "onExit" EXIT
 
 # Read script arguments
-while getopts ":r:s:l:e:o:p:c:t:v:k:d:" option; do
+while getopts ":r:s:l:e:o:p:c:t:v:d:" option; do
     case $option in
     r) resourceGroupName=${OPTARG} ;;
     s) subscription=${OPTARG} ;;
@@ -105,7 +104,6 @@ while getopts ":r:s:l:e:o:p:c:t:v:k:d:" option; do
     c) webApiAdClientId=${OPTARG} ;;
     t) webApiAdClientSecret=${OPTARG} ;;
     v) releaseVersion=${OPTARG} ;;
-    k) enableSoftDeleteOnKeyVault=${OPTARG} ;;
     d) dropPools=${OPTARG} ;;
     *) exitWithUsageInfo ;;
     esac

--- a/packages/resource-deployment/scripts/setup-key-vault.sh
+++ b/packages/resource-deployment/scripts/setup-key-vault.sh
@@ -8,7 +8,6 @@ set -eo pipefail
 
 export resourceGroupName
 export keyVault
-export enableSoftDeleteOnKeyVault
 
 # Set default ARM template files
 createKeyVaultTemplateFile="${0%/*}/../templates/key-vault-create.template.json"
@@ -58,7 +57,6 @@ function createKeyvaultIfNotExists() {
                 --template-file "$createKeyVaultTemplateFile" \
                 --parameters objectId=$objectId \
                 --query "properties.outputResources[].id" \
-                --parameters enableSoftDeleteOnKeyVault="$enableSoftDeleteOnKeyVault" \
                 -o tsv
         )
 
@@ -99,10 +97,9 @@ function setupKeyVaultResources() {
 }
 
 # Read script arguments
-while getopts ":r:k:c:p:e:" option; do
+while getopts ":r:c:p:e:" option; do
     case $option in
     r) resourceGroupName=${OPTARG} ;;
-    k) enableSoftDeleteOnKeyVault=${OPTARG} ;;
     c) webApiAdClientId=${OPTARG} ;;
     p) webApiAdClientSecret=${OPTARG} ;;
     e) environment=${OPTARG} ;;
@@ -111,7 +108,7 @@ while getopts ":r:k:c:p:e:" option; do
 done
 
 # Print script usage help
-if [[ -z $resourceGroupName ]] || [[ -z $enableSoftDeleteOnKeyVault ]] || [[ -z $webApiAdClientId ]] || [[ -z $webApiAdClientSecret ]]; then
+if [[ -z $resourceGroupName ]] || [[ -z $webApiAdClientId ]] || [[ -z $webApiAdClientSecret ]]; then
     exitWithUsageInfo
 fi
 

--- a/packages/resource-deployment/templates/key-vault-create.template.json
+++ b/packages/resource-deployment/templates/key-vault-create.template.json
@@ -16,13 +16,6 @@
                 "description": "The location in which the Azure resources should be deployed."
             }
         },
-        "enableSoftDeleteOnKeyVault": {
-            "defaultValue": true,
-            "type": "bool",
-            "metadata": {
-                "description": "Enables/Disables the soft delete option in key vault"
-            }
-        },
         "objectId": {
             "type": "string",
             "defaultValue": "f520d84c-3fd3-4cc8-88d4-2ed25b00d27a",
@@ -56,7 +49,7 @@
                 "enabledForDeployment": true,
                 "enabledForDiskEncryption": true,
                 "enabledForTemplateDeployment": true,
-                "enableSoftDelete": "[parameters('enableSoftDeleteOnKeyVault')]"
+                "enableSoftDelete": true
             }
         }
     ]


### PR DESCRIPTION
#### Details

Remove the enableSoftDeleteOnKeyvault flag from deployment scripts

##### Motivation

Azure has removed the option to opt out of soft delete, and all our pipelines set soft delete to true by default, so there is no reason to keep this flag.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
