### PR TITLE
Fix package path under package content only

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,6 +19,15 @@ This package is available on [npm](http://npmjs.com) as `accessibility-insights-
   npm install -g accessibility-insights-scan
 ```
 
+When installing package on [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about) follow the steps below.
+
+-   [Configure npm to use a different directory](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to support global package installation.
+-   Install package globally:
+
+```sh
+  npm install --unsafe-perm=true -g accessibility-insights-scan
+```
+
 ## Example Usage
 
 ## Single URL Scan

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js",

--- a/packages/cli/src/module-name-mapper.ts
+++ b/packages/cli/src/module-name-mapper.ts
@@ -10,14 +10,20 @@ moduleRef._resolveFilename = new Proxy(moduleRef._resolveFilename, {
     apply(target: any, thisArg: any, argumentsList: any): any {
         const moduleName = argumentsList[0] as string;
         let path = Reflect.apply(target, thisArg, argumentsList) as string;
-        if (moduleName.startsWith('@uifabric/styling')) {
-            if (require('os').type() === 'Windows_NT') {
-                path = path.replace('\\lib\\', '\\lib-commonjs\\');
-            } else {
-                path = path.replace('/lib/', '/lib-commonjs/');
-            }
+        if (moduleName.indexOf('@uifabric/styling') >= 0) {
+            path = fixModulePath('@uifabric', path);
         }
 
         return path;
     },
 });
+
+function fixModulePath(moduleName: string, path: string): string {
+    // fix path of the package content only
+    const index = path.lastIndexOf(moduleName);
+    if (require('os').type() === 'Windows_NT') {
+        return path.slice(0, index) + path.slice(index).replace('\\lib\\', '\\lib-commonjs\\');
+    } else {
+        return path.slice(0, index) + path.slice(index).replace('/lib/', '/lib-commonjs/');
+    }
+}

--- a/packages/cli/src/runner/url-command-runner.ts
+++ b/packages/cli/src/runner/url-command-runner.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 import { Spinner } from 'cli-spinner';
 import { inject, injectable } from 'inversify';
-import { AxeScanResults } from 'scanner-global-library';
 import { ReportDiskWriter } from '../report/report-disk-writer';
 import { ReportGenerator } from '../report/report-generator';
 import { AIScanner } from '../scanner/ai-scanner';
@@ -19,17 +19,19 @@ export class UrlCommandRunner implements CommandRunner {
 
     public async runCommand(scanArguments: ScanArguments): Promise<void> {
         const spinner = new Spinner(`Running scanner... %s \t`);
-        let axeResults: AxeScanResults;
 
         try {
             spinner.start();
 
-            axeResults = await this.scanner.scan(scanArguments.url);
+            const axeResults = await this.scanner.scan(scanArguments.url);
+            if (axeResults.error !== undefined) {
+                throw new Error(JSON.stringify(axeResults.error));
+            }
+
+            const reportContent = this.reportGenerator.generateReport(axeResults);
+            this.reportDiskWriter.writeToDirectory(scanArguments.output, scanArguments.url, 'html', reportContent);
         } finally {
             spinner.stop();
         }
-
-        const reportContent = this.reportGenerator.generateReport(axeResults);
-        this.reportDiskWriter.writeToDirectory(scanArguments.output, scanArguments.url, 'html', reportContent);
     }
 }

--- a/packages/crawler/src/global-overrides.ts
+++ b/packages/crawler/src/global-overrides.ts
@@ -39,14 +39,20 @@ moduleRef._resolveFilename = new Proxy(moduleRef._resolveFilename, {
     apply(target: any, thisArg: any, argumentsList: any): any {
         const moduleName = argumentsList[0] as string;
         let path = Reflect.apply(target, thisArg, argumentsList) as string;
-        if (moduleName.startsWith('@uifabric/styling')) {
-            if (require('os').type() === 'Windows_NT') {
-                path = path.replace('\\lib\\', '\\lib-commonjs\\');
-            } else {
-                path = path.replace('/lib/', '/lib-commonjs/');
-            }
+        if (moduleName.indexOf('@uifabric/styling') >= 0) {
+            path = fixModulePath('@uifabric', path);
         }
 
         return path;
     },
 });
+
+function fixModulePath(moduleName: string, path: string): string {
+    // fix path of the package content only
+    const index = path.lastIndexOf(moduleName);
+    if (require('os').type() === 'Windows_NT') {
+        return path.slice(0, index) + path.slice(index).replace('\\lib\\', '\\lib-commonjs\\');
+    } else {
+        return path.slice(0, index) + path.slice(index).replace('/lib/', '/lib-commonjs/');
+    }
+}

--- a/packages/web-api-scan-runner/src/module-name-mapper.ts
+++ b/packages/web-api-scan-runner/src/module-name-mapper.ts
@@ -9,14 +9,20 @@ moduleRef._resolveFilename = new Proxy(moduleRef._resolveFilename, {
     apply(target: any, thisArg: any, argumentsList: any): any {
         const moduleName = argumentsList[0] as string;
         let path = Reflect.apply(target, thisArg, argumentsList) as string;
-        if (moduleName.startsWith('@uifabric/styling')) {
-            if (require('os').type() === 'Windows_NT') {
-                path = path.replace('\\lib\\', '\\lib-commonjs\\');
-            } else {
-                path = path.replace('/lib/', '/lib-commonjs/');
-            }
+        if (moduleName.indexOf('@uifabric/styling') >= 0) {
+            path = fixModulePath('@uifabric', path);
         }
 
         return path;
     },
 });
+
+function fixModulePath(moduleName: string, path: string): string {
+    // fix path of the package content only
+    const index = path.lastIndexOf(moduleName);
+    if (require('os').type() === 'Windows_NT') {
+        return path.slice(0, index) + path.slice(index).replace('\\lib\\', '\\lib-commonjs\\');
+    } else {
+        return path.slice(0, index) + path.slice(index).replace('/lib/', '/lib-commonjs/');
+    }
+}


### PR DESCRIPTION
#### Details

Fix package path under package content only to support client global installation.
Update readme with WSL install steps.

[Validation deployment](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_releaseProgress?_a=release-pipeline-progress&releaseId=7914)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: Fixes #1442,#1443
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
