### PR TITLE
Increase max number of failed scan requests retries

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -153,7 +153,7 @@ Object {
       "format": "int",
     },
     "maxFailedScanRetryCount": Object {
-      "default": 3,
+      "default": 7,
       "doc": "Maximum number of retries (additional times to re-run a scan) allowed for a failed scan request.",
       "format": "int",
     },
@@ -341,7 +341,7 @@ Object {
       "format": "int",
     },
     "maxFailedScanRetryCount": Object {
-      "default": 3,
+      "default": 7,
       "doc": "Maximum number of retries (additional times to re-run a scan) allowed for a failed scan request.",
       "format": "int",
     },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -214,7 +214,7 @@ export class ServiceConfiguration {
                 },
                 maxFailedScanRetryCount: {
                     format: 'int',
-                    default: 3,
+                    default: 7,
                     doc: 'Maximum number of retries (additional times to re-run a scan) allowed for a failed scan request.',
                 },
                 maxSendNotificationRetryCount: {


### PR DESCRIPTION
#### Details

Increase max number of failed scan retries

##### Motivation

Mitigate the concurrency issue when building consolidated report for websites with 100 pages 

##### Context

When website scan runs it queues all discovered pages to scan. Some pages will fail to update consolidated report blob at the same time. Increasing number of retries will span failed pages scan requests longer with more probability to update the report blob.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
