### PR TITLE
Encode docker parameters

### DIFF
--- a/packages/azure-services/src/azure-batch/batch-task-config-generator.spec.ts
+++ b/packages/azure-services/src/azure-batch/batch-task-config-generator.spec.ts
@@ -73,6 +73,17 @@ describe(BatchTaskConfigGenerator, () => {
         );
     });
 
+    it('create container run options with encoded URL', async () => {
+        const taskArgsString = JSON.stringify({
+            url: 'https://localhost/support page/',
+        });
+        const environmentSettings = getEnvironmentSettings(taskArgsString);
+        const actualContainerRunOptions = testSubject.getContainerRunOptions(taskArgsString, environmentSettings);
+        expect(actualContainerRunOptions).toEqual(
+            "--init --rm --workdir / -e APPINSIGHTS_INSTRUMENTATIONKEY -e KEY_VAULT_URL -e TASK_ARGUMENTS -e url='https://localhost/support%20page/' --addon option",
+        );
+    });
+
     it('get environment settings', async () => {
         const taskArgsString = JSON.stringify(taskArgs);
         const expectedEnvironmentSettings = getEnvironmentSettings(taskArgsString);

--- a/packages/azure-services/src/azure-batch/batch-task-config-generator.ts
+++ b/packages/azure-services/src/azure-batch/batch-task-config-generator.ts
@@ -113,7 +113,8 @@ export class BatchTaskConfigGenerator {
     private createRunArgsOptions(taskArgsString: string): string {
         let options = '';
         const taskArgs = JSON.parse(taskArgsString) as { [key: string]: string };
-        Object.keys(taskArgs).forEach((arg) => (options += `-e ${arg}='${taskArgs[arg]}' `));
+        // encode parameters to pass into docker hosted process
+        Object.keys(taskArgs).forEach((arg) => (options += `-e ${arg}='${encodeURI(taskArgs[arg])}' `));
 
         return options.trimRight();
     }

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -41,6 +41,7 @@ let scanRunnerTelemetryManagerMock: IMock<ScanRunnerTelemetryManager>;
 let serviceConfigMock: IMock<ServiceConfiguration>;
 let loggerMock: IMock<GlobalLogger>;
 let runner: Runner;
+let scanMetadataInput: ScanMetadata;
 let scanMetadata: ScanMetadata;
 let dateNow: Date;
 let pageScanResultDbDocument: OnDemandPageScanResult;
@@ -66,9 +67,14 @@ describe(Runner, () => {
         dateNow = new Date();
         MockDate.set(dateNow);
 
+        scanMetadataInput = {
+            id: 'scanMetadataId',
+            url: 'https://localhost/support%20page/',
+            deepScan: false,
+        } as ScanMetadata;
         scanMetadata = {
             id: 'scanMetadataId',
-            url: 'url',
+            url: 'https://localhost/support page/',
             deepScan: false,
         } as ScanMetadata;
         pageScanResultDbDocument = {} as OnDemandPageScanResult;
@@ -392,7 +398,7 @@ function setupUpdateScanRunStateToRunning(succeeded: boolean = true): void {
 function setupScanMetadataConfig(): void {
     scanMetadataConfigMock
         .setup((o) => o.getConfig())
-        .returns(() => scanMetadata)
+        .returns(() => scanMetadataInput)
         .verifiable();
     loggerMock.setup((o) => o.setCommonProperties({ scanId: scanMetadata.id, url: scanMetadata.url })).verifiable();
 }

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -42,6 +42,9 @@ export class Runner {
 
     public async run(): Promise<void> {
         const scanMetadata = this.scanMetadataConfig.getConfig();
+        // decode URL back from docker parameter encoding
+        scanMetadata.url = decodeURI(scanMetadata.url);
+
         this.logger.setCommonProperties({ scanId: scanMetadata.id, url: scanMetadata.url });
         this.logger.logInfo('Starting page scan task.');
 


### PR DESCRIPTION
#### Details

Encode docker parameters to prevent parsing by Batch API

##### Context

Batch API try parse docker parameters and fails if URL with parameters is not encoded

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
