### PR TITLE
Fallback to load partial page resources

### DIFF
--- a/packages/cli/src/report/report-disk-writer.ts
+++ b/packages/cli/src/report/report-disk-writer.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import filenamifyCombined from 'filenamify';
+import filenamify from 'filenamify';
 import filenamifyUrl from 'filenamify-url';
 import { injectable } from 'inversify';
 import normalizePath from 'normalize-path';
@@ -25,7 +25,7 @@ export class ReportDiskWriter {
         try {
             reportFileName = `${filenamifyUrl(fileName, { replacement: '_' })}.${format}`;
         } catch {
-            reportFileName = `${filenamifyCombined(fileName, { replacement: '_' })}.${format}`;
+            reportFileName = `${filenamify(fileName, { replacement: '_' })}.${format}`;
         }
 
         const normalizedDirectory = this.ensureDirectoryFunc(directory);

--- a/packages/cli/src/report/report-disk-writer.ts
+++ b/packages/cli/src/report/report-disk-writer.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import filenamify from 'filenamify';
+import filenamifyCombined from 'filenamify';
 import filenamifyUrl from 'filenamify-url';
 import { injectable } from 'inversify';
 import normalizePath from 'normalize-path';
@@ -25,7 +25,7 @@ export class ReportDiskWriter {
         try {
             reportFileName = `${filenamifyUrl(fileName, { replacement: '_' })}.${format}`;
         } catch {
-            reportFileName = `${filenamify(fileName, { replacement: '_' })}.${format}`;
+            reportFileName = `${filenamifyCombined(fileName, { replacement: '_' })}.${format}`;
         }
 
         const normalizedDirectory = this.ensureDirectoryFunc(directory);

--- a/packages/scanner-global-library/src/index.ts
+++ b/packages/scanner-global-library/src/index.ts
@@ -10,4 +10,4 @@ export { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';
 export { Page } from './page';
 export { AxeScanResults } from './axe-scan-results';
 export { WebDriver } from './web-driver';
-export { PageNavigator } from './page-navigator';
+export { PageNavigator, OnNavigationError } from './page-navigator';

--- a/packages/scanner-global-library/src/page-configurator.spec.ts
+++ b/packages/scanner-global-library/src/page-configurator.spec.ts
@@ -43,6 +43,10 @@ describe(PageConfigurator, () => {
             .setup(async (o) => o.setUserAgent(chromeUserAgent))
             .returns(() => Promise.resolve())
             .verifiable();
+        pageMock
+            .setup(async (o) => o.setCacheEnabled(false))
+            .returns(() => Promise.resolve())
+            .verifiable();
 
         pageConfigurator = new PageConfigurator();
     });

--- a/packages/scanner-global-library/src/page-configurator.ts
+++ b/packages/scanner-global-library/src/page-configurator.ts
@@ -18,6 +18,7 @@ export class PageConfigurator {
 
     public async configurePage(page: Page): Promise<void> {
         await page.setBypassCSP(true);
+        await page.setCacheEnabled(false); // disable cache to allow page reload
         await page.setViewport({
             width: this.windowWidth,
             height: this.windowHeight,

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -1,13 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Page, Response } from 'puppeteer';
+import { Page, Response, LoadEvent } from 'puppeteer';
 import { injectable, inject } from 'inversify';
-import _ from 'lodash';
+import { isNil } from 'lodash';
 import { PageConfigurator } from './page-configurator';
 import { PageResponseProcessor } from './page-response-processor';
 import { BrowserError } from './browser-error';
 import { PageHandler } from './page-handler';
+
+export type OnNavigationError = (browserError: BrowserError, error?: unknown) => Promise<void>;
 
 @injectable()
 export class PageNavigator {
@@ -15,7 +17,7 @@ export class PageNavigator {
     // Refer to service configuration TaskRuntimeConfig.taskTimeoutInMinutes property
     public readonly gotoTimeoutMsecs = 60000;
 
-    public readonly pageRenderingTimeoutMsecs = 10000;
+    public readonly pageRenderingTimeoutMsecs = 60000;
 
     constructor(
         @inject(PageConfigurator) public readonly pageConfigurator: PageConfigurator,
@@ -23,28 +25,28 @@ export class PageNavigator {
         @inject(PageHandler) protected readonly pageRenderingHandler: PageHandler,
     ) {}
 
-    public async navigate(
-        url: string,
-        page: Page,
-        onNavigationError: (browserError: BrowserError, error?: unknown) => Promise<void> = () => Promise.resolve(),
-    ): Promise<Response> {
+    public async navigate(url: string, page: Page, onNavigationError: OnNavigationError = () => Promise.resolve()): Promise<Response> {
         // Configure page settings before navigating to URL
         await this.pageConfigurator.configurePage(page);
 
-        let response: Response;
-        try {
-            response = await page.goto(url, {
-                waitUntil: 'networkidle0',
-                timeout: this.gotoTimeoutMsecs,
-            });
-        } catch (err) {
-            const navigationError = this.pageResponseProcessor.getNavigationError(err as Error);
-            onNavigationError(navigationError, err);
+        // Try load all page resources
+        let navigationResult = await this.navigateToUrl(url, page, 'networkidle0');
+        if (navigationResult.browserError?.errorType === 'UrlNavigationTimeout') {
+            // Fallback to load partial page resources on navigation timeout.
+            // This will help in cases when page has a streaming video controls.
+            //
+            // The 'load' event is fired when the whole page has loaded, including all dependent resources such as stylesheets and images.
+            // However any dynamic contents may not be available if it is loaded after window.onload() event.
+            navigationResult = await this.navigateToUrl(url, page, 'load');
+        }
+
+        if (!isNil(navigationResult.browserError)) {
+            onNavigationError(navigationResult.browserError, navigationResult.error);
 
             return undefined;
         }
 
-        if (_.isNil(response)) {
+        if (isNil(navigationResult.response)) {
             onNavigationError({
                 errorType: 'NavigationError',
                 message: 'Unable to get a page response from the browser.',
@@ -55,7 +57,7 @@ export class PageNavigator {
         }
 
         // Validate HTTP response
-        const responseError = this.pageResponseProcessor.getResponseError(response);
+        const responseError = this.pageResponseProcessor.getResponseError(navigationResult.response);
         if (responseError !== undefined) {
             onNavigationError(responseError);
 
@@ -64,6 +66,28 @@ export class PageNavigator {
 
         await this.pageRenderingHandler.waitForPageToCompleteRendering(page, this.pageRenderingTimeoutMsecs);
 
-        return response;
+        return navigationResult.response;
+    }
+
+    private async navigateToUrl(
+        url: string,
+        page: Page,
+        condition: LoadEvent,
+    ): Promise<{ response: Response; browserError?: BrowserError; error?: unknown }> {
+        let response: Response;
+        let browserError: BrowserError;
+        try {
+            const options = {
+                waitUntil: condition,
+                timeout: this.gotoTimeoutMsecs,
+            };
+            response = await page.goto(url, options);
+
+            return { response };
+        } catch (error) {
+            browserError = this.pageResponseProcessor.getNavigationError(error as Error);
+
+            return { response, browserError, error };
+        }
     }
 }

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -17,7 +17,7 @@ export class PageNavigator {
     // Refer to service configuration TaskRuntimeConfig.taskTimeoutInMinutes property
     public readonly gotoTimeoutMsecs = 60000;
 
-    public readonly pageRenderingTimeoutMsecs = 60000;
+    public readonly pageRenderingTimeoutMsecs = 10000;
 
     constructor(
         @inject(PageConfigurator) public readonly pageConfigurator: PageConfigurator,

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -37,6 +37,8 @@ export class PageNavigator {
             //
             // The 'load' event is fired when the whole page has loaded, including all dependent resources such as stylesheets and images.
             // However any dynamic contents may not be available if it is loaded after window.onload() event.
+            // Since we reuse page instance from the first navigation attempt some contents could be already loaded and available which
+            // mitigates dynamic content rendering issue above.
             navigationResult = await this.navigateToUrl(url, page, 'load');
         }
 


### PR DESCRIPTION
#### Details

Fallback to load partial page resources on page navigation timeout. This will allow to scan pages with streaming video controls when headless browser fails wait for network idle state.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
