### PR TITLE
feat(axe-core-4.3.2): exclude scrollable-region-focusable rule

### DIFF
--- a/packages/scanner-global-library/src/factories/rule-exclusion.ts
+++ b/packages/scanner-global-library/src/factories/rule-exclusion.ts
@@ -43,6 +43,7 @@ export class RuleExclusion {
         'presentation-role-conflict',
         'region',
         'scope-attr-valid',
+        'scrollable-region-focusable',
         'skip-link',
         'tabindex',
         'table-duplicate-name',


### PR DESCRIPTION
#### Details

This PR brings the service in line with web and the other products. Per Fer, we have moved the scrollable-region-focusable to "needs review" in web, and it will be removed in other products since we don't have a concept for "needs review". It is in relation to the following issue: https://github.com/microsoft/accessibility-insights-web/issues/3987

##### Motivation

feature work addressing https://github.com/microsoft/accessibility-insights-web/issues/3987


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: https://github.com/microsoft/accessibility-insights-web/issues/3987
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
