### PR TITLE
fix: Use relative path for cosmos db RBAC role template

### DIFF
--- a/packages/resource-deployment/scripts/enable-system-identity-for-batch-vmss.sh
+++ b/packages/resource-deployment/scripts/enable-system-identity-for-batch-vmss.sh
@@ -47,7 +47,7 @@ enableCosmosAccess() {
     if [[ -z "$RBACRoleId" ]]; then
         RBACRoleId=$(az cosmosdb sql role definition create --account-name $cosmosAccountName \
             --resource-group $resourceGroupName \
-            --body @../templates/cosmos-db-rw-role.json \
+            --body @${0%/*}/../templates/cosmos-db-rw-role.json \
             --query "[?roleName=='$customRoleName'].id" -o tsv)
     fi
     az cosmosdb sql role assignment create --account-name $cosmosAccountName \

--- a/packages/resource-deployment/scripts/function-app-create.sh
+++ b/packages/resource-deployment/scripts/function-app-create.sh
@@ -173,7 +173,7 @@ function enableCosmosAccess() {
     if [[ -z "$RBACRoleId" ]]; then
         RBACRoleId=$(az cosmosdb sql role definition create --account-name $cosmosAccountName \
             --resource-group $resourceGroupName \
-            --body @../templates/cosmos-db-rw-role.json \
+            --body @${0%/*}/../templates/cosmos-db-rw-role.json \
             --query "[?roleName=='$customRoleName'].id" -o tsv)
     fi
     az cosmosdb sql role assignment create --account-name $cosmosAccountName \


### PR DESCRIPTION
#### Details

Fix cosmos RBAC role json path to be relative to the script location, not the working directory from which the script is run.

##### Motivation

This will fix the current canary deployment failures.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
