### PR TITLE
Update combined dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "lerna": "^4.0.0",
         "license-check-and-add": "^4.0.2",
         "npm-run-all": "^4.1.5",
-        "prettier": "2.4.0",
+        "prettier": "2.4.1",
         "simple-git": "^2.45.1",
         "syncpack": "^5.8.15",
         "tslint": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "jest": "^27.2.0",
         "jest-extended": "^0.11.5",
         "jest-html-reporter": "^3.4.1",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "lerna": "^4.0.0",
         "license-check-and-add": "^4.0.2",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/eslint-plugin-tslint": "^4.31.1",
-        "@typescript-eslint/parser": "^4.31.1",
+        "@typescript-eslint/parser": "^4.31.2",
         "codecov": "^3.8.2",
         "combine-dependabot-prs": "^1.0.4",
         "commander": "^8.2.0",

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
     "devDependencies": {
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
         "jest-junit": "^12.2.0",

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -26,7 +26,7 @@
         "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -29,7 +29,7 @@
         "@types/yargs": "^17.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -37,7 +37,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -24,7 +24,7 @@
     "devDependencies": {
         "@types/got": "^9.6.11",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/verror": "^1.10.4",
         "@types/yargs": "^17.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
         "@types/cli-spinner": "^0.2.0",
         "@types/escape-html": "^1.0.1",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/normalize-path": "^3.0.0",
         "@types/table": "^6.3.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
         "dts-bundle-generator": "^5.9.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mkdirp": "^1.0.4",
         "mockdate": "^3.0.5",
         "rimraf": "^3.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0",
         "webpack-node-externals": "^3.0.0"
     },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,7 +27,7 @@
         "@types/node": "^12.20.25",
         "@types/sha.js": "^2.4.0",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -34,7 +34,7 @@
         "jest": "^27.2.0",
         "jest-junit": "^12.2.0",
         "rimraf": "^3.0.2",
-        "rollup": "^2.56.3",
+        "rollup": "^2.57.0",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3"

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -32,7 +32,7 @@
         "@types/levelup": "^4.3.1",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.57.0",
         "ts-jest": "^27.0.5",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -24,7 +24,7 @@
     "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
     "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",
-        "@rollup/plugin-node-resolve": "^13.0.0",
+        "@rollup/plugin-node-resolve": "^13.0.5",
         "@types/cheerio": "^0.22.29",
         "@types/encoding-down": "^5.0.0",
         "@types/jest": "^27.0.1",

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -27,7 +27,7 @@
         "@azure/functions": "^1.2.3",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/yargs": "^17.0.0",
         "copy-webpack-plugin": "^9.0.0",

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -33,7 +33,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -40,7 +40,7 @@
         "ts-jest": "^27.0.5",
         "ts-loader": "^9.2.3",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -26,7 +26,7 @@
         "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -23,7 +23,7 @@
         "@types/deep-equal-in-any-order": "^1.0.1",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
         "jest-junit": "^12.2.0",

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -19,7 +19,7 @@
     },
     "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
     "devDependencies": {
-        "@types/chai": "^4.2.14",
+        "@types/chai": "^4.2.22",
         "@types/deep-equal-in-any-order": "^1.0.1",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -24,7 +24,7 @@
         "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -19,7 +19,7 @@
     },
     "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
     "devDependencies": {
-        "@types/chai": "^4.2.14",
+        "@types/chai": "^4.2.22",
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.170",
         "@types/node": "^12.20.25",

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -21,7 +21,7 @@
     "devDependencies": {
         "@types/chai": "^4.2.22",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
         "jest-junit": "^12.2.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -27,7 +27,7 @@
         "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -24,7 +24,7 @@
     "devDependencies": {
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
         "jest-junit": "^12.2.0",

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
     "devDependencies": {
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/puppeteer": "^3.0.0",
         "jest": "^27.2.0",

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -27,7 +27,7 @@
         "@types/node": "^12.20.25",
         "@types/puppeteer": "^3.0.0",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -29,7 +29,7 @@
         "@types/yargs": "^17.0.0",
         "jest": "^27.2.0",
         "jest-extended": "^0.11.5",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",

--- a/packages/storage-documents/package.json
+++ b/packages/storage-documents/package.json
@@ -25,7 +25,7 @@
         "@types/jest": "^27.0.1",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "ttypescript": "^1.5.12",
         "ts-transformer-keys": "^0.4.3",

--- a/packages/web-api-client/package.json
+++ b/packages/web-api-client/package.json
@@ -24,7 +24,7 @@
         "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/web-api-client/package.json
+++ b/packages/web-api-client/package.json
@@ -21,7 +21,7 @@
     "devDependencies": {
         "@types/got": "^9.6.11",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "jest": "^27.2.0",
         "jest-junit": "^12.2.0",

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -38,7 +38,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -29,7 +29,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -23,7 +23,7 @@
     "devDependencies": {
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/verror": "^1.10.4",
         "copy-webpack-plugin": "^9.0.0",

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -25,7 +25,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -34,7 +34,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -26,7 +26,7 @@
         "@types/cheerio": "^0.22.29",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/puppeteer": "^3.0.0",
         "@types/sha.js": "^2.4.0",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -35,7 +35,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "node-loader": "^2.0.0",
         "npm-force-resolutions": "^0.0.10",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -45,7 +45,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -37,7 +37,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -23,7 +23,7 @@
     "devDependencies": {
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/verror": "^1.10.4",
         "copy-webpack-plugin": "^9.0.0",

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -29,7 +29,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -33,7 +33,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -42,7 +42,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -24,7 +24,7 @@
         "@types/dotenv": "^8.2.0",
         "@types/got": "^9.6.11",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/puppeteer": "^3.0.0",
         "@types/sha.js": "^2.4.0",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -27,7 +27,7 @@
         "@azure/functions": "^1.2.3",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/sha.js": "^2.4.0",
         "@types/verror": "^1.10.4",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -43,7 +43,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -35,7 +35,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -44,7 +44,7 @@
         "ts-loader": "^9.2.3",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.52.1",
+        "webpack": "^5.53.0",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -27,7 +27,7 @@
         "@azure/functions": "^1.2.3",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.170",
+        "@types/lodash": "^4.14.173",
         "@types/node": "^12.20.25",
         "@types/sha.js": "^2.4.0",
         "@types/verror": "^1.10.4",

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -35,7 +35,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.3",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2617,10 +2617,10 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-node-resolve@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz#352f07e430ff377809ec8ec8a6fd636547162dc4"
-  integrity sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==
+"@rollup/plugin-node-resolve@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz#016abe58796a4ff544d6beac7818921e3d3777fc"
+  integrity sha512-mVaw6uxtvuGx/XCI4qBQXsDZJUfyx5vp39iE0J/7Hd6wDhEbjHr6aES7Nr9yWbuE0BY+oKp6N7Bq6jX5NCGNmQ==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -4315,15 +4315,10 @@ builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-builtin-modules@^3.0.0:
+builtin-modules@^3.0.0, builtin-modules@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
-
-builtin-modules@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
-  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 builtins@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8081,10 +8081,10 @@ jest-jasmine2@^27.2.0:
     pretty-format "^27.2.0"
     throat "^6.0.1"
 
-jest-junit@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-12.2.0.tgz#cff7f9516e84f8e30f6bdea04cd84db6b095a376"
-  integrity sha512-ecGzF3KEQwLbMP5xMO7wqmgmyZlY/5yWDvgE/vFa+/uIT0KsU5nluf0D2fjIlOKB+tb6DiuSSpZuGpsmwbf7Fw==
+jest-junit@^12.3.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-12.3.0.tgz#ee41a74e439eecdc8965f163f83035cce5998d6d"
+  integrity sha512-+NmE5ogsEjFppEl90GChrk7xgz8xzvF0f+ZT5AnhW6suJC93gvQtmQjfyjDnE0Z2nXJqEkxF0WXlvjG/J+wn/g==
   dependencies:
     mkdirp "^1.0.4"
     strip-ansi "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12966,10 +12966,10 @@ webpack-sources@^3.2.0:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.0.tgz#b16973bcf844ebcdb3afde32eda1c04d0b90f89d"
   integrity sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==
 
-webpack@^5.52.1:
-  version "5.52.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.52.1.tgz#2dc1d9029ecb7acfb80da7bf67baab67baa517a7"
-  integrity sha512-wkGb0hLfrS7ML3n2xIKfUIwHbjB6gxwQHyLmVHoAqEQBw+nWo+G6LoHL098FEXqahqximsntjBLuewStrnJk0g==
+webpack@^5.53.0:
+  version "5.53.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.53.0.tgz#f463cd9c6fc1356ae4b9b7ac911fd1f5b2df86af"
+  integrity sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11264,10 +11264,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup@^2.56.3:
-  version "2.56.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.3.tgz#b63edadd9851b0d618a6d0e6af8201955a77aeff"
-  integrity sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==
+rollup@^2.57.0:
+  version "2.57.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.57.0.tgz#c1694475eb22e1022477c0f4635fd0ac80713173"
+  integrity sha512-bKQIh1rWKofRee6mv8SrF2HdP6pea5QkwBZSMImJysFj39gQuiV8MEPBjXOCpzk3wSYp63M2v2wkWBmFC8O/rg==
   optionalDependencies:
     fsevents "~2.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2751,10 +2751,10 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/chai@^4.2.14":
-  version "4.2.14"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
-  integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
+"@types/chai@^4.2.22":
+  version "4.2.22"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.22.tgz#47020d7e4cf19194d43b5202f35f75bd2ad35ce7"
+  integrity sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==
 
 "@types/cheerio@^0.22.18", "@types/cheerio@^0.22.29":
   version "0.22.29"
@@ -3011,9 +3011,9 @@
   integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
 
 "@types/node@>=10.0.0":
-  version "16.9.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.2.tgz#81f5a039d6ed1941f8cc57506c74e7c2b8fc64b9"
-  integrity sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==
+  version "16.9.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
+  integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
 
 "@types/node@^12", "@types/node@^12.12.7", "@types/node@^12.20.25":
   version "12.20.25"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,10 +2975,10 @@
     "@types/abstract-leveldown" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.119", "@types/lodash@^4.14.170":
-  version "4.14.170"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
-  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
+"@types/lodash@^4.14.119", "@types/lodash@^4.14.173":
+  version "4.14.173"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.173.tgz#9d3b674c67a26cf673756f6aca7b429f237f91ed"
+  integrity sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3229,14 +3229,14 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.31.1":
-  version "4.31.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.1.tgz#8f9a2672033e6f6d33b1c0260eebdc0ddf539064"
-  integrity sha512-dnVZDB6FhpIby6yVbHkwTKkn2ypjVIfAR9nh+kYsA/ZL0JlTsd22BiDjouotisY3Irmd3OW1qlk9EI5R8GrvRQ==
+"@typescript-eslint/parser@^4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.2.tgz#54aa75986e3302d91eff2bbbaa6ecfa8084e9c34"
+  integrity sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.31.1"
-    "@typescript-eslint/types" "4.31.1"
-    "@typescript-eslint/typescript-estree" "4.31.1"
+    "@typescript-eslint/scope-manager" "4.31.2"
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/typescript-estree" "4.31.2"
     debug "^4.3.1"
 
 "@typescript-eslint/scope-manager@4.31.0":
@@ -3255,6 +3255,14 @@
     "@typescript-eslint/types" "4.31.1"
     "@typescript-eslint/visitor-keys" "4.31.1"
 
+"@typescript-eslint/scope-manager@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.2.tgz#1d528cb3ed3bcd88019c20a57c18b897b073923a"
+  integrity sha512-2JGwudpFoR/3Czq6mPpE8zBPYdHWFGL6lUNIGolbKQeSNv4EAiHaR5GVDQaLA0FwgcdcMtRk+SBJbFGL7+La5w==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/visitor-keys" "4.31.2"
+
 "@typescript-eslint/types@4.31.0":
   version "4.31.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.0.tgz#9a7c86fcc1620189567dc4e46cad7efa07ee8dce"
@@ -3264,6 +3272,11 @@
   version "4.31.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.1.tgz#5f255b695627a13401d2fdba5f7138bc79450d66"
   integrity sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ==
+
+"@typescript-eslint/types@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.2.tgz#2aea7177d6d744521a168ed4668eddbd912dfadf"
+  integrity sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==
 
 "@typescript-eslint/typescript-estree@4.31.0":
   version "4.31.0"
@@ -3291,6 +3304,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.2.tgz#abfd50594d8056b37e7428df3b2d185ef2d0060c"
+  integrity sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/visitor-keys" "4.31.2"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@4.31.0":
   version "4.31.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.0.tgz#4e87b7761cb4e0e627dc2047021aa693fc76ea2b"
@@ -3305,6 +3331,14 @@
   integrity sha512-PCncP8hEqKw6SOJY+3St4LVtoZpPPn+Zlpm7KW5xnviMhdqcsBty4Lsg4J/VECpJjw1CkROaZhH4B8M1OfnXTQ==
   dependencies:
     "@typescript-eslint/types" "4.31.1"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.2.tgz#7d5b4a4705db7fe59ecffb273c1d082760f635cc"
+  integrity sha512-PrBId7EQq2Nibns7dd/ch6S6/M4/iwLM9McbgeEbCXfxdwRUNxJ4UNreJ6Gh3fI2GNKNrWnQxKL7oCPmngKBug==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
     eslint-visitor-keys "^2.0.0"
 
 "@uifabric/foundation@^7.5.14":

--- a/yarn.lock
+++ b/yarn.lock
@@ -10497,10 +10497,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.0.tgz#85bdfe0f70c3e777cf13a4ffff39713ca6f64cba"
-  integrity sha512-DsEPLY1dE5HF3BxCRBmD4uYZ+5DCbvatnolqTqcxEgKVZnL2kUfyu7b8pPQ5+hTBkdhU9SLUmK0/pHb07RE4WQ==
+prettier@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 pretty-format@^22.4.3:
   version "22.4.3"


### PR DESCRIPTION
This PR was created by the Combine PRs action by combining the following PRs:

* #1722 chore(deps-dev): bump prettier from 2.4.0 to 2.4.1
* #1721 chore(deps-dev): bump @types/chai from 4.2.14 to 4.2.22
* #1720 chore(deps-dev): bump rollup from 2.56.3 to 2.57.0
* #1719 chore(deps-dev): bump @types/lodash from 4.14.170 to 4.14.173
* #1718 chore(deps-dev): bump webpack from 5.52.1 to 5.53.0
* #1716 chore(deps-dev): bump jest-junit from 12.2.0 to 12.3.0
* #1715 chore(deps-dev): bump @rollup/plugin-node-resolve from 13.0.0 to 13.0.5
* #1714 chore(deps-dev): bump @typescript-eslint/parser from 4.31.1 to 4.31.2
