### PR TITLE
feat(baseline-implementation): Add singleWorker option to the scan engine

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -211,3 +211,10 @@ describe: List of URLs to crawl in addition to URLs discovered from crawling the
 type: array
 describe: List of RegEx patterns to crawl in addition to the provided URL, separated by space.
 ```
+
+-   singleWorker: --singleWorker
+
+```sh
+type: boolean
+describe: Uses a single crawler worker.
+```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -110,6 +110,12 @@ function getScanArguments(): ScanArguments {
                 default: false,
                 hidden: true,
             },
+            singleWorker: {
+                type: 'boolean',
+                describe: 'Uses a single crawler worker.',
+                default: false,
+                alias: 'singleworker'
+            },
         })
         .check((args) => {
             validateScanArguments(args as ScanArguments);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -114,7 +114,7 @@ function getScanArguments(): ScanArguments {
                 type: 'boolean',
                 describe: 'Uses a single crawler worker.',
                 default: false,
-                alias: 'singleworker'
+                alias: 'singleworker',
             },
         })
         .check((args) => {

--- a/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
@@ -44,6 +44,7 @@ describe(CrawlerParametersBuilder, () => {
             continue: true,
             chromePath: 'chrome path',
             axeSourcePath: 'axe path',
+            singleWorker: false,
         };
         fileSystemMock
             .setup((o) => o.existsSync(scanArguments.inputFile))
@@ -68,6 +69,7 @@ describe(CrawlerParametersBuilder, () => {
             discoveryPatterns: ['regex'],
             chromePath: 'chrome path',
             axeSourcePath: 'axe path',
+            singleWorker: false,
         };
         const actualCrawlOptions = crawlerParametersBuilder.build(scanArguments);
         expect(actualCrawlOptions).toEqual(expectedCrawlOptions);

--- a/packages/cli/src/crawler/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.ts
@@ -42,6 +42,7 @@ export class CrawlerParametersBuilder {
             chromePath: scanArguments.chromePath,
             axeSourcePath: scanArguments.axeSourcePath,
             debug: scanArguments.debug,
+            singleWorker: scanArguments.singleWorker,
         };
     }
 

--- a/packages/cli/src/scan-arguments.ts
+++ b/packages/cli/src/scan-arguments.ts
@@ -20,4 +20,5 @@ export interface ScanArguments {
     chromePath?: string;
     axeSourcePath?: string;
     debug?: boolean;
+    singleWorker?: boolean;
 }

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
@@ -114,6 +114,22 @@ describe(PuppeteerCrawlerEngine, () => {
         await crawlerEngine.start(crawlerRunOptions);
     });
 
+    it.each([true, false])('returns list of urls with singleWorker = %s', async (singleWorker) => {
+        crawlerRunOptions.singleWorker = singleWorker;
+
+        if (singleWorker) {
+            baseCrawlerOptions.minConcurrency = 1;
+            baseCrawlerOptions.maxConcurrency = 1;
+        }
+
+        crawlerFactoryMock
+            .setup((o) => o.createPuppeteerCrawler(baseCrawlerOptions))
+            .returns(() => puppeteerCrawlerMock.object)
+            .verifiable();
+
+        await crawlerEngine.start(crawlerRunOptions);
+    });
+
     afterEach(() => {
         crawlerFactoryMock.verifyAll();
         puppeteerCrawlerMock.verifyAll();

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
@@ -60,6 +60,11 @@ export class PuppeteerCrawlerEngine {
             this.crawlerConfiguration.setChromePath(crawlerRunOptions.chromePath);
         }
 
+        if (crawlerRunOptions.singleWorker === true) {
+            puppeteerCrawlerOptions.minConcurrency = 1;
+            puppeteerCrawlerOptions.maxConcurrency = 1;
+        }
+
         if (crawlerRunOptions.debug === true) {
             this.crawlerConfiguration.setSilentMode(false);
 

--- a/packages/crawler/src/crawler/simple-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/simple-crawler-engine.spec.ts
@@ -99,7 +99,7 @@ describe(SimpleCrawlerEngine, () => {
     it.each([true, false])('returns list of urls with singleWorker = %s', async (singleWorker) => {
         crawlerRunOptions.singleWorker = singleWorker;
         setupCrawlerConfig();
-       
+
         requestQueueProviderMock
             .setup((rqp) => rqp())
             .returns(() => Promise.resolve(requestQueueStub))

--- a/packages/crawler/src/crawler/simple-crawler-engine.ts
+++ b/packages/crawler/src/crawler/simple-crawler-engine.ts
@@ -37,6 +37,11 @@ export class SimpleCrawlerEngine implements CrawlerEngine<string[]> {
             maxRequestsPerCrawl: this.crawlerConfiguration.maxRequestsPerCrawl(),
         };
 
+        if (crawlerRunOptions.singleWorker === true) {
+            basicCrawlerOptions.minConcurrency = 1;
+            basicCrawlerOptions.maxConcurrency = 1;
+        }
+
         if (crawlerRunOptions.debug === true) {
             this.crawlerConfiguration.setSilentMode(false);
 

--- a/packages/crawler/src/main.ts
+++ b/packages/crawler/src/main.ts
@@ -26,6 +26,7 @@ interface ScanArguments {
     discoveryPatterns: string[];
     debug: boolean;
     crawl: boolean;
+    singleWorker: boolean;
 }
 
 (async () => {
@@ -47,6 +48,7 @@ interface ScanArguments {
         inputUrls: scanArguments.inputUrls,
         discoveryPatterns: scanArguments.discoveryPatterns,
         debug: scanArguments.debug,
+        singleWorker: scanArguments.singleWorker,
     });
 })().catch((error) => {
     console.log('Exception: ', System.serializeError(error));

--- a/packages/crawler/src/types/crawler-run-options.ts
+++ b/packages/crawler/src/types/crawler-run-options.ts
@@ -20,4 +20,5 @@ export interface CrawlerRunOptions {
     baseCrawlPage?: Page;
     chromePath?: string;
     axeSourcePath?: string;
+    singleWorker?: boolean;
 }


### PR DESCRIPTION
#### Details

Allow the user to choose to run the scan engine using only a single crawler worker.

##### Motivation

This option will be used to help making the scan engine result deterministic, basically if the number of URLs in the website is > the MaxURLs, we should set singleWorker to true so we would get the same result every run.

##### Context
In the baselining feature, we need to make sure that the scan result is deterministic, so in the GH action and the ADO extension, we will set singleWorker to true.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
