### PR TITLE
fix: Correct CLI error that blocks scanner from running as expected

### DIFF
--- a/packages/cli/src/baseline/baseline-options-builder.ts
+++ b/packages/cli/src/baseline/baseline-options-builder.ts
@@ -18,7 +18,7 @@ export class BaselineOptionsBuilder {
 
     public build(scanArguments: ScanArguments): BaselineOptions | null {
         if (scanArguments.baselineFile == null) {
-            if (scanArguments.updateBaseline != null) {
+            if (scanArguments.updateBaseline) {
                 throw new Error('updateBaseline is only supported when baselineFile is specified');
             }
 


### PR DESCRIPTION
#### Details

#1743 added a bad command line validation. Since scanArguments.updateBaseline is a bool with a default value of false, it will never be null. As a result, the check that throws an error is wrong... and always throws. Simple fix is to throw if it's non-false (as opposed to non-null)

##### Motivation

Unbreak CLI

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
