### PR TITLE
chore: add SBOM generator task to build pipeline

### DIFF
--- a/azure-pipeline/build-artifacts-and-run-tests-job.yaml
+++ b/azure-pipeline/build-artifacts-and-run-tests-job.yaml
@@ -47,7 +47,7 @@ steps:
       displayName: 'Copy files to staging directory'
 
     - task: ManifestGeneratorTask@0
-      displayName: 'Generation Task'
+      displayName: 'SBOM Generation Task'
       inputs:
           BuildDropPath: '$(Build.ArtifactStagingDirectory)'
 


### PR DESCRIPTION
#### Details

Adds manifest generator to build pipeline. [Successful test run here.](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=27433&view=logs&j=a8c5912e-f1d9-5bff-0b4e-675d6dc59aa0&t=60ebb4aa-e163-585d-3fc1-b29cbfba3ba1&l=10)

##### Motivation

To make sure our pipelines meet the [executive order requirements](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
