### PR TITLE
chore: Use ubuntu 20.04 in build pipeline

### DIFF
--- a/packages/resource-deployment/README.md
+++ b/packages/resource-deployment/README.md
@@ -18,7 +18,7 @@ You can use the following PowerShell commands to accept the Azure Marketplace le
 ```PowerShell
 Connect-AzAccount
 Set-AzContext -Subscription <The name or id of the subscription> -Tenant <Tenant name or ID>
-Get-AzMarketplaceTerms -Publisher 'microsoft-azure-batch' -Product 'ubuntu-server-container' -Name '18-04-lts' | Set-AzMarketplaceTerms -Accept
+Get-AzMarketplaceTerms -Publisher 'microsoft-azure-batch' -Product 'ubuntu-server-container' -Name '16-04-lts' | Set-AzMarketplaceTerms -Accept
 ```
 
 ### 2. Clone the repository

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -217,7 +217,7 @@
                             "sku": "16-04-lts",
                             "version": "latest"
                         },
-                        "nodeAgentSkuId": "batch.node.ubuntu 20.04",
+                        "nodeAgentSkuId": "batch.node.ubuntu 16.04",
                         "diskEncryptionConfiguration": {
                             "targets": ["TemporaryDisk"]
                         },


### PR DESCRIPTION
#### Details

Change build agent ~~and Azure batch VMs~~ to use ubuntu-20.04 instead of ubuntu-16.04 (VM update deferred to a later PR)

##### Motivation

Ubuntu 16 is no longer supported for our build pipeline ([failing build example](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=27691&view=results)) or Azure batch VMs ([failing deployment example](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_releaseProgress?_a=release-pipeline-progress&releaseId=9189))

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
