### PR TITLE
feat(pr-baseline-2): Fix bug that crept in with #1788

### DIFF
--- a/packages/axe-result-converter/src/__snapshots__/combined-report-data-converter.spec.ts.snap
+++ b/packages/axe-result-converter/src/__snapshots__/combined-report-data-converter.spec.ts.snap
@@ -10,6 +10,155 @@ Object {
         Object {
           "failed": Array [
             Object {
+              "elementSelector": "selector-node-31",
+              "fix": Object {
+                "all": Array [],
+                "any": Array [
+                  Object {
+                    "data": "check-data-node-31",
+                    "id": "check-id-node-31",
+                    "message": "check-message-node-31",
+                  },
+                ],
+                "failureSummary": "failureSummary-node-31",
+                "none": Array [],
+              },
+              "rule": Object {
+                "description": "description-rule-3",
+                "ruleId": "rule-3",
+                "ruleUrl": "helpUrl-rule-3",
+                "tags": Array [
+                  "tag-rule-3",
+                ],
+              },
+              "snippet": "snippet-node-31",
+              "urls": Array [
+                "url-31",
+                "url-32",
+                "url-33",
+              ],
+            },
+            Object {
+              "elementSelector": "selector-node-32",
+              "fix": Object {
+                "all": Array [],
+                "any": Array [
+                  Object {
+                    "data": "check-data-node-32",
+                    "id": "check-id-node-32",
+                    "message": "check-message-node-32",
+                  },
+                ],
+                "failureSummary": "failureSummary-node-32",
+                "none": Array [],
+              },
+              "rule": Object {
+                "description": "description-rule-3",
+                "ruleId": "rule-3",
+                "ruleUrl": "helpUrl-rule-3",
+                "tags": Array [
+                  "tag-rule-3",
+                ],
+              },
+              "snippet": "snippet-node-32",
+              "urls": Array [
+                "url-31",
+                "url-32",
+              ],
+            },
+            Object {
+              "elementSelector": "selector-node-33",
+              "fix": Object {
+                "all": Array [],
+                "any": Array [
+                  Object {
+                    "data": "check-data-node-33",
+                    "id": "check-id-node-33",
+                    "message": "check-message-node-33",
+                  },
+                ],
+                "failureSummary": "failureSummary-node-33",
+                "none": Array [],
+              },
+              "rule": Object {
+                "description": "description-rule-3",
+                "ruleId": "rule-3",
+                "ruleUrl": "helpUrl-rule-3",
+                "tags": Array [
+                  "tag-rule-3",
+                ],
+              },
+              "snippet": "snippet-node-33",
+              "urls": Array [
+                "url-31",
+              ],
+            },
+          ],
+          "key": "rule-3",
+        },
+        Object {
+          "failed": Array [
+            Object {
+              "elementSelector": "selector-node-12",
+              "fix": Object {
+                "all": Array [],
+                "any": Array [
+                  Object {
+                    "data": "check-data-node-12",
+                    "id": "check-id-node-12",
+                    "message": "check-message-node-12",
+                  },
+                ],
+                "failureSummary": "failureSummary-node-12",
+                "none": Array [],
+              },
+              "rule": Object {
+                "description": "description-rule-2",
+                "ruleId": "rule-2",
+                "ruleUrl": "helpUrl-rule-2",
+                "tags": Array [
+                  "tag-rule-2",
+                ],
+              },
+              "snippet": "snippet-node-12",
+              "urls": Array [
+                "url-21",
+                "url-22",
+              ],
+            },
+            Object {
+              "elementSelector": "selector-node-22",
+              "fix": Object {
+                "all": Array [],
+                "any": Array [
+                  Object {
+                    "data": "check-data-node-22",
+                    "id": "check-id-node-22",
+                    "message": "check-message-node-22",
+                  },
+                ],
+                "failureSummary": "failureSummary-node-22",
+                "none": Array [],
+              },
+              "rule": Object {
+                "description": "description-rule-2",
+                "ruleId": "rule-2",
+                "ruleUrl": "helpUrl-rule-2",
+                "tags": Array [
+                  "tag-rule-2",
+                ],
+              },
+              "snippet": "snippet-node-22",
+              "urls": Array [
+                "url-21",
+              ],
+            },
+          ],
+          "key": "rule-2",
+        },
+        Object {
+          "failed": Array [
+            Object {
               "elementSelector": "selector-node-41",
               "fix": Object {
                 "all": Array [],
@@ -71,145 +220,12 @@ Object {
                 ],
               },
               "snippet": "snippet-node-11",
-              "urls": Array [],
+              "urls": Array [
+                "url-11",
+              ],
             },
           ],
           "key": "rule-1",
-        },
-        Object {
-          "failed": Array [
-            Object {
-              "elementSelector": "selector-node-12",
-              "fix": Object {
-                "all": Array [],
-                "any": Array [
-                  Object {
-                    "data": "check-data-node-12",
-                    "id": "check-id-node-12",
-                    "message": "check-message-node-12",
-                  },
-                ],
-                "failureSummary": "failureSummary-node-12",
-                "none": Array [],
-              },
-              "rule": Object {
-                "description": "description-rule-2",
-                "ruleId": "rule-2",
-                "ruleUrl": "helpUrl-rule-2",
-                "tags": Array [
-                  "tag-rule-2",
-                ],
-              },
-              "snippet": "snippet-node-12",
-              "urls": Array [],
-            },
-            Object {
-              "elementSelector": "selector-node-22",
-              "fix": Object {
-                "all": Array [],
-                "any": Array [
-                  Object {
-                    "data": "check-data-node-22",
-                    "id": "check-id-node-22",
-                    "message": "check-message-node-22",
-                  },
-                ],
-                "failureSummary": "failureSummary-node-22",
-                "none": Array [],
-              },
-              "rule": Object {
-                "description": "description-rule-2",
-                "ruleId": "rule-2",
-                "ruleUrl": "helpUrl-rule-2",
-                "tags": Array [
-                  "tag-rule-2",
-                ],
-              },
-              "snippet": "snippet-node-22",
-              "urls": Array [],
-            },
-          ],
-          "key": "rule-2",
-        },
-        Object {
-          "failed": Array [
-            Object {
-              "elementSelector": "selector-node-31",
-              "fix": Object {
-                "all": Array [],
-                "any": Array [
-                  Object {
-                    "data": "check-data-node-31",
-                    "id": "check-id-node-31",
-                    "message": "check-message-node-31",
-                  },
-                ],
-                "failureSummary": "failureSummary-node-31",
-                "none": Array [],
-              },
-              "rule": Object {
-                "description": "description-rule-3",
-                "ruleId": "rule-3",
-                "ruleUrl": "helpUrl-rule-3",
-                "tags": Array [
-                  "tag-rule-3",
-                ],
-              },
-              "snippet": "snippet-node-31",
-              "urls": Array [],
-            },
-            Object {
-              "elementSelector": "selector-node-32",
-              "fix": Object {
-                "all": Array [],
-                "any": Array [
-                  Object {
-                    "data": "check-data-node-32",
-                    "id": "check-id-node-32",
-                    "message": "check-message-node-32",
-                  },
-                ],
-                "failureSummary": "failureSummary-node-32",
-                "none": Array [],
-              },
-              "rule": Object {
-                "description": "description-rule-3",
-                "ruleId": "rule-3",
-                "ruleUrl": "helpUrl-rule-3",
-                "tags": Array [
-                  "tag-rule-3",
-                ],
-              },
-              "snippet": "snippet-node-32",
-              "urls": Array [],
-            },
-            Object {
-              "elementSelector": "selector-node-33",
-              "fix": Object {
-                "all": Array [],
-                "any": Array [
-                  Object {
-                    "data": "check-data-node-33",
-                    "id": "check-id-node-33",
-                    "message": "check-message-node-33",
-                  },
-                ],
-                "failureSummary": "failureSummary-node-33",
-                "none": Array [],
-              },
-              "rule": Object {
-                "description": "description-rule-3",
-                "ruleId": "rule-3",
-                "ruleUrl": "helpUrl-rule-3",
-                "tags": Array [
-                  "tag-rule-3",
-                ],
-              },
-              "snippet": "snippet-node-33",
-              "urls": Array [],
-            },
-          ],
-          "key": "rule-3",
         },
       ],
       "notApplicable": Array [
@@ -277,17 +293,17 @@ Object {
         Object {
           "failed": Array [
             Object {
-              "elementSelector": "selector-node-4",
+              "elementSelector": "selector-node-1",
               "fix": Object {
                 "all": Array [],
                 "any": Array [
                   Object {
-                    "data": "check-data-node-4",
-                    "id": "check-id-node-4",
-                    "message": "check-message-node-4",
+                    "data": "check-data-node-1",
+                    "id": "check-id-node-1",
+                    "message": "check-message-node-1",
                   },
                 ],
-                "failureSummary": "failureSummary-node-4",
+                "failureSummary": "failureSummary-node-1",
                 "none": Array [],
               },
               "rule": Object {
@@ -298,33 +314,12 @@ Object {
                   "tag-rule-id",
                 ],
               },
-              "snippet": "snippet-node-4",
-              "urls": Array [],
-            },
-            Object {
-              "elementSelector": "selector-node-3",
-              "fix": Object {
-                "all": Array [],
-                "any": Array [
-                  Object {
-                    "data": "check-data-node-3",
-                    "id": "check-id-node-3",
-                    "message": "check-message-node-3",
-                  },
-                ],
-                "failureSummary": "failureSummary-node-3",
-                "none": Array [],
-              },
-              "rule": Object {
-                "description": "description-rule-id",
-                "ruleId": "rule-id",
-                "ruleUrl": "helpUrl-rule-id",
-                "tags": Array [
-                  "tag-rule-id",
-                ],
-              },
-              "snippet": "snippet-node-3",
-              "urls": Array [],
+              "snippet": "snippet-node-1",
+              "urls": Array [
+                "url-z",
+                "url-y",
+                "url-x",
+              ],
             },
             Object {
               "elementSelector": "selector-node-2",
@@ -349,20 +344,23 @@ Object {
                 ],
               },
               "snippet": "snippet-node-2",
-              "urls": Array [],
+              "urls": Array [
+                "url-b",
+                "url-d",
+              ],
             },
             Object {
-              "elementSelector": "selector-node-1",
+              "elementSelector": "selector-node-3",
               "fix": Object {
                 "all": Array [],
                 "any": Array [
                   Object {
-                    "data": "check-data-node-1",
-                    "id": "check-id-node-1",
-                    "message": "check-message-node-1",
+                    "data": "check-data-node-3",
+                    "id": "check-id-node-3",
+                    "message": "check-message-node-3",
                   },
                 ],
-                "failureSummary": "failureSummary-node-1",
+                "failureSummary": "failureSummary-node-3",
                 "none": Array [],
               },
               "rule": Object {
@@ -373,8 +371,38 @@ Object {
                   "tag-rule-id",
                 ],
               },
-              "snippet": "snippet-node-1",
-              "urls": Array [],
+              "snippet": "snippet-node-3",
+              "urls": Array [
+                "url-c",
+                "url-d",
+              ],
+            },
+            Object {
+              "elementSelector": "selector-node-4",
+              "fix": Object {
+                "all": Array [],
+                "any": Array [
+                  Object {
+                    "data": "check-data-node-4",
+                    "id": "check-id-node-4",
+                    "message": "check-message-node-4",
+                  },
+                ],
+                "failureSummary": "failureSummary-node-4",
+                "none": Array [],
+              },
+              "rule": Object {
+                "description": "description-rule-id",
+                "ruleId": "rule-id",
+                "ruleUrl": "helpUrl-rule-id",
+                "tags": Array [
+                  "tag-rule-id",
+                ],
+              },
+              "snippet": "snippet-node-4",
+              "urls": Array [
+                "url-a",
+              ],
             },
           ],
           "key": "rule-id",

--- a/packages/axe-result-converter/src/combined-report-data-converter.ts
+++ b/packages/axe-result-converter/src/combined-report-data-converter.ts
@@ -88,7 +88,7 @@ export class CombinedReportDataConverter {
         for (const result of results) {
             if (result) {
                 failureData.push({
-                    urls: result.urlInfos ?? result.urls,
+                    urls: result.urlInfos?.length ? result.urlInfos : result.urls,
                     elementSelector: this.getElementSelector(result.junctionNode),
                     snippet: result.junctionNode.html,
                     fix: this.getNodeResult(result.junctionNode),


### PR DESCRIPTION
#### Details

The change for #1788 created a regression that caused URLs not to show up in reports that didn't use baselining. I should have taken a cue from the large difference in the snapshots but it slipped past me. Comparing the snapshot before #1788 and after this change, it contains only the expected differences.

##### Motivation

Fix regression

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
