### PR TITLE
chore: update VMs to Ubuntu 20.04

### DIFF
--- a/packages/resource-deployment/scripts/add-tags-for-batch-vmss.sh
+++ b/packages/resource-deployment/scripts/add-tags-for-batch-vmss.sh
@@ -29,7 +29,6 @@ addTagToVmss() {
 
 addResourceGroupNameTagToVMSS() {
     addTagToVmss "ResourceGroupName" "$resourceGroupName"
-    addTagToVmss "azsecpack" "nonprod"
 
     local vmssCreatedTime=$(
         az vmss show \

--- a/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup.sh
@@ -58,7 +58,7 @@ installBootstrapPackages
 
 "${0%/*}/pull-image-from-container-registry.sh"
 
-# echo "Invoking custom pool startup script"
-# "${0%/*}/custom-pool-post-startup.sh"
+echo "Invoking custom pool startup script"
+"${0%/*}/custom-pool-post-startup.sh"
 
 echo "Successfully completed pool startup script execution"


### PR DESCRIPTION
#### Details

Update VMs to Ubuntu 20.04

##### Motivation

Ubuntu 16.04 is no longer supported and Ubuntu 20.04 is the next version that still supports container workloads

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
