### PR TITLE
fix: scan package has no index.d.ts file

### DIFF
--- a/packages/axe-result-converter/src/index.ts
+++ b/packages/axe-result-converter/src/index.ts
@@ -3,5 +3,6 @@
 
 export * from './axe-result-types';
 export * from './scan-result-data';
+export * from './fingerprint-generator';
 export { AxeResultsReducer } from './axe-results-reducer';
 export { CombinedReportDataConverter } from './combined-report-data-converter';

--- a/packages/cli/src/baseline/baseline-engine.spec.ts
+++ b/packages/cli/src/baseline/baseline-engine.spec.ts
@@ -4,8 +4,7 @@
 import 'reflect-metadata';
 
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { AxeCoreResults, AxeResult, AxeResultsList } from 'axe-result-converter';
-import { FingerprintGenerator, FingerprintParameters } from 'axe-result-converter/src/fingerprint-generator';
+import { AxeCoreResults, AxeResult, AxeResultsList, FingerprintGenerator, FingerprintParameters } from 'axe-result-converter';
 import { BaselineFileContent, BaselineOptions, UrlNormalizer } from './baseline-types';
 import { BaselineEngine } from './baseline-engine';
 import { BaselineGenerator } from './baseline-generator';

--- a/packages/cli/src/baseline/baseline-engine.ts
+++ b/packages/cli/src/baseline/baseline-engine.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AxeCoreResults, AxeResult } from 'axe-result-converter';
+import { AxeCoreResults, AxeResult, FingerprintGenerator } from 'axe-result-converter';
 import { inject, injectable } from 'inversify';
 import { UrlInfo } from 'accessibility-insights-report';
-import { FingerprintGenerator } from '../../../axe-result-converter/src/fingerprint-generator';
 import { BaselineEvaluation, BaselineOptions, BaselineResult, CountsByRule } from './baseline-types';
 import { BaselineGenerator } from './baseline-generator';
 


### PR DESCRIPTION
#### Details

In #1788, the `FingerprintGenerator` and `FingerprintParameter` types were added to the `axe-results-converter` package and used in both the `axe-results-converter` package and the `accessibility-insights-scan` package. Unfortunately, I failed to export them correct from he first package, so when we tried to generate `index.d.ts`, there were 2 copies of each class and no `index.d.ts` file was produced. The error didn't appear right away because of a previously existing error about the `filenamify` package. Once I stubbed out the `filenamify` references, I was able to get a meaningful error message that allowed me to fix the problem.

##### Motivation

Consumption of the scan package is broken without an `index.d.ts` file.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
