### PR TITLE
fix: reformat VMSS tags and move set tags before setup system identity

### DIFF
--- a/packages/resource-deployment/scripts/add-tags-for-batch-vmss.sh
+++ b/packages/resource-deployment/scripts/add-tags-for-batch-vmss.sh
@@ -38,8 +38,8 @@ addResourceGroupNameTagToVMSS() {
             -o tsv
     )
     if [[ -z $vmssCreatedTime ]]; then
-        local currentTime=$(date "+%Y-%m-%d")
-        addTagToVmss "VmssCreatedDate" "$currentTime"
+        local currentDate=$(date "+%Y.%m.%d")
+        addTagToVmss "VmssCreatedDate" "$currentDate"
     fi
 }
 

--- a/packages/resource-deployment/scripts/delete-pools-if-needed.sh
+++ b/packages/resource-deployment/scripts/delete-pools-if-needed.sh
@@ -37,11 +37,11 @@ function checkIfVmssAreOld() {
         hasCreatedDateTags=true
 
         if [[ $kernelName == "Darwin" ]]; then
-            local recycleDate=$(date -j -v +"$recycleVmssIntervalDays"d -f "%Y-%m-%d" "$createdDate" "+%Y-%m-%d")
-            local currentDate=$(date "+%Y-%m-%d")
+            local recycleDate=$(date -j -v +"$recycleVmssIntervalDays"d -f "%Y.%m.%d" "$createdDate" "+%Y.%m.%d")
+            local currentDate=$(date "+%Y.%m.%d")
         else
-            local recycleDate=$(date -d "$createdDate+$recycleVmssIntervalDays days" "+%Y-%m-%d")
-            local currentDate=$(date "+%Y-%m-%d")
+            local recycleDate=$(date -d "$createdDate+$recycleVmssIntervalDays days" "+%Y.%m.%d")
+            local currentDate=$(date "+%Y.%m.%d")
         fi
 
         if [[ "$currentDate" > "$recycleDate" ]] || [[ "$currentDate" == "$recycleDate" ]]; then

--- a/packages/resource-deployment/scripts/setup-all-pools-for-batch.sh
+++ b/packages/resource-deployment/scripts/setup-all-pools-for-batch.sh
@@ -20,13 +20,6 @@ function setupPools() {
     # Enable managed identity on Batch pools
     pools=$(az batch pool list --query "[].id" -o tsv)
 
-    echo "Setup system identity for created pools"
-    for pool in $pools; do
-        command=". ${0%/*}/enable-system-identity-for-batch-vmss.sh"
-        commandName="Enable system identity for pool $pool"
-        . "${0%/*}/run-command-on-all-vmss-for-pool.sh"
-    done
-
     echo "Setup tags for Batch VMSS"
     parallelProcesses=()
     for pool in $pools; do
@@ -36,6 +29,14 @@ function setupPools() {
         parallelProcesses+=("$!")
     done
     waitForProcesses parallelProcesses
+
+    echo "Setup system identity for created pools"
+    for pool in $pools; do
+        command=". ${0%/*}/enable-system-identity-for-batch-vmss.sh"
+        commandName="Enable system identity for pool $pool"
+        . "${0%/*}/run-command-on-all-vmss-for-pool.sh"
+    done
+
 }
 
 # Read script arguments


### PR DESCRIPTION
#### Details

Change VmssCreatedDate tag to yyyy.mm.dd format and set VMSS tags before creating system identity

##### Motivation

A bug in the azure CLI tool causes date tags formatted as yyyy-mm-dd to be interpreted as a mathematical expression (for example, if you try to set a tag to "2021-10-25," it will be interpreted as a subtraction and the tag will be set to "1986"). When the VmssCreatedTag is not found or unable to be parsed as a date, our deployment scripts delete and recreate the pools. Since the tag is not set the way we intend, we currently rotate VMSS on every deployment, regardless of whether the rotation period has passed yet or not.

Moving the tags before the system identity operations will ensure that the VmssCreatedDate tag is set before any change is made to the system identity. Then, if creating or granting permissions to the system identity fails (which occasionally happens due to lag propagating the identity), we can redeploy without rotating the VMSS and deleting the existing system identity.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
