### PR TITLE
fix: reformat vmssCreatedDate with slashes

### DIFF
--- a/packages/resource-deployment/scripts/add-tags-for-batch-vmss.sh
+++ b/packages/resource-deployment/scripts/add-tags-for-batch-vmss.sh
@@ -38,7 +38,7 @@ addResourceGroupNameTagToVMSS() {
             -o tsv
     )
     if [[ -z $vmssCreatedTime ]]; then
-        local currentDate=$(date "+%Y.%m.%d")
+        local currentDate=$(date "+%Y/%m/%d")
         addTagToVmss "VmssCreatedDate" "$currentDate"
     fi
 }

--- a/packages/resource-deployment/scripts/delete-pools-if-needed.sh
+++ b/packages/resource-deployment/scripts/delete-pools-if-needed.sh
@@ -37,11 +37,11 @@ function checkIfVmssAreOld() {
         hasCreatedDateTags=true
 
         if [[ $kernelName == "Darwin" ]]; then
-            local recycleDate=$(date -j -v +"$recycleVmssIntervalDays"d -f "%Y.%m.%d" "$createdDate" "+%Y.%m.%d")
-            local currentDate=$(date "+%Y.%m.%d")
+            local recycleDate=$(date -j -v +"$recycleVmssIntervalDays"d -f "%Y/%m/%d" "$createdDate" "+%Y/%m/%d")
+            local currentDate=$(date "+%Y/%m/%d")
         else
-            local recycleDate=$(date -d "$createdDate+$recycleVmssIntervalDays days" "+%Y.%m.%d")
-            local currentDate=$(date "+%Y.%m.%d")
+            local recycleDate=$(date -d "$createdDate+$recycleVmssIntervalDays days" "+%Y/%m/%d")
+            local currentDate=$(date "+%Y/%m/%d")
         fi
 
         if [[ "$currentDate" > "$recycleDate" ]] || [[ "$currentDate" == "$recycleDate" ]]; then


### PR DESCRIPTION
#### Details

Use slashes instead of periods to format the date for VmssCreatedDate tags

##### Motivation

The date tool is unable to parse dates formatted like "2021.10.26+5 days" to calculate when the VMSS should be rotated. Using slashes fixes the issue and does not trigger the previous tag issue mentioned in #1797.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
