### PR TITLE
feat(pr-baseline-2): Update if fileFormatVersion changes

### DIFF
--- a/packages/cli/src/baseline/__snapshots__/baseline-engine.spec.ts.snap
+++ b/packages/cli/src/baseline/__snapshots__/baseline-engine.spec.ts.snap
@@ -420,3 +420,24 @@ Object {
   },
 }
 `;
+
+exports[`BaselineEngine updateResultsInPlace reports a different output if the file format version changes 1`] = `
+Object {
+  "axeResults": Object {
+    "violations": Object {},
+  },
+  "evaluation": Object {
+    "fixedViolationsByRule": Object {},
+    "newViolationsByRule": Object {},
+    "suggestedBaselineUpdate": Object {
+      "metadata": Object {
+        "fileFormatVersion": "1.1",
+      },
+      "results": Array [],
+    },
+    "totalBaselineViolations": 0,
+    "totalFixedViolations": 0,
+    "totalNewViolations": 0,
+  },
+}
+`;

--- a/packages/cli/src/baseline/baseline-engine.spec.ts
+++ b/packages/cli/src/baseline/baseline-engine.spec.ts
@@ -156,6 +156,20 @@ describe(BaselineEngine, () => {
             expect(() => testSubject.updateResultsInPlace(inputResults, inputOptions)).toThrowError(generatorError);
         });
 
+        it('reports a different output if the file format version changes', () => {
+            const baselineContentWithDifferentFileFormatVersion: BaselineFileContent = {
+                metadata: { fileFormatVersion: '1.1' },
+                results: [],
+            } as unknown as BaselineFileContent;
+            setupCurrentScanContents(baselineContentWithDifferentFileFormatVersion);
+            setupBaselineScanContents(baselineContentWithNoViolations);
+
+            const evaluation = testSubject.updateResultsInPlace(inputResults, inputOptions);
+
+            expect(evaluation.suggestedBaselineUpdate).toBe(baselineContentWithDifferentFileFormatVersion);
+            expect({ evaluation: evaluation, axeResults: inputResults }).toMatchSnapshot();
+        });
+
         it('Scan with no violations when no baseline content exists', () => {
             setupCurrentScanContents(baselineContentWithNoViolations);
             setupBaselineScanContents(null);

--- a/packages/cli/src/baseline/baseline-engine.ts
+++ b/packages/cli/src/baseline/baseline-engine.ts
@@ -80,7 +80,11 @@ export class BaselineEngine {
             }
         }
 
-        if (evaluation.totalFixedViolations || evaluation.totalNewViolations) {
+        if (
+            evaluation.totalFixedViolations ||
+            evaluation.totalNewViolations ||
+            baselineOptions.baselineContent?.metadata?.fileFormatVersion !== newBaseline.metadata.fileFormatVersion
+        ) {
             evaluation.suggestedBaselineUpdate = newBaseline;
         }
 


### PR DESCRIPTION
#### Details

The current code to detect baseline changes ignores the metadata.fileFormatVersion field. This field always gets written to a constant value, so this change would only take effect if the user manually edited the field. Definitely not a blocker for the MVP, but I want to capture the behavior while it's in my mind.

##### Motivation

Make code behave as intended

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
