### PR TITLE
Update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
         "socket.io-parser": ">=3.4.1",
         "set-value": ">=4.0.1",
         "nth-check": ">=2.0.1",
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^5.0.1",
+        "validator": ">=13.7.0"
     },
     "dependencies": {
         "accessibility-insights-report": "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12796,10 +12796,10 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validator@~10.8.0:
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-10.8.0.tgz#8acb15a5c39411cbc8ef2be0c98c2514da4410a7"
-  integrity sha512-mXqMxfCh5NLsVgYVKl9WvnHNDPCcbNppHSPPowu0VjtSsGWVY+z8hJF44edLR1nbLNzi3jYoYsIl8KZpioIk6g==
+validator@>=13.7.0, validator@~10.8.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
#### Details

Upgrade validator to version 13.7.0

CVE-2021-3765
Vulnerable versions: < 13.7.0
Patched version: 13.7.0
validator.js prior to 13.7.0 is vulnerable to Inefficient Regular Expression Complexity

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
