### PR TITLE
Privacy job manager

### DIFF
--- a/.vscode/workspace.code-workspace
+++ b/.vscode/workspace.code-workspace
@@ -9,6 +9,10 @@
             "path": "../packages/privacy-scan-runner"
         },
         {
+            "name": "privacy-scan-job-manager",
+            "path": "../packages/privacy-scan-job-manager"
+        },
+        {
             "name": "scanner-global-library",
             "path": "../packages/scanner-global-library"
         },

--- a/azure-pipeline/build-artifacts-and-run-tests-job.yaml
+++ b/azure-pipeline/build-artifacts-and-run-tests-job.yaml
@@ -33,6 +33,8 @@ steps:
               web-api-scan-runner/dist/**/*
               web-api-send-notification-runner/dist/**/*
               web-api-scan-request-sender/dist/**/*
+              privacy-scan-runner/dist/**/*
+              privacy-scan-job-manager/dist/**/*
               resource-deployment/dist/**/*
               web-api/dist/**/*
               web-workers/dist/**/*

--- a/packages/common/src/build-utilities/monorepo-packages.spec.ts
+++ b/packages/common/src/build-utilities/monorepo-packages.spec.ts
@@ -18,6 +18,7 @@ describe('listMonorepoPackageNames', () => {
               "health-client",
               "logger",
               "parallel-workers",
+              "privacy-scan-job-manager",
               "privacy-scan-runner",
               "resource-deployment",
               "scanner-global-library",

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -91,17 +91,17 @@ Object {
     },
     "privacyScanRunnerTaskImageName": Object {
       "default": "batch-privacy-scan-runner",
-      "doc": "The Docker image name used for task creation.",
+      "doc": "The container image name used for task creation.",
       "format": "String",
     },
     "scanRunnerTaskImageName": Object {
       "default": "batch-scan-runner",
-      "doc": "The Docker image name used for task creation.",
+      "doc": "The container image name used for task creation.",
       "format": "String",
     },
     "sendNotificationTaskImageName": Object {
       "default": "batch-scan-notification-runner",
-      "doc": "The Docker image name used for task creation.",
+      "doc": "The container image name used for task creation.",
       "format": "String",
     },
     "sendNotificationTasksCount": Object {
@@ -284,17 +284,17 @@ Object {
     },
     "privacyScanRunnerTaskImageName": Object {
       "default": "batch-privacy-scan-runner",
-      "doc": "The Docker image name used for task creation.",
+      "doc": "The container image name used for task creation.",
       "format": "String",
     },
     "scanRunnerTaskImageName": Object {
       "default": "batch-scan-runner",
-      "doc": "The Docker image name used for task creation.",
+      "doc": "The container image name used for task creation.",
       "format": "String",
     },
     "sendNotificationTaskImageName": Object {
       "default": "batch-scan-notification-runner",
-      "doc": "The Docker image name used for task creation.",
+      "doc": "The container image name used for task creation.",
       "format": "String",
     },
     "sendNotificationTasksCount": Object {

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -89,6 +89,11 @@ Object {
       "doc": "The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
+    "privacyScanRunnerTaskImageName": Object {
+      "default": "batch-privacy-scan-runner",
+      "doc": "The Docker image name used for task creation.",
+      "format": "String",
+    },
     "scanRunnerTaskImageName": Object {
       "default": "batch-scan-runner",
       "doc": "The Docker image name used for task creation.",
@@ -276,6 +281,11 @@ Object {
       "default": 30,
       "doc": "The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
+    },
+    "privacyScanRunnerTaskImageName": Object {
+      "default": "batch-privacy-scan-runner",
+      "doc": "The Docker image name used for task creation.",
+      "format": "String",
     },
     "scanRunnerTaskImageName": Object {
       "default": "batch-scan-runner",

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -28,6 +28,7 @@ export interface JobManagerConfig {
     sendNotificationTasksCount: number;
     scanRunnerTaskImageName: string;
     sendNotificationTaskImageName: string;
+    privacyScanRunnerTaskImageName: string;
 }
 
 export interface ScanRunTimeConfig {
@@ -198,12 +199,17 @@ export class ServiceConfiguration {
                 scanRunnerTaskImageName: {
                     format: 'String',
                     default: 'batch-scan-runner',
-                    doc: 'The Docker image name used for task creation.',
+                    doc: 'The container image name used for task creation.',
                 },
                 sendNotificationTaskImageName: {
                     format: 'String',
                     default: 'batch-scan-notification-runner',
-                    doc: 'The Docker image name used for task creation.',
+                    doc: 'The container image name used for task creation.',
+                },
+                privacyScanRunnerTaskImageName: {
+                    format: 'String',
+                    default: 'batch-privacy-scan-runner',
+                    doc: 'The container image name used for task creation.',
                 },
             },
             scanConfig: {

--- a/packages/privacy-scan-job-manager/.vscode/launch.json
+++ b/packages/privacy-scan-job-manager/.vscode/launch.json
@@ -8,9 +8,7 @@
             "name": "Start debugging privacy-scan-job-manager",
             "type": "node",
             "request": "launch",
-            "outFiles": [
-                "${workspaceFolder}/dist/**/*.js"
-            ],
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/src/index.ts",
             "preLaunchTask": "run",

--- a/packages/privacy-scan-job-manager/.vscode/launch.json
+++ b/packages/privacy-scan-job-manager/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Start debugging privacy-scan-job-manager",
+            "type": "node",
+            "request": "launch",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/src/index.ts",
+            "preLaunchTask": "run",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "smartStep": true
+        }
+    ]
+}

--- a/packages/privacy-scan-job-manager/.vscode/tasks.json
+++ b/packages/privacy-scan-job-manager/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "run",
+            "dependsOn": "tsc",
+            "windows": {
+                "command": "xcopy .env ./dist /y"
+            },
+            "osx": {
+                "command": "cp .env ./dist"
+            }
+        },
+        {
+            "type": "shell",
+            "label": "tsc",
+            "dependsOn": "clean",
+            "command": "tsc",
+            "problemMatcher": ["$tsc"]
+        },
+        {
+            "type": "shell",
+            "label": "clean",
+            "command": "npx rimraf dist"
+        }
+    ]
+}

--- a/packages/privacy-scan-job-manager/README.md
+++ b/packages/privacy-scan-job-manager/README.md
@@ -1,0 +1,20 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# Accessibility Insights Service - Privacy Scan Job Manager
+
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/packages/privacy-scan-job-manager/docker-image-config/.dockerignore
+++ b/packages/privacy-scan-job-manager/docker-image-config/.dockerignore
@@ -1,0 +1,3 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+*.map

--- a/packages/privacy-scan-job-manager/docker-image-config/Dockerfile
+++ b/packages/privacy-scan-job-manager/docker-image-config/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+FROM mcr.microsoft.com/windows/servercore:1809-amd64
+
+ENV NODE_VERSION 12.21.0
+
+USER ContainerAdministrator
+
+# Install Node.js
+RUN powershell Set-ExecutionPolicy RemoteSigned
+RUN powershell -Command \
+    Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+RUN setx /m PATH "%PATH%;C:\nodejs"
+
+# Bundle app package
+COPY . .
+
+# Install app dependencies
+RUN npm install
+
+ENTRYPOINT ["powershell.exe", "./privacy-scan-job-manager.ps1"]

--- a/packages/privacy-scan-job-manager/docker-image-config/privacy-scan-job-manager.ps1
+++ b/packages/privacy-scan-job-manager/docker-image-config/privacy-scan-job-manager.ps1
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+Write-Host "adding route for Managed Service Identity"
+$gateway = (route print | ?{$_ -like "*0.0.0.0*0.0.0.0*"} | %{$_ -split " "} | ?{$_.trim() -ne "" } | ?{$_ -ne "0.0.0.0" })[0]
+$arguments = 'add','169.254.169.0','mask','255.255.255.0',$gateway
+&'route' $arguments
+
+node ./privacy-scan-job-manager.js

--- a/packages/privacy-scan-job-manager/jest.config.js
+++ b/packages/privacy-scan-job-manager/jest.config.js
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../jest.config.base');
+const package = require('./package');
+
+module.exports = {
+    ...baseConfig,
+    displayName: package.name,
+};

--- a/packages/privacy-scan-job-manager/package.json
+++ b/packages/privacy-scan-job-manager/package.json
@@ -1,0 +1,62 @@
+{
+    "name": "privacy-scan-job-manager",
+    "version": "1.0.0",
+    "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
+    "scripts": {
+        "build": "webpack --config ./webpack.config.js && node ../../create-docker-image-package-json.js",
+        "cbuild": "npm-run-all --serial clean build",
+        "clean": "rimraf dist test-results",
+        "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
+        "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
+        "test": "jest --coverage --colors"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Microsoft/accessibility-insights-service.git"
+    },
+    "author": "Microsoft",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Microsoft/accessibility-insights-service/issues"
+    },
+    "homepage": "https://github.com/Microsoft/accessibility-insights-service#readme",
+    "devDependencies": {
+        "@types/dotenv": "^8.2.0",
+        "@types/jest": "^27.4.0",
+        "@types/lodash": "^4.14.178",
+        "@types/node": "^12.20.41",
+        "@types/verror": "^1.10.4",
+        "copy-webpack-plugin": "^10.2.0",
+        "fork-ts-checker-webpack-plugin": "^6.5.0",
+        "jest": "^27.4.7",
+        "jest-junit": "^12.3.0",
+        "mockdate": "^3.0.5",
+        "node-loader": "^2.0.0",
+        "npm-run-all": "^4.1.5",
+        "rimraf": "^3.0.2",
+        "ts-jest": "^27.1.2",
+        "ts-loader": "^9.2.6",
+        "typemoq": "^2.1.0",
+        "typescript": "^4.5.4",
+        "webpack": "^5.66.0",
+        "webpack-cli": "^4.9.1",
+        "webpack-ignore-dynamic-require": "^1.0.0"
+    },
+    "dependencies": {
+        "@azure/batch": "^10.0.2",
+        "@azure/ms-rest-nodeauth": "^3.1.1",
+        "applicationinsights": "^2.2.0",
+        "azure-services": "^1.0.0",
+        "common": "^1.0.0",
+        "dotenv": "^10.0.0",
+        "inversify": "^6.0.1",
+        "lodash": "^4.17.21",
+        "logger": "1.0.0",
+        "moment": "^2.29.1",
+        "reflect-metadata": "^0.1.13",
+        "service-library": "1.0.0",
+        "verror": "^1.10.1",
+        "storage-documents": "1.0.0",
+        "yargs": "^17.3.1"
+    }
+}

--- a/packages/privacy-scan-job-manager/prettier.config.js
+++ b/packages/privacy-scan-job-manager/prettier.config.js
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../prettier.config');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/packages/privacy-scan-job-manager/run-in-docker-container.sh
+++ b/packages/privacy-scan-job-manager/run-in-docker-container.sh
@@ -10,5 +10,5 @@ cp ../resource-deployment/runtime-config/runtime-config.dev.json ./dist/runtime-
 cp ./.env ./dist/
 yarn build &&
     cd ./dist &&
-    docker build --tag scan-request-sender . &&
-    docker run scan-request-sender
+    docker build --tag privacy-scan-job-manager . &&
+    docker run privacy-scan-job-manager

--- a/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.spec.ts
+++ b/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.spec.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { JobManagerConfig, ServiceConfiguration } from 'common';
+import { IMock, Mock } from 'typemoq';
+import { ScannerBatchTaskPropertyProvider } from './scanner-batch-task-property-provider';
+
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+
+describe(ScannerBatchTaskPropertyProvider, () => {
+    let testSubject: ScannerBatchTaskPropertyProvider;
+    let serviceConfigMock: IMock<ServiceConfiguration>;
+
+    beforeEach(() => {
+        serviceConfigMock = Mock.ofType(ServiceConfiguration);
+        testSubject = new ScannerBatchTaskPropertyProvider(serviceConfigMock.object);
+    });
+
+    afterEach(() => {
+        serviceConfigMock.verifyAll();
+    });
+
+    it('get image name', async () => {
+        serviceConfigMock
+            .setup(async (o) => o.getConfigValue('jobManagerConfig'))
+            .returns(() => Promise.resolve({ scanRunnerTaskImageName: 'scanRunnerTaskImageName' } as JobManagerConfig))
+            .verifiable();
+
+        const actualImageName = await testSubject.getImageName();
+        expect(actualImageName).toEqual('scanRunnerTaskImageName');
+    });
+
+    it('get additional container run options', () => {
+        const actualRunOptions = testSubject.getAdditionalContainerRunOptions();
+        expect(actualRunOptions).toEqual('');
+    });
+
+    it('get get user elevation level', () => {
+        const actualElevationLevel = testSubject.getUserElevationLevel();
+        expect(actualElevationLevel).toEqual('admin');
+    });
+});

--- a/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.spec.ts
+++ b/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.spec.ts
@@ -25,11 +25,11 @@ describe(ScannerBatchTaskPropertyProvider, () => {
     it('get image name', async () => {
         serviceConfigMock
             .setup(async (o) => o.getConfigValue('jobManagerConfig'))
-            .returns(() => Promise.resolve({ scanRunnerTaskImageName: 'scanRunnerTaskImageName' } as JobManagerConfig))
+            .returns(() => Promise.resolve({ privacyScanRunnerTaskImageName: 'privacyScanRunnerTaskImageName' } as JobManagerConfig))
             .verifiable();
 
         const actualImageName = await testSubject.getImageName();
-        expect(actualImageName).toEqual('scanRunnerTaskImageName');
+        expect(actualImageName).toEqual('privacyScanRunnerTaskImageName');
     });
 
     it('get additional container run options', () => {

--- a/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
+++ b/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BatchTaskPropertyProvider, UserAccessLevels } from 'azure-services';
+import { ServiceConfiguration } from 'common';
+import { inject, injectable } from 'inversify';
+
+@injectable()
+export class ScannerBatchTaskPropertyProvider extends BatchTaskPropertyProvider {
+    constructor(@inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration) {
+        super();
+    }
+
+    public async getImageName(): Promise<string> {
+        return (await this.serviceConfig.getConfigValue('jobManagerConfig')).privacyScanRunnerTaskImageName;
+    }
+
+    public getAdditionalContainerRunOptions?(): string {
+        return '';
+    }
+
+    public getUserElevationLevel(): UserAccessLevels {
+        return 'admin';
+    }
+}

--- a/packages/privacy-scan-job-manager/src/index.ts
+++ b/packages/privacy-scan-job-manager/src/index.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { System } from 'common';
+import { PrivacyScanJobManagerEntryPoint } from './privacy-scan-job-manager-entry-point';
+import { setupPrivacyScanJobManagerContainer } from './setup-privacy-scan-job-manager-container';
+
+(async () => {
+    const webApiJobManagerEntryPoint = new PrivacyScanJobManagerEntryPoint(setupPrivacyScanJobManagerContainer());
+    await webApiJobManagerEntryPoint.start();
+})().catch((error) => {
+    console.log(System.serializeError(error));
+    process.exitCode = 1;
+});

--- a/packages/privacy-scan-job-manager/src/privacy-scan-job-manager-entry-point.spec.ts
+++ b/packages/privacy-scan-job-manager/src/privacy-scan-job-manager-entry-point.spec.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { BaseTelemetryProperties, ContextAwareLogger, Logger } from 'logger';
+import { IMock, Mock, Times } from 'typemoq';
+import { PrivacyScanJobManagerEntryPoint } from './privacy-scan-job-manager-entry-point';
+import { Worker } from './worker/worker';
+
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+
+class PrivacyScanJobManagerEntryPointWrapper extends PrivacyScanJobManagerEntryPoint {
+    public invokeGetTelemetryBaseProperties(): BaseTelemetryProperties {
+        return this.getTelemetryBaseProperties();
+    }
+
+    public async runCustomAction(container: Container): Promise<void> {
+        return super.runCustomAction(container);
+    }
+}
+
+describe(PrivacyScanJobManagerEntryPoint, () => {
+    let testSubject: PrivacyScanJobManagerEntryPointWrapper;
+    let containerMock: IMock<Container>;
+    let workerMock: IMock<Worker>;
+    let loggerMock: IMock<Logger>;
+
+    beforeEach(() => {
+        containerMock = Mock.ofType(Container);
+        workerMock = Mock.ofType(Worker);
+        loggerMock = Mock.ofType(ContextAwareLogger);
+
+        testSubject = new PrivacyScanJobManagerEntryPointWrapper(containerMock.object);
+    });
+
+    describe('getTelemetryBaseProperties', () => {
+        it('returns data with source property', () => {
+            expect(testSubject.invokeGetTelemetryBaseProperties()).toEqual({
+                source: 'privacyScanJobManager',
+            } as BaseTelemetryProperties);
+        });
+    });
+
+    describe('runCustomAction', () => {
+        beforeEach(() => {
+            containerMock.setup((c) => c.get(Worker)).returns(() => workerMock.object);
+            containerMock.setup((c) => c.get(ContextAwareLogger)).returns(() => loggerMock.object);
+        });
+
+        it('invokes worker', async () => {
+            loggerMock
+                .setup(async (l) => l.setup())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            workerMock
+                .setup(async (w) => w.init())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            workerMock
+                .setup(async (w) => w.run())
+                .returns(async () => Promise.resolve())
+                .verifiable(Times.once());
+
+            await testSubject.runCustomAction(containerMock.object);
+        });
+    });
+
+    afterEach(() => {
+        containerMock.verifyAll();
+        workerMock.verifyAll();
+        loggerMock.verifyAll();
+    });
+});

--- a/packages/privacy-scan-job-manager/src/privacy-scan-job-manager-entry-point.ts
+++ b/packages/privacy-scan-job-manager/src/privacy-scan-job-manager-entry-point.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Container } from 'inversify';
+import { BaseTelemetryProperties, ContextAwareLogger } from 'logger';
+import { ProcessEntryPointBase } from 'service-library';
+import { Worker } from './worker/worker';
+
+export class PrivacyScanJobManagerEntryPoint extends ProcessEntryPointBase {
+    protected getTelemetryBaseProperties(): BaseTelemetryProperties {
+        return { source: 'privacyScanJobManager' };
+    }
+
+    protected async runCustomAction(container: Container): Promise<void> {
+        const logger = container.get(ContextAwareLogger);
+        await logger.setup();
+
+        const worker = container.get<Worker>(Worker);
+        await worker.init();
+        await worker.run();
+    }
+}

--- a/packages/privacy-scan-job-manager/src/setup-privacy-scan-job-manager-container.spec.ts
+++ b/packages/privacy-scan-job-manager/src/setup-privacy-scan-job-manager-container.spec.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Batch, BatchTaskConfigGenerator, BatchTaskPropertyProvider, Queue } from 'azure-services';
+import { ServiceConfiguration } from 'common';
+import { Container } from 'inversify';
+import { setupPrivacyScanJobManagerContainer } from './setup-privacy-scan-job-manager-container';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
+
+describe(setupPrivacyScanJobManagerContainer, () => {
+    const batchAccountUrl = 'test-batch-account-url';
+    const batchAccountName = 'test-batch-account-name';
+
+    beforeEach(() => {
+        process.env.AZURE_STORAGE_SCAN_QUEUE = 'test-scan-queue';
+        process.env.AZURE_STORAGE_NOTIFICATION_QUEUE = 'test-notification-queue';
+        process.env.AZ_BATCH_ACCOUNT_NAME = batchAccountName;
+        process.env.AZ_BATCH_ACCOUNT_URL = batchAccountUrl;
+        process.env.AZ_BATCH_POOL_ID = 'test-batch-pool-id';
+    });
+
+    test.each([BatchTaskPropertyProvider, ServiceConfiguration])('resolves %p to singleton value', (key) => {
+        const container = setupPrivacyScanJobManagerContainer();
+
+        verifySingletonDependencyResolution(container, key);
+    });
+
+    it('resolves batch task config generator to non singleton value', () => {
+        const container = setupPrivacyScanJobManagerContainer();
+
+        verifyNonSingletonDependencyResolution(container, BatchTaskConfigGenerator);
+    });
+
+    it('verify dependencies resolution', () => {
+        const container = setupPrivacyScanJobManagerContainer();
+
+        verifyNonSingletonDependencyResolution(container, Queue);
+        verifySingletonDependencyResolution(container, Batch);
+    });
+
+    function verifySingletonDependencyResolution(container: Container, key: any): void {
+        expect(container.get(key)).toBeDefined();
+        expect(container.get(key)).toBe(container.get(key));
+    }
+
+    function verifyNonSingletonDependencyResolution(container: Container, key: any): void {
+        expect(container.get(key)).toBeDefined();
+        expect(container.get(key)).not.toBe(container.get(key));
+    }
+});

--- a/packages/privacy-scan-job-manager/src/setup-privacy-scan-job-manager-container.ts
+++ b/packages/privacy-scan-job-manager/src/setup-privacy-scan-job-manager-container.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BatchTaskPropertyProvider, registerAzureServicesToContainer } from 'azure-services';
+import { setupRuntimeConfigContainer } from 'common';
+import { Container } from 'inversify';
+import { registerLoggerToContainer } from 'logger';
+import { ScannerBatchTaskPropertyProvider } from './batch/scanner-batch-task-property-provider';
+
+export function setupPrivacyScanJobManagerContainer(): Container {
+    const container = new Container({ autoBindInjectable: true });
+    setupRuntimeConfigContainer(container);
+    registerLoggerToContainer(container);
+    registerAzureServicesToContainer(container);
+
+    container.bind(BatchTaskPropertyProvider).to(ScannerBatchTaskPropertyProvider).inSingletonScope();
+
+    return container;
+}

--- a/packages/privacy-scan-job-manager/src/test-utilities/mockable-logger.ts
+++ b/packages/privacy-scan-job-manager/src/test-utilities/mockable-logger.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Logger } from 'logger';
+
+export class MockableLogger extends Logger {}

--- a/packages/privacy-scan-job-manager/src/test-utilities/promisable-mock.ts
+++ b/packages/privacy-scan-job-manager/src/test-utilities/promisable-mock.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { IMock } from 'typemoq';
+
+export function getPromisableDynamicMock<T>(mock: IMock<T>): IMock<T> {
+    // workaround for issue https://github.com/florinn/typemoq/issues/70
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.setup((x: any) => x.then).returns(() => undefined);
+
+    return mock;
+}

--- a/packages/privacy-scan-job-manager/src/worker/worker.spec.ts
+++ b/packages/privacy-scan-job-manager/src/worker/worker.spec.ts
@@ -1,0 +1,489 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import {
+    Batch,
+    BatchConfig,
+    BatchTask,
+    JobTask,
+    JobTaskState,
+    PoolLoadGenerator,
+    PoolLoadSnapshot,
+    PoolMetricsInfo,
+    Queue,
+    StorageConfig,
+} from 'azure-services';
+import { QueueRuntimeConfig, ServiceConfiguration } from 'common';
+import * as _ from 'lodash';
+import * as mockDate from 'mockdate';
+import { BatchPoolLoadSnapshotProvider, OnDemandPageScanRunResultProvider, ScanMessage } from 'service-library';
+import { OnDemandPageScanResult, OnDemandScanRequestMessage, StorageDocument } from 'storage-documents';
+import { IMock, It, Mock } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { Worker } from './worker';
+
+/* eslint-disable no-invalid-this, @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any, no-bitwise */
+
+enum EnableBaseWorkflow {
+    none,
+    onTasksAdded = 1 << 1,
+    handleFailedTasks = 1 << 2,
+}
+
+class TestableWorker extends Worker {
+    public enableBaseWorkflow: EnableBaseWorkflow;
+
+    public onTasksAddedCallback: (tasks: JobTask[]) => Promise<void>;
+
+    public excludeCompletedScansCallback: (scanMessages: ScanMessage[]) => Promise<ScanMessage[]>;
+
+    public handleFailedTasksCallback: (failedTasks: BatchTask[]) => Promise<void>;
+
+    public activeScanMessages: ScanMessage[];
+
+    public async getMessagesForTaskCreation(): Promise<ScanMessage[]> {
+        return super.getMessagesForTaskCreation();
+    }
+
+    public async onTasksValidation(): Promise<void> {
+        return super.handleFailedTasks([]);
+    }
+
+    public async handleFailedTasks(failedTasks: BatchTask[]): Promise<void> {
+        await this.invokeOverrides(
+            EnableBaseWorkflow.handleFailedTasks,
+            this.handleFailedTasksCallback,
+            async () => super.handleFailedTasks(failedTasks),
+            undefined,
+            failedTasks,
+        );
+    }
+
+    public async onTasksAdded(tasks: JobTask[]): Promise<void> {
+        await this.invokeOverrides(
+            EnableBaseWorkflow.onTasksAdded,
+            this.onTasksAddedCallback,
+            async () => super.onTasksAdded(tasks),
+            undefined,
+            tasks,
+        );
+    }
+
+    private async invokeOverrides(
+        workflow: EnableBaseWorkflow,
+        callback: any,
+        baseWorkflow?: any,
+        defaultResult?: any,
+        ...params: any
+    ): Promise<any> {
+        if (callback !== undefined) {
+            return callback(...params);
+        }
+
+        if ((this.enableBaseWorkflow & workflow) === workflow) {
+            return baseWorkflow(...params);
+        }
+
+        return defaultResult;
+    }
+}
+
+class QueueMessagesGenerator {
+    public scanMessagesByRun: ScanMessage[][] = [];
+
+    public scanMessages: ScanMessage[] = [];
+
+    public jobTasksByRun: JobTask[][] = [];
+
+    public jobTasks: JobTask[] = [];
+
+    public runCount = 0;
+
+    public maxRunCount = 2;
+
+    public messagesPerRun = 3;
+
+    public queueMessagesGeneratorFn = () => () => {
+        let messages: ScanMessage[] = [];
+        if (this.runCount < this.maxRunCount) {
+            messages = createScanMessages(this.messagesPerRun, this.runCount * this.maxRunCount);
+            this.scanMessagesByRun[this.runCount] = messages;
+            this.scanMessages.push(...messages);
+            this.runCount += 1;
+        }
+
+        return messages;
+    };
+
+    public jobTaskGeneratorFn = () => () => {
+        if (this.runCount === 0) {
+            return [];
+        }
+
+        const jobTasks = createJobTasks(this.scanMessagesByRun[this.runCount - 1]);
+        this.jobTasksByRun[this.runCount - 1] = jobTasks;
+        this.jobTasks.push(...jobTasks);
+
+        return jobTasks;
+    };
+}
+
+const messageVisibilityTimeout = 600;
+const dateNowIso = '2019-12-12T12:00:00.000Z';
+mockDate.set(dateNowIso);
+
+let testSubject: TestableWorker;
+let batchMock: IMock<Batch>;
+let queueMock: IMock<Queue>;
+let poolLoadGeneratorMock: IMock<PoolLoadGenerator>;
+let serviceConfigMock: IMock<ServiceConfiguration>;
+let loggerMock: IMock<MockableLogger>;
+let batchPoolLoadSnapshotProviderMock: IMock<BatchPoolLoadSnapshotProvider>;
+let onDemandPageScanRunResultProviderMock: IMock<OnDemandPageScanRunResultProvider>;
+let storageConfigStub: StorageConfig;
+let poolMetricsInfo: PoolMetricsInfo;
+let batchConfig: BatchConfig;
+let queueMessagesGenerator: QueueMessagesGenerator;
+
+describe(Worker, () => {
+    beforeEach(() => {
+        batchConfig = {
+            accountName: 'batch-account-name',
+            accountUrl: '',
+            poolId: 'pool-Id',
+            jobId: 'batch-job-id',
+        } as BatchConfig;
+
+        poolMetricsInfo = {
+            id: 'pool-id',
+            maxTasksPerPool: 4,
+            load: {
+                activeTasks: 0,
+                runningTasks: 1,
+            },
+        };
+
+        batchMock = Mock.ofType(Batch);
+        queueMock = Mock.ofType(Queue);
+        poolLoadGeneratorMock = Mock.ofType(PoolLoadGenerator);
+        batchPoolLoadSnapshotProviderMock = Mock.ofType(BatchPoolLoadSnapshotProvider);
+        onDemandPageScanRunResultProviderMock = Mock.ofType(OnDemandPageScanRunResultProvider);
+
+        serviceConfigMock = Mock.ofType(ServiceConfiguration);
+        setupServiceConfigMock(messageVisibilityTimeout);
+
+        storageConfigStub = {
+            scanQueue: 'scan-queue',
+        } as StorageConfig;
+        loggerMock = Mock.ofType(MockableLogger);
+
+        batchMock.setup((o) => o.getPoolMetricsInfo()).returns(async () => Promise.resolve(poolMetricsInfo));
+        queueMessagesGenerator = new QueueMessagesGenerator();
+
+        testSubject = new TestableWorker(
+            batchMock.object,
+            queueMock.object,
+            poolLoadGeneratorMock.object,
+            batchPoolLoadSnapshotProviderMock.object,
+            onDemandPageScanRunResultProviderMock.object,
+            batchConfig,
+            serviceConfigMock.object,
+            storageConfigStub,
+            loggerMock.object,
+        );
+    });
+
+    afterEach(() => {
+        batchMock.verifyAll();
+        queueMock.verifyAll();
+        poolLoadGeneratorMock.verifyAll();
+        batchPoolLoadSnapshotProviderMock.verifyAll();
+        onDemandPageScanRunResultProviderMock.verifyAll();
+        serviceConfigMock.verifyAll();
+        loggerMock.verifyAll();
+    });
+
+    afterAll(() => {
+        mockDate.reset();
+    });
+
+    it('skip getting messages if pool has no available slots', async () => {
+        const poolLoadSnapshot = {
+            tasksIncrementCountPerInterval: 0,
+            samplingIntervalInSeconds: 15,
+        } as PoolLoadSnapshot;
+        poolLoadGeneratorMock
+            .setup((o) => o.getPoolLoadSnapshot(poolMetricsInfo))
+            .returns(async () => Promise.resolve(poolLoadSnapshot))
+            .verifiable();
+        batchPoolLoadSnapshotProviderMock
+            .setup((o) =>
+                o.writeBatchPoolLoadSnapshot(
+                    It.isValue({
+                        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                        ...({} as StorageDocument),
+                        batchAccountName: batchConfig.accountName,
+                        ...poolLoadSnapshot,
+                    }),
+                ),
+            )
+            .verifiable();
+        loggerMock
+            .setup((o) =>
+                o.trackEvent(
+                    'BatchPoolStats',
+                    null,
+                    It.isValue({
+                        runningTasks: poolMetricsInfo.load.runningTasks,
+                        samplingIntervalInSeconds: poolLoadSnapshot.samplingIntervalInSeconds,
+                        maxParallelTasks: poolMetricsInfo.maxTasksPerPool,
+                    }),
+                ),
+            )
+            .verifiable();
+
+        const actualMessages = await testSubject.getMessagesForTaskCreation();
+
+        expect(actualMessages).toEqual([]);
+    });
+
+    it('get messages from a queue', async () => {
+        const poolLoadSnapshot = {
+            tasksIncrementCountPerInterval: 10,
+            samplingIntervalInSeconds: 15,
+        } as PoolLoadSnapshot;
+        poolLoadGeneratorMock
+            .setup((o) => o.getPoolLoadSnapshot(poolMetricsInfo))
+            .returns(async () => Promise.resolve(poolLoadSnapshot))
+            .verifiable();
+        batchPoolLoadSnapshotProviderMock
+            .setup((o) =>
+                o.writeBatchPoolLoadSnapshot(
+                    It.isValue({
+                        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                        ...({} as StorageDocument),
+                        batchAccountName: batchConfig.accountName,
+                        ...poolLoadSnapshot,
+                    }),
+                ),
+            )
+            .verifiable();
+
+        queueMessagesGenerator.queueMessagesGeneratorFn()();
+        queueMock
+            .setup((o) => o.getMessagesWithTotalCount(testSubject.getQueueName(), poolLoadSnapshot.tasksIncrementCountPerInterval))
+            .returns(async () => Promise.resolve(queueMessagesGenerator.scanMessages.map((m) => m.message)))
+            .verifiable();
+
+        loggerMock
+            .setup((o) =>
+                o.trackEvent(
+                    'BatchPoolStats',
+                    null,
+                    It.isValue({
+                        runningTasks: poolMetricsInfo.load.runningTasks,
+                        samplingIntervalInSeconds: poolLoadSnapshot.samplingIntervalInSeconds,
+                        maxParallelTasks: poolMetricsInfo.maxTasksPerPool,
+                    }),
+                ),
+            )
+            .verifiable();
+
+        const actualMessages = await testSubject.getMessagesForTaskCreation();
+
+        expect(actualMessages).toEqual(queueMessagesGenerator.scanMessages);
+    });
+
+    it('update pool stats when tasks added', async () => {
+        const tasks = [{}, {}, {}];
+        poolLoadGeneratorMock.setup((o) => o.setLastTasksIncrementCount(tasks.length)).verifiable();
+        testSubject.enableBaseWorkflow = EnableBaseWorkflow.onTasksAdded;
+
+        await testSubject.onTasksAdded(tasks as JobTask[]);
+    });
+
+    it('handleFailedTasks() - skip if task has no scan id argument', async () => {
+        const failedTasks = [
+            {
+                id: 'id',
+                taskArguments: '{}',
+            },
+        ] as BatchTask[];
+
+        loggerMock
+            .setup((o) =>
+                o.logError(
+                    `Unable to update failed scan run result. Task has no scan id run arguments defined.`,
+                    It.isValue({
+                        correlatedBatchTaskId: failedTasks[0].id,
+                        taskProperties: JSON.stringify(failedTasks[0]),
+                    }),
+                ),
+            )
+            .verifiable();
+
+        testSubject.enableBaseWorkflow = EnableBaseWorkflow.handleFailedTasks;
+
+        await testSubject.handleFailedTasks(failedTasks);
+    });
+
+    it('handleFailedTasks() - skip if task has no scan id argument', async () => {
+        const failedTasks = [
+            {
+                id: 'task-id-1',
+                taskArguments: '{}',
+            },
+            {
+                id: 'task-id-2',
+                taskArguments: '{}',
+            },
+        ] as BatchTask[];
+
+        failedTasks.map((task) => {
+            loggerMock
+                .setup((o) =>
+                    o.logError(
+                        `Unable to update failed scan run result. Task has no scan id run arguments defined.`,
+                        It.isValue({
+                            correlatedBatchTaskId: task.id,
+                            taskProperties: JSON.stringify(task),
+                        }),
+                    ),
+                )
+                .verifiable();
+        });
+
+        testSubject.enableBaseWorkflow = EnableBaseWorkflow.handleFailedTasks;
+
+        await testSubject.handleFailedTasks(failedTasks);
+    });
+
+    it('handleFailedTasks() - skip if scan document not found in a storage', async () => {
+        const failedTasks = [
+            {
+                id: 'task-id-1',
+                taskArguments: JSON.stringify({ id: 'scan-id-1' }),
+            },
+            {
+                id: 'task-id-2',
+                taskArguments: JSON.stringify({ id: 'scan-id-2' }),
+            },
+        ] as BatchTask[];
+
+        failedTasks.map((task) => {
+            loggerMock
+                .setup((o) =>
+                    o.logError(
+                        `Unable to find corresponding scan document in a result storage.`,
+                        It.isValue({
+                            correlatedBatchTaskId: task.id,
+                            taskProperties: JSON.stringify(task),
+                        }),
+                    ),
+                )
+                .verifiable();
+        });
+
+        testSubject.enableBaseWorkflow = EnableBaseWorkflow.handleFailedTasks;
+
+        await testSubject.handleFailedTasks(failedTasks);
+    });
+
+    it('handleFailedTasks() - update scan document with task error', async () => {
+        const failedTasks: BatchTask[] = [];
+        const pageScanResults: OnDemandPageScanResult[] = [];
+
+        for (let i = 0; i < 2; i += 1) {
+            const scanId = `scan-id-${i}`;
+            failedTasks.push({
+                id: `task-id-${i}`,
+                correlationId: scanId,
+                exitCode: 1,
+                timestamp: new Date(),
+                failureInfo: {
+                    category: 'serverError',
+                    message: `failureInfo-message-${i}`,
+                },
+                taskArguments: JSON.stringify({ id: scanId }),
+            } as BatchTask);
+
+            const error = `Task was terminated unexpectedly. Exit code: 1`;
+            const error2 = `${error}, Error category: serverError, Error details: ${failedTasks[0].failureInfo.message}`;
+            pageScanResults.push({
+                run: {
+                    state: 'failed',
+                    timestamp: new Date().toJSON(),
+                    error: error2,
+                },
+            } as OnDemandPageScanResult);
+        }
+
+        failedTasks.map((task) => {
+            onDemandPageScanRunResultProviderMock
+                .setup((o) => o.readScanRun(task.correlationId))
+                .returns(async () => Promise.resolve({} as OnDemandPageScanResult))
+                .verifiable();
+        });
+
+        pageScanResults.map((scan) => {
+            onDemandPageScanRunResultProviderMock.setup((o) => o.updateScanRun(scan)).verifiable();
+        });
+
+        testSubject.enableBaseWorkflow = EnableBaseWorkflow.handleFailedTasks;
+
+        await testSubject.handleFailedTasks(failedTasks);
+    });
+});
+
+function createJobTasks(messages: ScanMessage[]): JobTask[] {
+    let count = 0;
+
+    const stateGeneratorFn = (seed: number): JobTaskState => {
+        if (seed === 2) {
+            return JobTaskState.failed;
+        } else if (seed === 3) {
+            return JobTaskState.completed;
+        }
+
+        return JobTaskState.queued;
+    };
+
+    return messages.map((m) => {
+        count += 1;
+
+        return {
+            id: `task-id-${m.scanId}_${m.messageId}_${Date.now}`,
+            correlationId: m.messageId,
+            state: stateGeneratorFn(count),
+        } as JobTask;
+    });
+}
+
+function createScanMessages(count: number, shift: number = 0): ScanMessage[] {
+    const scanMessages: ScanMessage[] = [];
+    for (let i = shift; i < count + shift; i += 1) {
+        scanMessages.push({
+            scanId: `scan-id-${i}`,
+            messageId: `message-id-${i}`,
+            message: {
+                messageId: `message-id-${i}`,
+                messageText: JSON.stringify(<OnDemandScanRequestMessage>{
+                    id: `scan-id-${i}`,
+                    url: 'https://localhost/',
+                }),
+                popReceipt: `pop-receipt-${i}`,
+            },
+        });
+    }
+
+    return scanMessages;
+}
+
+function setupServiceConfigMock(timeout: number): void {
+    serviceConfigMock.reset();
+    serviceConfigMock
+        .setup(async (o) => o.getConfigValue('queueConfig'))
+        .returns(async () => Promise.resolve(<QueueRuntimeConfig>(<unknown>{ messageVisibilityTimeoutInSeconds: timeout })));
+}

--- a/packages/privacy-scan-job-manager/src/worker/worker.ts
+++ b/packages/privacy-scan-job-manager/src/worker/worker.ts
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Batch, BatchConfig, BatchTask, JobTask, Message, PoolLoadGenerator, PoolLoadSnapshot, Queue, StorageConfig } from 'azure-services';
+import { ServiceConfiguration, System } from 'common';
+import { inject, injectable } from 'inversify';
+import { isNil, mergeWith } from 'lodash';
+import { GlobalLogger } from 'logger';
+import { BatchPoolLoadSnapshotProvider, BatchTaskCreator, OnDemandPageScanRunResultProvider, ScanMessage } from 'service-library';
+import { OnDemandScanRequestMessage, StorageDocument } from 'storage-documents';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+@injectable()
+export class Worker extends BatchTaskCreator {
+    public constructor(
+        @inject(Batch) batch: Batch,
+        @inject(Queue) queue: Queue,
+        @inject(PoolLoadGenerator) private readonly poolLoadGenerator: PoolLoadGenerator,
+        @inject(BatchPoolLoadSnapshotProvider) private readonly batchPoolLoadSnapshotProvider: BatchPoolLoadSnapshotProvider,
+        @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
+        @inject(BatchConfig) batchConfig: BatchConfig,
+        @inject(ServiceConfiguration) serviceConfig: ServiceConfiguration,
+        @inject(StorageConfig) private readonly storageConfig: StorageConfig,
+        @inject(GlobalLogger) logger: GlobalLogger,
+        system: typeof System = System,
+    ) {
+        super(batch, queue, batchConfig, serviceConfig, logger, system);
+    }
+
+    public getQueueName(): string {
+        return this.storageConfig.scanQueue;
+    }
+
+    public async getMessagesForTaskCreation(): Promise<ScanMessage[]> {
+        const poolMetricsInfo = await this.batch.getPoolMetricsInfo();
+        const poolLoadSnapshot = await this.poolLoadGenerator.getPoolLoadSnapshot(poolMetricsInfo);
+        await this.writePoolLoadSnapshot(poolLoadSnapshot);
+
+        let messages: ScanMessage[] = [];
+        const queueName = this.getQueueName();
+        if (poolLoadSnapshot.tasksIncrementCountPerInterval > 0) {
+            const queueMessages = await this.queue.getMessagesWithTotalCount(queueName, poolLoadSnapshot.tasksIncrementCountPerInterval);
+            if (queueMessages?.length > 0) {
+                messages = this.convertToScanMessages(queueMessages);
+            }
+        }
+
+        this.logger.logInfo(
+            'Pool load statistics',
+            mergeWith({}, poolLoadSnapshot, (t, s) =>
+                s !== undefined ? (s.constructor.name !== 'Date' ? s.toString() : s.toJSON()) : 'undefined',
+            ) as any,
+        );
+
+        this.logger.trackEvent('BatchPoolStats', null, {
+            runningTasks: poolMetricsInfo.load.runningTasks,
+            samplingIntervalInSeconds: poolLoadSnapshot.samplingIntervalInSeconds,
+            maxParallelTasks: poolMetricsInfo.maxTasksPerPool,
+        });
+
+        return messages;
+    }
+
+    public async onTasksAdded(tasks: JobTask[]): Promise<void> {
+        this.poolLoadGenerator.setLastTasksIncrementCount(tasks.length);
+    }
+
+    public async handleFailedTasks(failedTasks: BatchTask[]): Promise<void> {
+        await Promise.all(
+            failedTasks.map(async (failedTask) => {
+                const taskArguments = JSON.parse(failedTask.taskArguments) as OnDemandScanRequestMessage;
+                if (!isNil(taskArguments?.id)) {
+                    let error = `Task was terminated unexpectedly. Exit code: ${failedTask.exitCode}`;
+                    error =
+                        failedTask.failureInfo !== undefined
+                            ? // eslint-disable-next-line max-len
+                              `${error}, Error category: ${failedTask.failureInfo.category}, Error details: ${failedTask.failureInfo.message}`
+                            : error;
+
+                    const pageScanResult = await this.onDemandPageScanRunResultProvider.readScanRun(taskArguments.id);
+                    if (pageScanResult !== undefined) {
+                        pageScanResult.run = {
+                            state: 'failed',
+                            timestamp: failedTask.timestamp.toJSON(),
+                            error,
+                        };
+                        await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
+                    } else {
+                        this.logger.logError(`Unable to find corresponding scan document in a result storage.`, {
+                            correlatedBatchTaskId: failedTask.id,
+                            taskProperties: JSON.stringify(failedTask),
+                        });
+                    }
+
+                    this.logger.logError(error, { correlatedBatchTaskId: failedTask.id, taskProperties: JSON.stringify(failedTask) });
+                } else {
+                    this.logger.logError(`Unable to update failed scan run result. Task has no scan id run arguments defined.`, {
+                        correlatedBatchTaskId: failedTask.id,
+                        taskProperties: JSON.stringify(failedTask),
+                    });
+                }
+            }),
+        );
+    }
+
+    private async writePoolLoadSnapshot(poolLoadSnapshot: PoolLoadSnapshot): Promise<void> {
+        await this.batchPoolLoadSnapshotProvider.writeBatchPoolLoadSnapshot({
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            ...({} as StorageDocument),
+            batchAccountName: this.batchConfig.accountName,
+            ...poolLoadSnapshot,
+        });
+    }
+
+    private convertToScanMessages(messages: Message[]): ScanMessage[] {
+        return messages.map((message) => {
+            return {
+                scanId: this.parseMessageBody(message).id,
+                messageId: message.messageId,
+                message: message,
+            };
+        });
+    }
+
+    private parseMessageBody(message: Message): OnDemandScanRequestMessage {
+        return message.messageText === undefined ? undefined : (JSON.parse(message.messageText) as OnDemandScanRequestMessage);
+    }
+}

--- a/packages/privacy-scan-job-manager/tsconfig.json
+++ b/packages/privacy-scan-job-manager/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    }
+}

--- a/packages/privacy-scan-job-manager/webpack.config.js
+++ b/packages/privacy-scan-job-manager/webpack.config.js
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const path = require('path');
+const webpack = require('webpack');
+const forkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const copyWebpackPlugin = require('copy-webpack-plugin');
+const ignoreDynamicRequire = require('webpack-ignore-dynamic-require');
+
+module.exports = (env) => {
+    const version = env ? env.version : 'dev';
+    console.log(`Building for version : ${version}`);
+
+    return {
+        devtool: 'cheap-source-map',
+        externals: ['yargs', 'applicationinsights'],
+        entry: {
+            ['privacy-scan-job-manager']: path.resolve('./src/index.ts'),
+        },
+        mode: 'development',
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    use: [
+                        {
+                            loader: 'ts-loader',
+                            options: {
+                                transpileOnly: true,
+                                experimentalWatchApi: true,
+                            },
+                        },
+                    ],
+                    exclude: ['/node_modules/', /\.(spec|e2e)\.ts$/],
+                },
+                {
+                    test: /\.node$/,
+                    use: [
+                        {
+                            loader: 'node-loader',
+                        },
+                    ],
+                },
+            ],
+        },
+        name: 'privacy-scan-job-manager',
+        node: {
+            __dirname: false,
+        },
+        output: {
+            path: path.resolve('./dist'),
+            filename: '[name].js',
+            libraryTarget: 'commonjs2',
+        },
+        plugins: [
+            new webpack.DefinePlugin({
+                __IMAGE_VERSION__: JSON.stringify(version),
+            }),
+            new forkTsCheckerWebpackPlugin(),
+            new ignoreDynamicRequire(),
+            new copyWebpackPlugin({
+                patterns: [
+                    {
+                        context: './docker-image-config',
+                        from: '.dockerignore',
+                        to: '',
+                    },
+                    {
+                        context: './docker-image-config',
+                        from: 'Dockerfile',
+                        to: '',
+                    },
+                    {
+                        context: './docker-image-config',
+                        from: 'privacy-scan-job-manager.ps1',
+                        to: '',
+                    },
+                    {
+                        context: '../../packages/parallel-workers/dist',
+                        from: '**/*.js',
+                        to: '',
+                    },
+                ],
+            }),
+        ],
+        resolve: {
+            extensions: ['.ts', '.js', '.json'],
+            mainFields: ['main'],
+        },
+        target: 'node',
+    };
+};

--- a/packages/resource-deployment/scripts/create-queues.sh
+++ b/packages/resource-deployment/scripts/create-queues.sh
@@ -35,6 +35,8 @@ function setupQueues() {
         "createQueue \"ondemand-scanrequest-dead\""
         "createQueue \"ondemand-send-notification\""
         "createQueue \"ondemand-send-notification-dead\""
+        "createQueue \"privacy-scan-request\""
+        "createQueue \"privacy-scan-request-dead\""
     )
     runCommandsWithoutSecretsInParallel createQueueProcesses
 

--- a/packages/resource-deployment/scripts/job-schedule-create.sh
+++ b/packages/resource-deployment/scripts/job-schedule-create.sh
@@ -22,6 +22,9 @@ parsedOnDemandSendNotificationFileName="on-demand-send-notification.generated.te
 onDemandScanScheduleJobName="on-demand-url-scan-schedule"
 parsedOnDemandScanScheduleFileName="on-demand-url-scan-schedule.generated.template.json"
 
+privacyScanScheduleJobName="privacy-scan-schedule"
+parsedPrivacyScanScheduleFileName="privacy-scan-schedule.generated.template.json"
+
 adjustJob() {
     local jobName=$1
     local jobTemplate=$2
@@ -78,6 +81,7 @@ appInsightsKey=$(az monitor app-insights component show --app "$appInsightsName"
 sed -e "s@%APP_INSIGHTS_TOKEN%@$appInsightsKey@" -e "s@%KEY_VAULT_TOKEN%@$keyVaultUrl@" -e "s@%CONTAINER_REGISTRY_TOKEN%@$containerRegistryName@" "$templatesFolder/on-demand-url-scan-schedule.template.json" >"$parsedOnDemandScanScheduleFileName"
 sed -e "s@%APP_INSIGHTS_TOKEN%@$appInsightsKey@" -e "s@%KEY_VAULT_TOKEN%@$keyVaultUrl@" -e "s@%CONTAINER_REGISTRY_TOKEN%@$containerRegistryName@" "$templatesFolder/on-demand-scan-req-schedule.template.json" >"$parsedOnDemandScanReqScheduleFileName"
 sed -e "s@%APP_INSIGHTS_TOKEN%@$appInsightsKey@" -e "s@%KEY_VAULT_TOKEN%@$keyVaultUrl@" -e "s@%CONTAINER_REGISTRY_TOKEN%@$containerRegistryName@" "$templatesFolder/on-demand-send-notification-schedule.template.json" >"$parsedOnDemandSendNotificationFileName"
+sed -e "s@%APP_INSIGHTS_TOKEN%@$appInsightsKey@" -e "s@%KEY_VAULT_TOKEN%@$keyVaultUrl@" -e "s@%CONTAINER_REGISTRY_TOKEN%@$containerRegistryName@" "$templatesFolder/privacy-scan-schedule.template.json" >"$parsedPrivacyScanScheduleFileName"
 
 echo "Logging into batch account '$batchAccountName' in resource group '$resourceGroupName'..."
 az batch account login --name "$batchAccountName" --resource-group "$resourceGroupName"
@@ -88,5 +92,6 @@ allJobsScheduleList=$(az batch job-schedule list --query "[*].id" -o tsv)
 adjustJob "$onDemandScanScheduleJobName" "$parsedOnDemandScanScheduleFileName" "$allJobsScheduleList"
 adjustJob "$onDemandScanReqScheduleJobName" "$parsedOnDemandScanReqScheduleFileName" "$allJobsScheduleList"
 adjustJob "$onDemandSendNotificationJobName" "$parsedOnDemandSendNotificationFileName" "$allJobsScheduleList"
+adjustJob "$privacyScanScheduleJobName" "$parsedPrivacyScanScheduleFileName" "$allJobsScheduleList"
 
 echo "Job schedules were created successfully."

--- a/packages/resource-deployment/scripts/pool-startup/pool-startup.ps1
+++ b/packages/resource-deployment/scripts/pool-startup/pool-startup.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 [CmdletBinding()]
 Param(
     [Parameter()]

--- a/packages/resource-deployment/scripts/pool-startup/pull-image-from-container-registry.ps1
+++ b/packages/resource-deployment/scripts/pool-startup/pull-image-from-container-registry.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 [CmdletBinding()]
 Param(
     [Parameter()]
@@ -78,7 +79,7 @@ function getSecretValue($key) {
 function loginToContainerRegistry() {
     $containerRegistryUsername = getSecretValue "containerRegistryUsername"
     $containerRegistryPassword = getSecretValue "containerRegistryPassword"
-    $global:azurecr="$containerRegistryUsername.azurecr.io"
+    $global:azurecr = "$containerRegistryUsername.azurecr.io"
 
     Write-Output "Login to the container registry $azurecr..."
     echo "$containerRegistryPassword" | docker login -u "$containerRegistryUsername" --password-stdin "$azurecr"
@@ -86,8 +87,8 @@ function loginToContainerRegistry() {
 
 function pullDockerImages() {
     Write-Output "Pulling Batch images from container registry..."
-    $scanManagerImage="$azurecr/batch-scan-manager:latest"
-    $scanRunnerImage="$azurecr/batch-scan-runner:latest"
+    $scanManagerImage = "$azurecr/batch-scan-manager:latest"
+    $scanRunnerImage = "$azurecr/batch-scan-runner:latest"
 
     Write-Output "Pulling image $scanManagerImage"
     docker pull $scanManagerImage

--- a/packages/resource-deployment/scripts/pool-startup/pull-image-from-container-registry.sh
+++ b/packages/resource-deployment/scripts/pool-startup/pull-image-from-container-registry.sh
@@ -66,7 +66,6 @@ loginToContainerRegistry() {
 
     getSecretValue "containerRegistryUsername" containerRegistryUsername
     getSecretValue "containerRegistryPassword" containerRegistryPassword
-    containerRegistryName=$containerRegistryUsername
 
     azurecr="$containerRegistryUsername.azurecr.io"
     echo "Login to the container registry $azurecr..."

--- a/packages/resource-deployment/scripts/push-image-to-container-registry.sh
+++ b/packages/resource-deployment/scripts/push-image-to-container-registry.sh
@@ -56,6 +56,8 @@ setImageBuildSource() {
     batchScanRequestSenderDist="${0%/*}/../../../web-api-scan-request-sender/dist/"
     batchScanNotificationManagerDist="${0%/*}/../../../web-api-send-notification-job-manager/dist/"
     batchScanNotificationRunnerDist="${0%/*}/../../../web-api-send-notification-runner/dist/"
+    batchPrivacyScanRunnerDist="${0%/*}/../../../privacy-scan-runner/dist/"
+    batchPrivacyScanJobManagerDist="${0%/*}/../../../privacy-scan-job-manager/dist/"
 }
 
 prepareImageBuildSource() {
@@ -73,6 +75,8 @@ prepareImageBuildSource() {
     cp "${0%/*}/../runtime-config/runtime-config.$environment.json" "${batchScanRequestSenderDist}runtime-config.json"
     cp "${0%/*}/../runtime-config/runtime-config.$environment.json" "${batchScanNotificationManagerDist}runtime-config.json"
     cp "${0%/*}/../runtime-config/runtime-config.$environment.json" "${batchScanNotificationRunnerDist}runtime-config.json"
+    cp "${0%/*}/../runtime-config/runtime-config.$environment.json" "${batchPrivacyScanRunnerDist}runtime-config.json"
+    cp "${0%/*}/../runtime-config/runtime-config.$environment.json" "${batchPrivacyScanJobManagerDist}runtime-config.json"
     echo "Runtime configuration copied successfully."
 }
 
@@ -87,6 +91,8 @@ pushImagesToRegistry() (
         "pushImageToRegistry \"batch-scan-request-sender\" $batchScanRequestSenderDist linux"
         "pushImageToRegistry \"batch-scan-notification-manager\" $batchScanNotificationManagerDist linux"
         "pushImageToRegistry \"batch-scan-notification-runner\" $batchScanNotificationRunnerDist linux"
+        "pushImageToRegistry \"batch-privacy-scan-runner\" $batchPrivacyScanRunnerDist windows"
+        "pushImageToRegistry \"batch-privacy-scan-manager\" $batchPrivacyScanJobManagerDist windows"
     )
 
     echo "Pushing images to Azure Container Registry."

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -19,6 +19,15 @@
         },
         "onDemandUrlScanPoolTaskSlotsPerNode": {
             "value": "2"
+        },
+        "privacyScanPoolNodes": {
+            "value": "1"
+        },
+        "privacyScanPoolVmSize": {
+            "value": "standard_d11_v2"
+        },
+        "privacyScanPoolTaskSlotsPerNode": {
+            "value": "2"
         }
     }
 }

--- a/packages/resource-deployment/templates/batch-account-prod.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-prod.parameters.json
@@ -19,6 +19,15 @@
         },
         "onDemandUrlScanPoolTaskSlotsPerNode": {
             "value": "2"
+        },
+        "privacyScanPoolNodes": {
+            "value": "1"
+        },
+        "privacyScanPoolVmSize": {
+            "value": "standard_d11_v2"
+        },
+        "privacyScanPoolTaskSlotsPerNode": {
+            "value": "2"
         }
     }
 }

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -62,42 +62,63 @@
             "defaultValue": "2",
             "type": "string",
             "metadata": {
-                "description": "Number of dedicated nodes for on-demand-scan-request-pool"
+                "description": "Number of dedicated nodes for on-demand-scan-request-pool pool"
             }
         },
         "onDemandScanRequestPoolVmSize": {
             "defaultValue": "standard_d1_v2",
             "type": "string",
             "metadata": {
-                "description": "vmSize for on-demand-scan-request-pool"
+                "description": "VM size for on-demand-scan-request-pool pool"
             }
         },
         "onDemandScanRequestPoolTaskSlotsPerNode": {
             "defaultValue": "2",
             "type": "string",
             "metadata": {
-                "description": "taskSlotsPerNode for on-demand-scan-request-pool"
+                "description": "Task slots per node for on-demand-scan-request-pool pool"
             }
         },
         "onDemandUrlScanPoolNodes": {
             "defaultValue": "3",
             "type": "string",
             "metadata": {
-                "description": "Number of dedicated nodes for on-demand-url-scan-pool"
+                "description": "Number of dedicated nodes for on-demand-url-scan-pool pool"
             }
         },
         "onDemandUrlScanPoolVmSize": {
             "defaultValue": "standard_d11_v2",
             "type": "string",
             "metadata": {
-                "description": "vmSize for on-demand-scan-request-pool"
+                "description": "VM size for on-demand-url-scan-pool pool"
             }
         },
         "onDemandUrlScanPoolTaskSlotsPerNode": {
             "defaultValue": "4",
             "type": "string",
             "metadata": {
-                "description": "taskSlotsPerNode for on-demand-scan-request-pool"
+                "description": "Task slots per node for on-demand-url-scan-pool pool"
+            }
+        },
+        "privacyScanPoolNodes": {
+            "defaultValue": "3",
+            "type": "string",
+            "metadata": {
+                "description": "Number of dedicated nodes for privacy-scan-pool pool"
+            }
+        },
+        "privacyScanPoolVmSize": {
+            "defaultValue": "standard_d11_v2",
+            "type": "string",
+            "metadata": {
+                "description": "VM size for privacy-scan-pool pool"
+            }
+        },
+        "privacyScanPoolTaskSlotsPerNode": {
+            "defaultValue": "4",
+            "type": "string",
+            "metadata": {
+                "description": "Task slots per node for privacy-scan-pool pool"
             }
         }
     },
@@ -127,7 +148,9 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2021-01-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-url-scan-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
                 "vmSize": "[parameters('onDemandUrlScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -145,7 +168,10 @@
                         },
                         "nodeAgentSkuId": "batch.node.windows amd64",
                         "diskEncryptionConfiguration": {
-                            "targets": ["TemporaryDisk", "OsDisk"]
+                            "targets": [
+                                "TemporaryDisk",
+                                "OsDisk"
+                            ]
                         },
                         "containerConfiguration": {
                             "type": "dockerCompatible",
@@ -201,7 +227,9 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2021-01-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-scan-request-pool')]",
-            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
             "properties": {
                 "vmSize": "[parameters('onDemandScanRequestPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -219,7 +247,9 @@
                         },
                         "nodeAgentSkuId": "batch.node.ubuntu 20.04",
                         "diskEncryptionConfiguration": {
-                            "targets": ["TemporaryDisk"]
+                            "targets": [
+                                "TemporaryDisk"
+                            ]
                         },
                         "containerConfiguration": {
                             "type": "dockerCompatible",
@@ -264,6 +294,85 @@
                     "userIdentity": {
                         "autoUser": {
                             "scope": "Pool",
+                            "elevationLevel": "Admin"
+                        }
+                    },
+                    "maxTaskRetryCount": 3,
+                    "waitForSuccess": true
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Batch/batchAccounts/pools",
+            "apiVersion": "2021-01-01",
+            "name": "[concat(parameters('batchAccount'), '/privacy-scan-pool')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
+            ],
+            "properties": {
+                "vmSize": "[parameters('privacyScanPoolVmSize')]",
+                "interNodeCommunication": "Disabled",
+                "taskSlotsPerNode": "[parameters('privacyScanPoolTaskSlotsPerNode')]",
+                "taskSchedulingPolicy": {
+                    "nodeFillType": "Spread"
+                },
+                "deploymentConfiguration": {
+                    "virtualMachineConfiguration": {
+                        "imageReference": {
+                            "publisher": "microsoftwindowsserver",
+                            "offer": "windowsserver",
+                            "sku": "2019-datacenter-with-containers",
+                            "version": "latest"
+                        },
+                        "nodeAgentSkuId": "batch.node.windows amd64",
+                        "diskEncryptionConfiguration": {
+                            "targets": [
+                                "TemporaryDisk",
+                                "OsDisk"
+                            ]
+                        },
+                        "containerConfiguration": {
+                            "type": "dockerCompatible",
+                            "containerImageNames": [
+                                "[concat(variables('containerRegistryServerName'), '/batch-privacy-scan-manager')]",
+                                "[concat(variables('containerRegistryServerName'), '/batch-privacy-scan-runner')]"
+                            ],
+                            "containerRegistries": [
+                                {
+                                    "registryServer": "[variables('containerRegistryServerName')]",
+                                    "username": "[parameters('containerRegistryServerUserName')]",
+                                    "password": "[parameters('containerRegistryServerPassword')]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "networkConfiguration": {
+                    "subnetId": "[concat(variables('vnetResource'), '/subnets/default')]"
+                },
+                "scaleSettings": {
+                    "fixedScale": {
+                        "targetDedicatedNodes": "[parameters('privacyScanPoolNodes')]",
+                        "targetLowPriorityNodes": 0,
+                        "resizeTimeout": "PT15M"
+                    }
+                },
+                "startTask": {
+                    "commandLine": "powershell.exe pool-startup.ps1",
+                    "environmentSettings": [
+                        {
+                            "name": "KEY_VAULT_NAME",
+                            "value": "[parameters('keyVault')]"
+                        }
+                    ],
+                    "resourceFiles": [
+                        {
+                            "autoStorageContainerName": "batch-pool-startup-script"
+                        }
+                    ],
+                    "userIdentity": {
+                        "autoUser": {
+                            "scope": "Task",
                             "elevationLevel": "Admin"
                         }
                     },

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -148,9 +148,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2021-01-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-url-scan-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "[parameters('onDemandUrlScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -168,10 +166,7 @@
                         },
                         "nodeAgentSkuId": "batch.node.windows amd64",
                         "diskEncryptionConfiguration": {
-                            "targets": [
-                                "TemporaryDisk",
-                                "OsDisk"
-                            ]
+                            "targets": ["TemporaryDisk", "OsDisk"]
                         },
                         "containerConfiguration": {
                             "type": "dockerCompatible",
@@ -227,9 +222,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2021-01-01",
             "name": "[concat(parameters('batchAccount'), '/on-demand-scan-request-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "[parameters('onDemandScanRequestPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -247,9 +240,7 @@
                         },
                         "nodeAgentSkuId": "batch.node.ubuntu 20.04",
                         "diskEncryptionConfiguration": {
-                            "targets": [
-                                "TemporaryDisk"
-                            ]
+                            "targets": ["TemporaryDisk"]
                         },
                         "containerConfiguration": {
                             "type": "dockerCompatible",
@@ -306,9 +297,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2021-01-01",
             "name": "[concat(parameters('batchAccount'), '/privacy-scan-pool')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"
-            ],
+            "dependsOn": ["[resourceId('Microsoft.Batch/batchAccounts', parameters('batchAccount'))]"],
             "properties": {
                 "vmSize": "[parameters('privacyScanPoolVmSize')]",
                 "interNodeCommunication": "Disabled",
@@ -326,10 +315,7 @@
                         },
                         "nodeAgentSkuId": "batch.node.windows amd64",
                         "diskEncryptionConfiguration": {
-                            "targets": [
-                                "TemporaryDisk",
-                                "OsDisk"
-                            ]
+                            "targets": ["TemporaryDisk", "OsDisk"]
                         },
                         "containerConfiguration": {
                             "type": "dockerCompatible",

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -80,7 +80,7 @@
             }
         },
         "onDemandUrlScanPoolNodes": {
-            "defaultValue": "3",
+            "defaultValue": "2",
             "type": "string",
             "metadata": {
                 "description": "Number of dedicated nodes for on-demand-url-scan-pool pool"
@@ -101,7 +101,7 @@
             }
         },
         "privacyScanPoolNodes": {
-            "defaultValue": "3",
+            "defaultValue": "2",
             "type": "string",
             "metadata": {
                 "description": "Number of dedicated nodes for privacy-scan-pool pool"

--- a/packages/resource-deployment/templates/privacy-scan-schedule.template.json
+++ b/packages/resource-deployment/templates/privacy-scan-schedule.template.json
@@ -1,5 +1,5 @@
 {
-    "id": "on-demand-send-notification-schedule",
+    "id": "privacy-scan-schedule",
     "schedule": {
         "recurrenceInterval": "PT1M"
     },
@@ -10,11 +10,11 @@
             "maxTaskRetryCount": 0
         },
         "jobManagerTask": {
-            "id": "on-demand-send-notification-job-manager-task",
+            "id": "privacy-scan-job-manager-task",
             "commandLine": "",
             "containerSettings": {
-                "containerRunOptions": "--init --rm --workdir / -e APPINSIGHTS_INSTRUMENTATIONKEY -e AZURE_STORAGE_NOTIFICATION_QUEUE -e KEY_VAULT_URL",
-                "imageName": "%CONTAINER_REGISTRY_TOKEN%.azurecr.io/batch-scan-notification-manager"
+                "containerRunOptions": "--init --rm --workdir / -e APPINSIGHTS_INSTRUMENTATIONKEY -e AZURE_STORAGE_SCAN_QUEUE -e KEY_VAULT_URL",
+                "imageName": "%CONTAINER_REGISTRY_TOKEN%.azurecr.io/batch-privacy-scan-manager"
             },
             "constraints": {
                 "maxWallClockTime": "PT1H",
@@ -25,7 +25,7 @@
             "userIdentity": {
                 "autoUser": {
                     "scope": "task",
-                    "elevationLevel": "nonadmin"
+                    "elevationLevel": "admin"
                 }
             },
             "runExclusive": false
@@ -36,8 +36,8 @@
                 "value": "%APP_INSIGHTS_TOKEN%"
             },
             {
-                "name": "AZURE_STORAGE_NOTIFICATION_QUEUE",
-                "value": "ondemand-send-notification"
+                "name": "AZURE_STORAGE_SCAN_QUEUE",
+                "value": "privacy-scan-request"
             },
             {
                 "name": "KEY_VAULT_URL",
@@ -45,7 +45,7 @@
             }
         ],
         "poolInfo": {
-            "poolId": "on-demand-scan-request-pool"
+            "poolId": "privacy-scan-pool"
         }
     }
 }

--- a/packages/web-api-scan-job-manager/run-in-docker-container.sh
+++ b/packages/web-api-scan-job-manager/run-in-docker-container.sh
@@ -10,5 +10,5 @@ cp ../resource-deployment/runtime-config/runtime-config.dev.json ./dist/runtime-
 cp ./.env ./dist/
 yarn build &&
     cd ./dist &&
-    docker build --tag job-manager . &&
-    docker run job-manager
+    docker build --tag a11y-scan-job-manager . &&
+    docker run a11y-scan-job-manager

--- a/packages/web-api-scan-runner/run-in-docker-container.sh
+++ b/packages/web-api-scan-runner/run-in-docker-container.sh
@@ -11,5 +11,5 @@ cp ../resource-deployment/runtime-config/runtime-config.dev.json ./dist/runtime-
 cp ./.env ./dist/
 yarn build &&
     cd ./dist &&
-    docker build --tag runner . &&
-    docker run --init --cap-add=SYS_ADMIN --ipc=host runner
+    docker build --tag a11y-scan-runner . &&
+    docker run --init --cap-add=SYS_ADMIN --ipc=host a11y-scan-runner


### PR DESCRIPTION
#### Details

Added Batch job manager to support privacy scanner
Configured dedicated Batch pool to run privacy scan
Configured Batch job manager schedule
Configured storage privacy scan queue
Enabled container images deployment for privacy job manager and runner
Fixed issue with AAD principal availability of VMSS Batch pool managed identity

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
