### PR TITLE
Detect consent banner

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -117,6 +117,18 @@ Object {
       "format": "Boolean",
     },
   },
+  "privacyScanConfig": Object {
+    "bannerDetectionTimeout": Object {
+      "default": 100,
+      "doc": "The maximum time in milliseconds to wait for the banner XPath after the initial page load has completed",
+      "format": "int",
+    },
+    "bannerXPath": Object {
+      "default": "//div[@id=\\"wcpConsentBannerCtrl\\"]",
+      "doc": "The default XPath to use for consent banner detection",
+      "format": "String",
+    },
+  },
   "queueConfig": Object {
     "maxQueueSize": Object {
       "default": 10,
@@ -308,6 +320,18 @@ Object {
       "default": true,
       "doc": "Property to decide if console logging is enabled",
       "format": "Boolean",
+    },
+  },
+  "privacyScanConfig": Object {
+    "bannerDetectionTimeout": Object {
+      "default": 100,
+      "doc": "The maximum time in milliseconds to wait for the banner XPath after the initial page load has completed",
+      "format": "int",
+    },
+    "bannerXPath": Object {
+      "default": "//div[@id=\\"wcpConsentBannerCtrl\\"]",
+      "doc": "The default XPath to use for consent banner detection",
+      "format": "String",
     },
   },
   "queueConfig": Object {

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -55,6 +55,7 @@ export interface RuntimeConfig {
     restApiConfig: RestApiConfig;
     availabilityTestConfig: AvailabilityTestConfig;
     crawlConfig: CrawlConfig;
+    privacyScanConfig: PrivacyScanConfig;
 }
 
 export interface FeatureFlags {
@@ -77,6 +78,11 @@ export interface AvailabilityTestConfig {
 export interface CrawlConfig {
     deepScanDiscoveryLimit: number;
     deepScanUpperLimit: number;
+}
+
+export interface PrivacyScanConfig {
+    bannerXPath: string;
+    bannerDetectionTimeout: number;
 }
 
 export declare type ResourceType = 'batch' | 'registry';
@@ -320,6 +326,18 @@ export class ServiceConfiguration {
                     format: 'int',
                     default: 10,
                     doc: 'The maximum number of URLs that will be processed for a deep scan request',
+                },
+            },
+            privacyScanConfig: {
+                bannerXPath: {
+                    format: 'String',
+                    default: '//div[@id="wcpConsentBannerCtrl"]',
+                    doc: 'The default XPath to use for consent banner detection',
+                },
+                bannerDetectionTimeout: {
+                    format: 'int',
+                    default: 100,
+                    doc: 'The maximum time in milliseconds to wait for the banner XPath after the initial page load has completed',
                 },
             },
         };

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -42,6 +42,6 @@
         "logger": "1.0.0",
         "puppeteer": "^5.5.0",
         "reflect-metadata": "^0.1.13",
-        "storage-documents": "^1.0.0"
+        "storage-documents": "1.0.0"
     }
 }

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -28,6 +28,7 @@
         "@types/puppeteer": "^3.0.0",
         "jest": "^27.4.7",
         "jest-junit": "^12.3.0",
+        "mockdate": "^3.0.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.1.2",
         "typemoq": "^2.1.0",

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -41,6 +41,7 @@
         "lodash": "^4.17.21",
         "logger": "1.0.0",
         "puppeteer": "^5.5.0",
-        "reflect-metadata": "^0.1.13"
+        "reflect-metadata": "^0.1.13",
+        "storage-documents": "^1.0.0"
     }
 }

--- a/packages/scanner-global-library/src/index.ts
+++ b/packages/scanner-global-library/src/index.ts
@@ -12,3 +12,4 @@ export { AxeScanResults } from './axe-scan-results';
 export { WebDriver } from './web-driver';
 export { PageNavigator, OnNavigationError } from './page-navigator';
 export { PrivacyScanResult } from './privacy-scan-result';
+export { PrivacyPageScanner } from './privacy-page-scanner';

--- a/packages/scanner-global-library/src/privacy-page-scanner.spec.ts
+++ b/packages/scanner-global-library/src/privacy-page-scanner.spec.ts
@@ -7,6 +7,7 @@ import { PrivacyScanConfig, ServiceConfiguration } from 'common';
 import { IMock, Mock } from 'typemoq';
 import * as Puppeteer from 'puppeteer';
 import { ConsentResult, PrivacyPageScanReport } from 'storage-documents';
+import * as MockDate from 'mockdate';
 import { BrowserError } from './browser-error';
 import { Page } from './page';
 import { PrivacyScanResult } from './privacy-scan-result';
@@ -32,8 +33,9 @@ describe(PrivacyPageScanner, () => {
         serviceConfigMock.setup((c) => c.getConfigValue('privacyScanConfig')).returns(async () => privacyConfig);
         pageMock.setup((p) => p.currentPage).returns(() => puppeteerPageMock.object);
         puppeteerPageMock.setup((p) => p.url()).returns(() => url);
+        MockDate.set(currentDate);
 
-        testSubject = new PrivacyPageScanner(serviceConfigMock.object, () => currentDate);
+        testSubject = new PrivacyPageScanner(serviceConfigMock.object);
     });
 
     afterEach(() => {

--- a/packages/scanner-global-library/src/privacy-page-scanner.spec.ts
+++ b/packages/scanner-global-library/src/privacy-page-scanner.spec.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { PrivacyScanConfig, ServiceConfiguration } from 'common';
+import { IMock, Mock } from 'typemoq';
+import * as Puppeteer from 'puppeteer';
+import { ConsentResult, PrivacyPageScanReport } from 'storage-documents';
+import { BrowserError } from './browser-error';
+import { Page } from './page';
+import { PrivacyScanResult } from './privacy-scan-result';
+import { PrivacyPageScanner } from './privacy-page-scanner';
+
+describe(PrivacyPageScanner, () => {
+    const privacyConfig: PrivacyScanConfig = {
+        bannerXPath: 'default banner xpath',
+        bannerDetectionTimeout: 1000,
+    };
+    const url = 'test url';
+    const currentDate = new Date(1, 2, 3, 4);
+    let serviceConfigMock: IMock<ServiceConfiguration>;
+    let pageMock: IMock<Page>;
+    let puppeteerPageMock: IMock<Puppeteer.Page>;
+
+    let testSubject: PrivacyPageScanner;
+
+    beforeEach(() => {
+        serviceConfigMock = Mock.ofType<ServiceConfiguration>();
+        pageMock = Mock.ofType<Page>();
+        puppeteerPageMock = Mock.ofType<Puppeteer.Page>();
+        serviceConfigMock.setup((c) => c.getConfigValue('privacyScanConfig')).returns(async () => privacyConfig);
+        pageMock.setup((p) => p.currentPage).returns(() => puppeteerPageMock.object);
+        puppeteerPageMock.setup((p) => p.url()).returns(() => url);
+
+        testSubject = new PrivacyPageScanner(serviceConfigMock.object, () => currentDate);
+    });
+
+    afterEach(() => {
+        pageMock.verifyAll();
+        puppeteerPageMock.verifyAll();
+    });
+
+    it('Returns error if there was a page navigation error', async () => {
+        const browserError = {
+            errorType: 'UrlNavigationTimeout',
+            message: 'Navigation timeout',
+            statusCode: 400,
+        } as BrowserError;
+        const expectedResult: PrivacyScanResult = {
+            error: browserError,
+            pageResponseCode: 400,
+        };
+        pageMock.setup((p) => p.lastBrowserError).returns(() => browserError);
+
+        const result = await testSubject.scanPageForPrivacy(pageMock.object);
+
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('Throws if page is not open', () => {
+        pageMock.setup((p) => p.lastBrowserError).returns(() => undefined);
+        pageMock.setup((p) => p.isOpen()).returns(() => false);
+
+        expect(testSubject.scanPageForPrivacy(pageMock.object)).rejects.toThrow();
+    });
+
+    it('Returns hasBanner=true if default XPath is found', async () => {
+        const expectedResult: PrivacyScanResult = {
+            pageResponseCode: 200,
+            scannedUrl: url,
+            results: createPageScanReport(true, []),
+        };
+        setupOpenPage();
+        puppeteerPageMock
+            .setup((p) => p.waitForXPath(privacyConfig.bannerXPath, { timeout: privacyConfig.bannerDetectionTimeout }))
+            .returns(async () => undefined)
+            .verifiable();
+
+        const result = await testSubject.scanPageForPrivacy(pageMock.object);
+
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('Returns hasBanner=false if XPath not found', async () => {
+        const expectedResult: PrivacyScanResult = {
+            pageResponseCode: 200,
+            scannedUrl: url,
+            results: createPageScanReport(false, []),
+        };
+        setupOpenPage();
+        puppeteerPageMock
+            .setup((p) => p.waitForXPath(privacyConfig.bannerXPath, { timeout: privacyConfig.bannerDetectionTimeout }))
+            .throws(new Error())
+            .verifiable();
+
+        const result = await testSubject.scanPageForPrivacy(pageMock.object);
+
+        expect(result).toEqual(expectedResult);
+    });
+
+    function setupOpenPage(): void {
+        const navigationResponseStub = {
+            status: () => 200,
+        } as Puppeteer.Response;
+        pageMock.setup((p) => p.lastBrowserError).returns(() => undefined);
+        pageMock.setup((p) => p.isOpen()).returns(() => true);
+        pageMock.setup((p) => p.navigationResponse).returns(() => navigationResponseStub);
+    }
+
+    function createPageScanReport(hasBanner: boolean, cookieCollectionResults: ConsentResult[]): PrivacyPageScanReport {
+        return {
+            FinishDateTime: currentDate,
+            NavigationalUri: url,
+            SeedUri: url,
+            HttpStatusCode: 200,
+            BannerDetectionXpathExpression: privacyConfig.bannerXPath,
+            BannerDetected: hasBanner,
+            CookieCollectionConsentResults: cookieCollectionResults,
+        };
+    }
+});

--- a/packages/scanner-global-library/src/privacy-page-scanner.ts
+++ b/packages/scanner-global-library/src/privacy-page-scanner.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { PrivacyScanConfig, ServiceConfiguration } from 'common';
+import { inject, injectable } from 'inversify';
+import _ from 'lodash';
+import { ConsentResult } from 'storage-documents';
+import { PrivacyScanResult } from './privacy-scan-result';
+import { Page } from './page';
+
+@injectable()
+export class PrivacyPageScanner {
+    constructor(
+        @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
+        private readonly getCurrentDate: () => Date = () => new Date(),
+    ) {}
+
+    public async scanPageForPrivacy(page: Page): Promise<PrivacyScanResult> {
+        if (!_.isNil(page.lastBrowserError)) {
+            return { error: page.lastBrowserError, pageResponseCode: page.lastBrowserError.statusCode };
+        }
+
+        if (!page.isOpen()) {
+            throw new Error(`Page is not ready. Call create() and navigateToUrl() before scan.`);
+        }
+
+        const privacyScanConfig = await this.serviceConfig.getConfigValue('privacyScanConfig');
+
+        const hasBanner = await this.hasBanner(page, privacyScanConfig);
+        const cookieCollectionResults: ConsentResult[] = []; // TBD
+
+        return {
+            pageResponseCode: page.navigationResponse.status(),
+            scannedUrl: page.currentPage.url(),
+            results: {
+                FinishDateTime: this.getCurrentDate(),
+                NavigationalUri: page.currentPage.url(),
+                SeedUri: page.currentPage.url(),
+                HttpStatusCode: page.navigationResponse.status(),
+                BannerDetectionXpathExpression: privacyScanConfig.bannerXPath,
+                BannerDetected: hasBanner,
+                CookieCollectionConsentResults: cookieCollectionResults,
+            },
+        };
+    }
+
+    public async hasBanner(page: Page, privacyScanConfig: PrivacyScanConfig): Promise<boolean> {
+        try {
+            await page.currentPage.waitForXPath(privacyScanConfig.bannerXPath, {
+                timeout: privacyScanConfig.bannerDetectionTimeout,
+            });
+
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+}

--- a/packages/scanner-global-library/src/privacy-page-scanner.ts
+++ b/packages/scanner-global-library/src/privacy-page-scanner.ts
@@ -10,10 +10,7 @@ import { Page } from './page';
 
 @injectable()
 export class PrivacyPageScanner {
-    constructor(
-        @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
-        private readonly getCurrentDate: () => Date = () => new Date(),
-    ) {}
+    constructor(@inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration) {}
 
     public async scanPageForPrivacy(page: Page): Promise<PrivacyScanResult> {
         if (!_.isNil(page.lastBrowserError)) {
@@ -33,7 +30,7 @@ export class PrivacyPageScanner {
             pageResponseCode: page.navigationResponse.status(),
             scannedUrl: page.currentPage.url(),
             results: {
-                FinishDateTime: this.getCurrentDate(),
+                FinishDateTime: new Date(),
                 NavigationalUri: page.currentPage.url(),
                 SeedUri: page.currentPage.url(),
                 HttpStatusCode: page.navigationResponse.status(),

--- a/packages/scanner-global-library/src/privacy-scan-result.ts
+++ b/packages/scanner-global-library/src/privacy-scan-result.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { PrivacyPageScanReport } from 'storage-documents';
 import { BrowserError } from './browser-error';
 
 export interface PrivacyScanResult {
-    results?: unknown; // TBD
+    results?: PrivacyPageScanReport;
     error?: string | BrowserError;
     pageResponseCode?: number;
     scannedUrl?: string;

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -54,6 +54,7 @@
         "puppeteer": "^5.5.0",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
+        "scanner-global-library": "^1.0.0",
         "storage-documents": "1.0.0",
         "yargs": "^17.3.1"
     }

--- a/packages/service-library/src/dev-utilities/banner-detection-test.ts
+++ b/packages/service-library/src/dev-utilities/banner-detection-test.ts
@@ -106,6 +106,8 @@ async function scanAllUrls(urls: string[]): Promise<BannerDetectionResults> {
         errors: [],
     };
 
+    // Process urls sequentially because opening all URLs in parallel can affect load times
+    // and prevent the banner from being detected
     for (const url of urls) {
         const page = await openUrl(url);
         const privacyScanResult = await privacyPageScanner.scanPageForPrivacy(page);

--- a/packages/service-library/src/dev-utilities/banner-detection-test.ts
+++ b/packages/service-library/src/dev-utilities/banner-detection-test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import fs from 'fs';
+import readline from 'readline';
+import {
+    BrowserError,
+    Page,
+    PageConfigurator,
+    PageHandler,
+    PageNavigator,
+    PageResponseProcessor,
+    PrivacyPageScanner,
+    WebDriver,
+} from 'scanner-global-library';
+import { ConsoleLoggerClient, GlobalLogger } from 'logger';
+import { PromiseUtils, ServiceConfiguration } from 'common';
+import yargs from 'yargs';
+import _ from 'lodash';
+
+type BannerDetectionTestArgs = {
+    urlsListPath: string;
+    outputPath: string;
+};
+
+type BannerDetectionError = {
+    url: string;
+    error: string | BrowserError;
+    pageResponseCode?: number;
+};
+
+type BannerDetectionResults = {
+    urlsWithBanner: string[];
+    urlsWithoutBanner: string[];
+    errors: BannerDetectionError[];
+};
+
+const serviceConfig = new ServiceConfiguration();
+const logger = new GlobalLogger([new ConsoleLoggerClient(serviceConfig, console)], process);
+const webDriver = new WebDriver(new PromiseUtils(), logger);
+const pageNavigator = new PageNavigator(new PageConfigurator(), new PageResponseProcessor(), new PageHandler(logger));
+const privacyPageScanner = new PrivacyPageScanner(serviceConfig);
+
+function getArguments(): BannerDetectionTestArgs {
+    yargs.option<keyof BannerDetectionTestArgs, yargs.Options>('urlsListPath', {
+        alias: 'p',
+        demandOption: true,
+        description: 'The path to a file containing a newline-separated list of urls to test',
+    });
+
+    yargs.option<keyof BannerDetectionTestArgs, yargs.Options>('outputPath', {
+        alias: 'o',
+        default: './banner-detection-results.json',
+        description: 'The path or filename to store banner detection results (in json format). Defaults to ./banner-detection-results.json',
+    });
+
+    yargs.wrap(yargs.terminalWidth()).describe('help', 'Show help');
+
+    return yargs.argv as yargs.Arguments<BannerDetectionTestArgs>;
+}
+
+function validateArguments(args: BannerDetectionTestArgs): boolean {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (!fs.existsSync(args.urlsListPath)) {
+        logger.logError(`Input file path ${args.urlsListPath} does not exist`);
+
+        return false;
+    }
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (fs.existsSync(args.outputPath)) {
+        const rl = readline.createInterface(process.stdin, process.stdout);
+        let shouldContinue = false;
+        rl.question(`File ${args.outputPath} already exists. Continue and overwrite the file? (y/n)`, (response) => {
+            if (response.toLowerCase() === 'y') {
+                shouldContinue = true;
+            }
+            rl.close();
+        });
+
+        return shouldContinue;
+    }
+
+    return true;
+}
+
+async function openUrl(url: string): Promise<Page> {
+    const page = new Page(webDriver, undefined, pageNavigator, logger);
+    await page.create();
+    await page.navigateToUrl(url);
+
+    return page;
+}
+
+function readUrlsList(filename: string): string[] {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const lines = fs.readFileSync(filename).toString().split('\n');
+
+    return lines.map((line) => line.trim()).filter((str) => !_.isEmpty(str));
+}
+
+async function scanAllUrls(urls: string[]): Promise<BannerDetectionResults> {
+    const results: BannerDetectionResults = {
+        urlsWithBanner: [],
+        urlsWithoutBanner: [],
+        errors: [],
+    };
+
+    await Promise.all(
+        urls.map(async (url) => {
+            const page = await openUrl(url);
+            const privacyScanResult = await privacyPageScanner.scanPageForPrivacy(page);
+
+            if (privacyScanResult.error !== undefined || privacyScanResult.results === undefined) {
+                results.errors.push({
+                    url,
+                    error: privacyScanResult.error,
+                    pageResponseCode: privacyScanResult.pageResponseCode,
+                });
+            } else if (privacyScanResult.results.BannerDetected) {
+                results.urlsWithBanner.push(url);
+            } else {
+                results.urlsWithoutBanner.push(url);
+            }
+        }),
+    );
+
+    return results;
+}
+
+function saveResults(results: BannerDetectionResults, filename: string): void {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(filename, JSON.stringify(results));
+}
+
+(async () => {
+    const args = getArguments();
+    if (!validateArguments(args)) {
+        return;
+    }
+
+    await logger.setup();
+
+    const urls = readUrlsList(args.urlsListPath);
+    logger.logInfo(`Found ${urls.length} URLs in file ${args.urlsListPath}. Beginning privacy scanning...`);
+
+    const results = await scanAllUrls(urls);
+
+    logger.logInfo('Completed banner detection test for all URLs.');
+    logger.logInfo(
+        `Detected banner on ${results.urlsWithBanner.length} out of ${urls.length} total URLs. ${results.errors.length} URLs failed to scan.`,
+    );
+    logger.logInfo(`Saving JSON results to ${args.outputPath}`);
+
+    saveResults(results, args.outputPath);
+
+    webDriver.close();
+})().catch((e) => logger.logError(e));

--- a/packages/service-library/src/dev-utilities/banner-detection-test.ts
+++ b/packages/service-library/src/dev-utilities/banner-detection-test.ts
@@ -107,24 +107,24 @@ async function scanAllUrls(urls: string[]): Promise<BannerDetectionResults> {
         errors: [],
     };
 
-    await Promise.all(
-        urls.map(async (url) => {
-            const page = await openUrl(url);
-            const privacyScanResult = await privacyPageScanner.scanPageForPrivacy(page);
+    for (const url of urls) {
+        const page = await openUrl(url);
+        const privacyScanResult = await privacyPageScanner.scanPageForPrivacy(page);
 
-            if (privacyScanResult.error !== undefined || privacyScanResult.results === undefined) {
-                results.errors.push({
-                    url,
-                    error: privacyScanResult.error,
-                    pageResponseCode: privacyScanResult.pageResponseCode,
-                });
-            } else if (privacyScanResult.results.BannerDetected) {
-                results.urlsWithBanner.push(url);
-            } else {
-                results.urlsWithoutBanner.push(url);
-            }
-        }),
-    );
+        if (privacyScanResult.error !== undefined || privacyScanResult.results === undefined) {
+            results.errors.push({
+                url,
+                error: privacyScanResult.error,
+                pageResponseCode: privacyScanResult.pageResponseCode,
+            });
+        } else if (privacyScanResult.results.BannerDetected) {
+            results.urlsWithBanner.push(url);
+        } else {
+            results.urlsWithoutBanner.push(url);
+        }
+
+        page.currentPage.close();
+    }
 
     return results;
 }

--- a/packages/service-library/src/dev-utilities/banner-detection-test.ts
+++ b/packages/service-library/src/dev-utilities/banner-detection-test.ts
@@ -122,7 +122,7 @@ async function scanAllUrls(urls: string[]): Promise<BannerDetectionResults> {
             results.urlsWithoutBanner.push(url);
         }
 
-        page.currentPage.close();
+        page.close();
     }
 
     return results;
@@ -153,6 +153,4 @@ function saveResults(results: BannerDetectionResults, filename: string): void {
     logger.logInfo(`Saving JSON results to ${args.outputPath}`);
 
     saveResults(results, args.outputPath);
-
-    webDriver.close();
 })().catch((e) => logger.logError(e));

--- a/packages/storage-documents/src/index.ts
+++ b/packages/storage-documents/src/index.ts
@@ -14,3 +14,5 @@ export * from './on-demand-notification-request-message';
 export * from './batch-pool-load-snapshot';
 export * from './website-scan-result';
 export * from './combined-scan-results';
+export * from './privacy-scan-types/privacy-page-scan-report';
+export * from './privacy-scan-types/privacy-scan-combined-report';

--- a/packages/storage-documents/src/privacy-scan-types/privacy-page-scan-report.ts
+++ b/packages/storage-documents/src/privacy-scan-types/privacy-page-scan-report.ts
@@ -4,13 +4,9 @@
 export interface PrivacyPageScanReport {
     FinishDateTime: Date;
     NavigationalUri: string;
-    SeedUrl: string;
+    SeedUri: string;
     HttpStatusCode: number;
-    Cookies: CookieByDomain[];
-    CookiesBeforeConsent: CookieByDomain;
-    CookiesAfterConsent: CookieByDomain;
     CookieCollectionConsentResults: ConsentResult[];
-    MultiLoadResults?: MultiLoadResult[];
     BannerDetected: boolean;
     BannerDetectionXpathExpression: string;
     ConsentModalValidationResult?: ConsentModalValidationResult;


### PR DESCRIPTION
#### Details

Create PrivacyPageScanner, which takes a Page object, checks for the banner XPath, and returns a (currently incomplete) privacy scan report

##### Motivation

Detect the privacy banner on a page

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
