### PR TITLE
Collect cookies for consent scenarios

### DIFF
--- a/packages/privacy-scan-core/src/cookie-collector.spec.ts
+++ b/packages/privacy-scan-core/src/cookie-collector.spec.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import * as Puppeteer from 'puppeteer';
+import { IMock, Mock, Times } from 'typemoq';
+import { ConsentResult, CookieByDomain } from 'storage-documents';
+import _ from 'lodash';
+import { CookieCollector } from './cookie-collector';
+import { CookieScenario } from './cookie-scenarios';
+
+describe(CookieCollector, () => {
+    const cookieScenario: CookieScenario = {
+        name: 'cookieName',
+        value: 'test cookie value',
+    };
+    const url = 'test url';
+    const expiryDate = new Date(0, 1, 2, 3);
+
+    let pageCookies: Puppeteer.Cookie[];
+    let pageCookiesByDomain: CookieByDomain[];
+    let puppeteerPageMock: IMock<Puppeteer.Page>;
+    let reloadPageMock: IMock<(page: Puppeteer.Page) => Promise<void>>;
+
+    let testSubject: CookieCollector;
+
+    beforeEach(() => {
+        puppeteerPageMock = Mock.ofType<Puppeteer.Page>();
+        reloadPageMock = Mock.ofInstance(() => undefined);
+        pageCookies = [
+            {
+                name: 'domain1cookie1',
+                domain: 'domain1',
+                expires: expiryDate.getTime(),
+            },
+            {
+                name: 'domain1cookie2',
+                domain: 'domain1',
+                expires: expiryDate.getTime(),
+            },
+            {
+                name: 'domain2cookie',
+                domain: 'domain2',
+                expires: expiryDate.getTime(),
+            },
+        ] as Puppeteer.Cookie[];
+        pageCookiesByDomain = [
+            {
+                Domain: 'domain1',
+                Cookies: [
+                    { Name: 'domain1cookie1', Domain: 'domain1', Expires: expiryDate },
+                    { Name: 'domain1cookie2', Domain: 'domain1', Expires: expiryDate },
+                ],
+            },
+            {
+                Domain: 'domain2',
+                Cookies: [{ Name: 'domain2cookie', Domain: 'domain2', Expires: expiryDate }],
+            },
+        ];
+        puppeteerPageMock.setup((p) => p.cookies()).returns(async () => pageCookies);
+        puppeteerPageMock.setup((p) => p.url()).returns(() => url);
+
+        testSubject = new CookieCollector();
+    });
+
+    afterEach(() => {
+        puppeteerPageMock.verifyAll();
+        reloadPageMock.verifyAll();
+    });
+
+    it('Gets cookies before and after consent', async () => {
+        const newCookie = {
+            name: 'new cookie',
+            domain: 'new domain',
+            expires: expiryDate.getTime(),
+        } as Puppeteer.Cookie;
+        const expectedResult: ConsentResult = {
+            CookiesUsedForConsent: `${cookieScenario.name}=${cookieScenario.value}`,
+            CookiesBeforeConsent: pageCookiesByDomain,
+            CookiesAfterConsent: [
+                ...pageCookiesByDomain,
+                {
+                    Domain: 'new domain',
+                    Cookies: [
+                        {
+                            Domain: 'new domain',
+                            Name: 'new cookie',
+                            Expires: expiryDate,
+                        },
+                    ],
+                },
+            ],
+        };
+        setupClearCookies();
+        setupLoadPageWithCookie([newCookie]);
+        reloadPageMock.setup((r) => r(puppeteerPageMock.object)).verifiable(Times.exactly(2));
+
+        const actualResults = await testSubject.getCookiesForScenario(puppeteerPageMock.object, cookieScenario, reloadPageMock.object);
+
+        expect(actualResults).toEqual(expectedResult);
+    });
+
+    function setupClearCookies(): void {
+        puppeteerPageMock.setup((p) => p.deleteCookie(...pageCookies)).verifiable();
+    }
+
+    function setupLoadPageWithCookie(newCookiesAfterLoad: Puppeteer.Cookie[]): void {
+        puppeteerPageMock
+            .setup((p) => p.setCookie(cookieScenario))
+            .returns(async () => {
+                pageCookies.push(...newCookiesAfterLoad);
+            })
+            .verifiable();
+    }
+});

--- a/packages/privacy-scan-core/src/cookie-collector.ts
+++ b/packages/privacy-scan-core/src/cookie-collector.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { injectable } from 'inversify';
+import _ from 'lodash';
+import { ConsentResult, CookieByDomain } from 'storage-documents';
+import * as Puppeteer from 'puppeteer';
+import { CookieScenario } from './cookie-scenarios';
+
+@injectable()
+export class CookieCollector {
+    public async getCookiesForScenario(
+        page: Puppeteer.Page,
+        cookieScenario: CookieScenario,
+        reloadPage: (page: Puppeteer.Page) => Promise<void>,
+    ): Promise<ConsentResult> {
+        await this.clearCookies(page, reloadPage);
+
+        const cookiesBeforeConsent = await this.getCurrentCookies(page);
+
+        await this.reloadWithCookie(page, cookieScenario, reloadPage);
+
+        const cookiesAfterConsent = await this.getCurrentCookies(page);
+
+        return {
+            CookiesUsedForConsent: `${cookieScenario.name}=${cookieScenario.value}`,
+            CookiesBeforeConsent: cookiesBeforeConsent,
+            CookiesAfterConsent: cookiesAfterConsent,
+        };
+    }
+
+    private async getCurrentCookies(page: Puppeteer.Page): Promise<CookieByDomain[]> {
+        const results: CookieByDomain[] = [];
+        const cookies = await page.cookies();
+        const groupedCookies = _.groupBy(cookies, (cookie) => cookie.domain);
+        Object.keys(groupedCookies).forEach((domain) => {
+            results.push({
+                Domain: domain,
+                Cookies: groupedCookies[domain].map((c) => {
+                    return {
+                        Name: c.name,
+                        Domain: c.domain,
+                        Expires: new Date(c.expires),
+                    };
+                }),
+            });
+        });
+
+        return results;
+    }
+
+    private async clearCookies(page: Puppeteer.Page, reloadPage: (page: Puppeteer.Page) => Promise<void>): Promise<void> {
+        await page.deleteCookie(...(await page.cookies()));
+        await reloadPage(page);
+    }
+
+    private async reloadWithCookie(
+        page: Puppeteer.Page,
+        cookieScenario: CookieScenario,
+        reloadPage: (page: Puppeteer.Page) => Promise<void>,
+    ): Promise<void> {
+        await page.setCookie(cookieScenario);
+        await reloadPage(page);
+    }
+}

--- a/packages/privacy-scan-core/src/cookie-collector.ts
+++ b/packages/privacy-scan-core/src/cookie-collector.ts
@@ -13,16 +13,16 @@ export class CookieCollector {
     public async getCookiesForScenario(
         page: Puppeteer.Page,
         cookieScenario: CookieScenario,
-        reloadPage: ReloadPageFunc,
+        reloadPageFunc: ReloadPageFunc,
     ): Promise<ConsentResult> {
-        let reloadResponse = await this.clearCookies(page, reloadPage);
+        let reloadResponse = await this.clearCookies(page, reloadPageFunc);
         if (!reloadResponse.success) {
             return { Error: reloadResponse.error };
         }
 
         const cookiesBeforeConsent = await this.getCurrentCookies(page);
 
-        reloadResponse = await this.reloadWithCookie(page, cookieScenario, reloadPage);
+        reloadResponse = await this.reloadWithCookie(page, cookieScenario, reloadPageFunc);
         if (!reloadResponse.success) {
             return { Error: reloadResponse.error };
         }
@@ -56,19 +56,19 @@ export class CookieCollector {
         return results;
     }
 
-    private async clearCookies(page: Puppeteer.Page, reloadPage: ReloadPageFunc): Promise<ReloadPageResponse> {
+    private async clearCookies(page: Puppeteer.Page, reloadPageFunc: ReloadPageFunc): Promise<ReloadPageResponse> {
         await page.deleteCookie(...(await page.cookies()));
 
-        return reloadPage(page);
+        return reloadPageFunc(page);
     }
 
     private async reloadWithCookie(
         page: Puppeteer.Page,
         cookieScenario: CookieScenario,
-        reloadPage: ReloadPageFunc,
+        reloadPageFunc: ReloadPageFunc,
     ): Promise<ReloadPageResponse> {
         await page.setCookie(cookieScenario);
 
-        return reloadPage(page);
+        return reloadPageFunc(page);
     }
 }

--- a/packages/privacy-scan-core/src/cookie-scenarios.ts
+++ b/packages/privacy-scan-core/src/cookie-scenarios.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type CookieScenario = {
+    name: string;
+    value: string;
+};
+
+export const getAllCookieScenarios = (): CookieScenario[] => {
+    const timestamp = Date.now();
+
+    return [
+        {
+            name: 'MSCC',
+            value: `${timestamp}`,
+        },
+        {
+            name: 'MSCC',
+            value: 'cid=3nqibqsmahlqkom8tlvlek2q-c1=2-c2=0-c3=0',
+        },
+        {
+            name: 'MSCC',
+            value: 'cid=3nqibqsmahlqkom8tlvlek2q-c1=0-c2=2-c3=0',
+        },
+        {
+            name: 'MSCC',
+            value: 'cid=3nqibqsmahlqkom8tlvlek2q-c1=0-c2=0-c3=2',
+        },
+        {
+            name: 'MSCC',
+            value: 'cid=3nqibqsmahlqkom8tlvlek2q-c1=2-c2=2-c3=2',
+        },
+    ];
+};

--- a/packages/privacy-scan-core/src/index.ts
+++ b/packages/privacy-scan-core/src/index.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export { PrivacyResults, PrivacyPageScanner } from './privacy-page-scanner';
+export { PrivacyPageScanner } from './privacy-page-scanner';
 export { CookieCollector } from './cookie-collector';
+export * from './types';

--- a/packages/privacy-scan-core/src/index.ts
+++ b/packages/privacy-scan-core/src/index.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 export { PrivacyResults, PrivacyPageScanner } from './privacy-page-scanner';
+export { CookieCollector } from './cookie-collector';

--- a/packages/privacy-scan-core/src/privacy-page-scanner.spec.ts
+++ b/packages/privacy-scan-core/src/privacy-page-scanner.spec.ts
@@ -9,9 +9,11 @@ import * as Puppeteer from 'puppeteer';
 import { ConsentResult } from 'storage-documents';
 import * as MockDate from 'mockdate';
 import _ from 'lodash';
-import { PrivacyPageScanner, PrivacyResults } from './privacy-page-scanner';
+import { PrivacyPageScanner } from './privacy-page-scanner';
 import { CookieCollector } from './cookie-collector';
 import { CookieScenario } from './cookie-scenarios';
+import { PrivacyResults } from './types';
+import { ReloadPageFunc } from '.';
 
 describe(PrivacyPageScanner, () => {
     const privacyConfig: PrivacyScanConfig = {
@@ -36,7 +38,7 @@ describe(PrivacyPageScanner, () => {
             value: 'cookie value 2',
         },
     ];
-    const reloadPageStub: (page: Puppeteer.Page) => Promise<void> = async () => undefined;
+    const reloadPageStub: ReloadPageFunc = async () => undefined;
 
     let serviceConfigMock: IMock<ServiceConfiguration>;
     let puppeteerPageMock: IMock<Puppeteer.Page>;

--- a/packages/privacy-scan-core/src/privacy-page-scanner.spec.ts
+++ b/packages/privacy-scan-core/src/privacy-page-scanner.spec.ts
@@ -8,7 +8,10 @@ import { IMock, Mock } from 'typemoq';
 import * as Puppeteer from 'puppeteer';
 import { ConsentResult } from 'storage-documents';
 import * as MockDate from 'mockdate';
+import _ from 'lodash';
 import { PrivacyPageScanner, PrivacyResults } from './privacy-page-scanner';
+import { CookieCollector } from './cookie-collector';
+import { CookieScenario } from './cookie-scenarios';
 
 describe(PrivacyPageScanner, () => {
     const privacyConfig: PrivacyScanConfig = {
@@ -17,9 +20,27 @@ describe(PrivacyPageScanner, () => {
     };
     const url = 'test url';
     const currentDate = new Date(1, 2, 3, 4);
+    const consentResult: ConsentResult = {
+        CookiesUsedForConsent: 'cookie',
+        CookiesAfterConsent: [],
+        CookiesBeforeConsent: [],
+    };
+    const expectedCookieCollectionResults = [_.clone(consentResult), _.clone(consentResult)];
+    const cookieScenarios: CookieScenario[] = [
+        {
+            name: 'MSCC',
+            value: 'cookie value 1',
+        },
+        {
+            name: 'MSCC',
+            value: 'cookie value 2',
+        },
+    ];
+    const reloadPageStub: (page: Puppeteer.Page) => Promise<void> = async () => undefined;
 
     let serviceConfigMock: IMock<ServiceConfiguration>;
     let puppeteerPageMock: IMock<Puppeteer.Page>;
+    let cookieCollectorMock: IMock<CookieCollector>;
 
     let testSubject: PrivacyPageScanner;
 
@@ -28,47 +49,59 @@ describe(PrivacyPageScanner, () => {
         puppeteerPageMock = Mock.ofType<Puppeteer.Page>();
         serviceConfigMock.setup((c) => c.getConfigValue('privacyScanConfig')).returns(async () => privacyConfig);
         puppeteerPageMock.setup((p) => p.url()).returns(() => url);
+        cookieCollectorMock = Mock.ofType<CookieCollector>();
         MockDate.set(currentDate);
 
-        testSubject = new PrivacyPageScanner(serviceConfigMock.object);
+        testSubject = new PrivacyPageScanner(serviceConfigMock.object, cookieCollectorMock.object, () => cookieScenarios);
     });
 
     afterEach(() => {
         puppeteerPageMock.verifyAll();
     });
 
-    it('Returns hasBanner=true if default XPath is found', async () => {
-        const expectedResult = createPageScanReport(true, []);
+    it('Returns expected cookies and hasBanner=true if default XPath is found', async () => {
+        const expectedResult = createPageScanReport(true);
         puppeteerPageMock
             .setup((p) => p.waitForXPath(privacyConfig.bannerXPath, { timeout: privacyConfig.bannerDetectionTimeout }))
             .returns(async () => undefined)
             .verifiable();
+        setupCollectCookies();
 
-        const result = await testSubject.scanPageForPrivacy(puppeteerPageMock.object);
+        const result = await testSubject.scanPageForPrivacy(puppeteerPageMock.object, reloadPageStub);
 
         expect(result).toEqual(expectedResult);
     });
 
-    it('Returns hasBanner=false if XPath not found', async () => {
-        const expectedResult = createPageScanReport(false, []);
+    it('Returns expected cookies and hasBanner=false if XPath not found', async () => {
+        const expectedResult = createPageScanReport(false);
         puppeteerPageMock
             .setup((p) => p.waitForXPath(privacyConfig.bannerXPath, { timeout: privacyConfig.bannerDetectionTimeout }))
             .throws(new Error())
             .verifiable();
+        setupCollectCookies();
 
-        const result = await testSubject.scanPageForPrivacy(puppeteerPageMock.object);
+        const result = await testSubject.scanPageForPrivacy(puppeteerPageMock.object, reloadPageStub);
 
         expect(result).toEqual(expectedResult);
     });
 
-    function createPageScanReport(hasBanner: boolean, cookieCollectionResults: ConsentResult[]): PrivacyResults {
+    function createPageScanReport(hasBanner: boolean): PrivacyResults {
         return {
             FinishDateTime: currentDate,
             NavigationalUri: url,
             SeedUri: url,
             BannerDetectionXpathExpression: privacyConfig.bannerXPath,
             BannerDetected: hasBanner,
-            CookieCollectionConsentResults: cookieCollectionResults,
+            CookieCollectionConsentResults: expectedCookieCollectionResults,
         };
+    }
+
+    function setupCollectCookies(): void {
+        cookieScenarios.forEach((scenario) => {
+            cookieCollectorMock
+                .setup((cc) => cc.getCookiesForScenario(puppeteerPageMock.object, scenario, reloadPageStub))
+                .returns(async () => consentResult)
+                .verifiable();
+        });
     }
 });

--- a/packages/privacy-scan-core/src/privacy-page-scanner.ts
+++ b/packages/privacy-scan-core/src/privacy-page-scanner.ts
@@ -7,12 +7,12 @@
 import { PrivacyScanConfig, ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import _ from 'lodash';
-import { ConsentResult, PrivacyPageScanReport } from 'storage-documents';
+import { ConsentResult } from 'storage-documents';
 import * as Puppeteer from 'puppeteer';
 import { CookieScenario, getAllCookieScenarios } from './cookie-scenarios';
 import { CookieCollector } from './cookie-collector';
-
-export type PrivacyResults = Omit<PrivacyPageScanReport, 'HttpStatusCode'>;
+import { PrivacyResults } from './types';
+import { ReloadPageFunc } from '.';
 
 @injectable()
 export class PrivacyPageScanner {
@@ -22,7 +22,7 @@ export class PrivacyPageScanner {
         private readonly getCookieScenarios: () => CookieScenario[] = getAllCookieScenarios,
     ) {}
 
-    public async scanPageForPrivacy(page: Puppeteer.Page, reloadPage: (page: Puppeteer.Page) => Promise<void>): Promise<PrivacyResults> {
+    public async scanPageForPrivacy(page: Puppeteer.Page, reloadPage: ReloadPageFunc): Promise<PrivacyResults> {
         const privacyScanConfig = await this.serviceConfig.getConfigValue('privacyScanConfig');
 
         const hasBanner = await this.hasBanner(page, privacyScanConfig);
@@ -50,10 +50,7 @@ export class PrivacyPageScanner {
         }
     }
 
-    private async getAllConsentResults(
-        page: Puppeteer.Page,
-        reloadPage: (page: Puppeteer.Page) => Promise<void>,
-    ): Promise<ConsentResult[]> {
+    private async getAllConsentResults(page: Puppeteer.Page, reloadPage: ReloadPageFunc): Promise<ConsentResult[]> {
         const results: ConsentResult[] = [];
         const scenarios = this.getCookieScenarios();
 

--- a/packages/privacy-scan-core/src/privacy-page-scanner.ts
+++ b/packages/privacy-scan-core/src/privacy-page-scanner.ts
@@ -22,11 +22,11 @@ export class PrivacyPageScanner {
         private readonly getCookieScenarios: () => CookieScenario[] = getAllCookieScenarios,
     ) {}
 
-    public async scanPageForPrivacy(page: Puppeteer.Page, reloadPage: ReloadPageFunc): Promise<PrivacyResults> {
+    public async scanPageForPrivacy(page: Puppeteer.Page, reloadPageFunc: ReloadPageFunc): Promise<PrivacyResults> {
         const privacyScanConfig = await this.serviceConfig.getConfigValue('privacyScanConfig');
 
         const hasBanner = await this.hasBanner(page, privacyScanConfig);
-        const cookieCollectionResults = await this.getAllConsentResults(page, reloadPage);
+        const cookieCollectionResults = await this.getAllConsentResults(page, reloadPageFunc);
 
         return {
             FinishDateTime: new Date(),
@@ -50,13 +50,13 @@ export class PrivacyPageScanner {
         }
     }
 
-    private async getAllConsentResults(page: Puppeteer.Page, reloadPage: ReloadPageFunc): Promise<ConsentResult[]> {
+    private async getAllConsentResults(page: Puppeteer.Page, reloadPageFunc: ReloadPageFunc): Promise<ConsentResult[]> {
         const results: ConsentResult[] = [];
         const scenarios = this.getCookieScenarios();
 
         // Test sequentially so that cookie values don't interfere with each other
         for (const scenario of scenarios) {
-            results.push(await this.cookieCollector.getCookiesForScenario(page, scenario, reloadPage));
+            results.push(await this.cookieCollector.getCookiesForScenario(page, scenario, reloadPageFunc));
         }
 
         return results;

--- a/packages/privacy-scan-core/src/types.ts
+++ b/packages/privacy-scan-core/src/types.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { PrivacyPageScanReport } from 'storage-documents';
+import * as Puppeteer from 'puppeteer';
+
+export type PrivacyResults = Omit<PrivacyPageScanReport, 'HttpStatusCode'>;
+
+export type ReloadPageResponse = {
+    success: boolean;
+    error?: unknown;
+};
+
+export type ReloadPageFunc = (page: Puppeteer.Page) => Promise<ReloadPageResponse>;

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -217,7 +217,7 @@ describe(Page, () => {
 
         beforeEach(() => {
             simulatePageLaunch();
-            privacyScannerMock.setup((s) => s.scanPageForPrivacy(puppeteerPageMock.object)).returns(async () => privacyResults);
+            privacyScannerMock.setup((s) => s.scanPageForPrivacy(puppeteerPageMock.object, It.isAny())).returns(async () => privacyResults);
         });
 
         it('scan page', async () => {

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -125,6 +125,22 @@ describe(Page, () => {
             expect(axeScanResults).toEqual(expectedAxeScanResults);
         });
 
+        it('handles error thrown by scan engine', async () => {
+            const scanError = new Error('Test error');
+            const expectedResult = { error: `Axe core engine error. ${System.serializeError(scanError)}`, scannedUrl: url };
+
+            puppeteerPageMock.setup((p) => p.url()).returns(() => url);
+            setupAxePuppeteerFactoryMock();
+            axePuppeteerMock.reset();
+            axePuppeteerMock = getPromisableDynamicMock(axePuppeteerMock);
+            axePuppeteerMock.setup((ap) => ap.analyze()).throws(scanError);
+            simulatePageNavigation(puppeteerResponseMock.object);
+
+            const axeScanResults = await page.scanForA11yIssues();
+
+            expect(axeScanResults).toEqual(expectedResult);
+        });
+
         it('scan page without redirected flag on encoded URL', async () => {
             const requestUrl = 'http://localhost/страница';
             const encodedRequestUrl = encodeURI(requestUrl);
@@ -233,6 +249,20 @@ describe(Page, () => {
             const privacyScanResults = await page.scanForPrivacy();
 
             expect(privacyScanResults).toEqual(expectedPrivacyScanResults);
+        });
+
+        it('handles error thrown by scan engine', async () => {
+            const scanError = new Error('Test error');
+            const expectedResult = { error: `Privacy scan engine error. ${System.serializeError(scanError)}`, scannedUrl: url };
+
+            puppeteerPageMock.setup((p) => p.url()).returns(() => url);
+            simulatePageNavigation(puppeteerResponseMock.object);
+            privacyScannerMock.reset();
+            privacyScannerMock.setup((p) => p.scanPageForPrivacy(It.isAny(), It.isAny())).throws(scanError);
+
+            const privacyScanResults = await page.scanForPrivacy();
+
+            expect(privacyScanResults).toEqual(expectedResult);
         });
 
         it('scan page with navigation error', async () => {

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -139,7 +139,7 @@ export class Page {
 
     private async scanPageForCookies(): Promise<PrivacyScanResult> {
         const navigationStatusCode = this.navigationResponse.status();
-        const reloadPage = async (page: Puppeteer.Page) => {
+        const reloadPageFunc = async (page: Puppeteer.Page) => {
             await this.navigateToUrl(page.url());
 
             return { success: this.navigationResponse.ok(), error: this.lastBrowserError };
@@ -147,7 +147,7 @@ export class Page {
 
         let privacyResult: PrivacyResults;
         try {
-            privacyResult = await this.privacyPageScanner.scanPageForPrivacy(this.page, reloadPage);
+            privacyResult = await this.privacyPageScanner.scanPageForPrivacy(this.page, reloadPageFunc);
         } catch (error) {
             this.logger?.logError('Privacy scan engine error', { browserError: System.serializeError(error), url: this.page.url() });
 

--- a/packages/service-library/src/dev-utilities/banner-detection-test.ts
+++ b/packages/service-library/src/dev-utilities/banner-detection-test.ts
@@ -10,7 +10,7 @@ import { ConsoleLoggerClient, GlobalLogger } from 'logger';
 import { PromiseUtils, ServiceConfiguration } from 'common';
 import yargs from 'yargs';
 import _ from 'lodash';
-import { PrivacyPageScanner } from 'privacy-scan-core';
+import { PrivacyPageScanner, CookieCollector } from 'privacy-scan-core';
 
 type BannerDetectionTestArgs = {
     urlsListPath: string;
@@ -33,7 +33,7 @@ const serviceConfig = new ServiceConfiguration();
 const logger = new GlobalLogger([new ConsoleLoggerClient(serviceConfig, console)], process);
 const webDriver = new WebDriver(new PromiseUtils(), logger);
 const pageNavigator = new PageNavigator(new PageConfigurator(), new PageResponseProcessor(), new PageHandler(logger));
-const privacyPageScanner = new PrivacyPageScanner(serviceConfig);
+const privacyPageScanner = new PrivacyPageScanner(serviceConfig, new CookieCollector());
 const page = new Page(webDriver, undefined, pageNavigator, privacyPageScanner, logger);
 
 function getArguments(): BannerDetectionTestArgs {

--- a/packages/storage-documents/src/privacy-scan-types/privacy-page-scan-report.ts
+++ b/packages/storage-documents/src/privacy-scan-types/privacy-page-scan-report.ts
@@ -25,9 +25,10 @@ export interface CookieByDomain {
 }
 
 export interface ConsentResult {
-    CookiesUsedForConsent: string;
-    CookiesBeforeConsent: CookieByDomain[];
-    CookiesAfterConsent: CookieByDomain[];
+    CookiesUsedForConsent?: string;
+    CookiesBeforeConsent?: CookieByDomain[];
+    CookiesAfterConsent?: CookieByDomain[];
+    Error?: unknown;
 }
 
 export interface MultiLoadResult {


### PR DESCRIPTION
#### Details

- Add MVP cookie scenarios
- Collect cookies for each scenario

##### Motivation

Enables the privacy scanner to collect cookies for specific consent scenarios and return discovered cookies to WCP

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
