### PR TITLE
Privacy report generation

### DIFF
--- a/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.spec.ts
+++ b/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.spec.ts
@@ -129,7 +129,7 @@ describe(CombinedPrivacyScanResultProcessor, () => {
         };
         websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
         combinedReportProviderMock
-            .setup((c) => c.readCombinedResults(reportId))
+            .setup((c) => c.readCombinedReport(reportId))
             .returns(async () => errorReadResponse)
             .verifiable();
 
@@ -143,7 +143,7 @@ describe(CombinedPrivacyScanResultProcessor, () => {
             .returns(() => reportId)
             .verifiable();
         websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
-        combinedReportProviderMock.setup((c) => c.readCombinedResults(It.isAny())).verifiable(Times.never());
+        combinedReportProviderMock.setup((c) => c.readCombinedReport(It.isAny())).verifiable(Times.never());
         setupCombineReports(undefined);
         setupWriteReport();
         setupUpdateWebsiteScanResult();
@@ -160,7 +160,7 @@ describe(CombinedPrivacyScanResultProcessor, () => {
             },
         };
         websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
-        combinedReportProviderMock.setup((c) => c.readCombinedResults(reportId)).returns(async () => blobNotFoundResponse);
+        combinedReportProviderMock.setup((c) => c.readCombinedReport(reportId)).returns(async () => blobNotFoundResponse);
         setupCombineReports(undefined);
         setupWriteReport();
         setupUpdateWebsiteScanResult();
@@ -241,7 +241,7 @@ describe(CombinedPrivacyScanResultProcessor, () => {
             etag: etag,
         };
         combinedReportProviderMock
-            .setup((c) => c.readCombinedResults(reportId))
+            .setup((c) => c.readCombinedReport(reportId))
             .returns(async () => readResponse)
             .verifiable();
     }

--- a/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.spec.ts
+++ b/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.spec.ts
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { GuidGenerator, RetryHelper } from 'common';
+import _ from 'lodash';
+import { GlobalLogger } from 'logger';
+import { PrivacyScanResult } from 'scanner-global-library';
+import {
+    GeneratedReport,
+    PrivacyReportReadResponse,
+    PrivacyReportWriteResponse,
+    PrivacyScanCombinedReportProvider,
+    WebsiteScanResultProvider,
+} from 'service-library';
+import {
+    OnDemandPageScanReport,
+    OnDemandPageScanResult,
+    PrivacyPageScanReport,
+    PrivacyScanCombinedReport,
+    WebsiteScanResult,
+} from 'storage-documents';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { CombinedPrivacyScanResultProcessor } from './combined-privacy-scan-result-processor';
+import { PrivacyReportReducer } from './privacy-report-reducer';
+
+describe(CombinedPrivacyScanResultProcessor, () => {
+    const reportId = 'report id';
+    const pageScanReport = { HttpStatusCode: 200 } as PrivacyPageScanReport;
+    const combinedReport = { Status: 'Completed' } as PrivacyScanCombinedReport;
+    const privacyResults: PrivacyScanResult = {
+        results: pageScanReport,
+    };
+    const onDemandPageScanReport: OnDemandPageScanReport = {
+        reportId,
+        format: 'consolidated.json',
+        href: 'report href',
+    };
+    let websiteScanResult: WebsiteScanResult;
+    let pageScanResult: OnDemandPageScanResult;
+
+    let combinedReportProviderMock: IMock<PrivacyScanCombinedReportProvider>;
+    let privacyReportReducerMock: IMock<PrivacyReportReducer>;
+    let websiteScanResultProviderMock: IMock<WebsiteScanResultProvider>;
+    let retryHelperMock: IMock<RetryHelper<void>>;
+    let loggerMock: IMock<GlobalLogger>;
+    let guidGeneratorMock: IMock<GuidGenerator>;
+
+    let testSubject: CombinedPrivacyScanResultProcessor;
+
+    beforeEach(() => {
+        combinedReportProviderMock = Mock.ofType<PrivacyScanCombinedReportProvider>();
+        privacyReportReducerMock = Mock.ofType<PrivacyReportReducer>();
+        websiteScanResultProviderMock = Mock.ofType<WebsiteScanResultProvider>();
+        retryHelperMock = Mock.ofType<RetryHelper<void>>();
+        loggerMock = Mock.ofType<GlobalLogger>();
+        guidGeneratorMock = Mock.ofType<GuidGenerator>();
+
+        websiteScanResult = {
+            id: 'website scan result id',
+            reports: [
+                {
+                    reportId,
+                    format: 'consolidated.json',
+                    href: 'report href',
+                },
+            ],
+        } as WebsiteScanResult;
+        pageScanResult = {
+            id: 'page scan id',
+            websiteScanRefs: [
+                {
+                    id: websiteScanResult.id,
+                    scanGroupType: 'consolidated-scan-report',
+                },
+            ],
+            url: 'scan url',
+            reports: [
+                {
+                    reportId: 'page scan report id',
+                    format: 'json',
+                    href: 'page scan report href',
+                },
+            ],
+        } as OnDemandPageScanResult;
+
+        setupRetryHelperMock();
+
+        testSubject = new CombinedPrivacyScanResultProcessor(
+            combinedReportProviderMock.object,
+            privacyReportReducerMock.object,
+            websiteScanResultProviderMock.object,
+            retryHelperMock.object,
+            loggerMock.object,
+            guidGeneratorMock.object,
+        );
+    });
+
+    afterEach(() => {
+        combinedReportProviderMock.verifyAll();
+        privacyReportReducerMock.verifyAll();
+        websiteScanResultProviderMock.verifyAll();
+        retryHelperMock.verifyAll();
+        guidGeneratorMock.verifyAll();
+    });
+
+    it('Does nothing if websiteScanRefs is undefined', async () => {
+        pageScanResult.websiteScanRefs = undefined;
+
+        websiteScanResultProviderMock.setup((w) => w.read(It.isAny())).verifiable(Times.never());
+
+        await testSubject.generateCombinedScanResults(privacyResults, pageScanResult);
+    });
+
+    it('Does nothing if websiteScanRefs is empty', async () => {
+        pageScanResult.websiteScanRefs = [];
+
+        websiteScanResultProviderMock.setup((w) => w.read(It.isAny())).verifiable(Times.never());
+
+        await testSubject.generateCombinedScanResults(privacyResults, pageScanResult);
+    });
+
+    it('Throws if blob read fails', () => {
+        const errorReadResponse: PrivacyReportReadResponse = {
+            error: {
+                errorCode: 'jsonParseError',
+            },
+        };
+        websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
+        combinedReportProviderMock
+            .setup((c) => c.readCombinedResults(reportId))
+            .returns(async () => errorReadResponse)
+            .verifiable();
+
+        expect(async () => testSubject.generateCombinedScanResults(privacyResults, pageScanResult)).rejects.toThrow();
+    });
+
+    it('Creates a new report if none exists', async () => {
+        websiteScanResult.reports = undefined;
+        guidGeneratorMock
+            .setup((gg) => gg.createGuid())
+            .returns(() => reportId)
+            .verifiable();
+        websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
+        combinedReportProviderMock.setup((c) => c.readCombinedResults(It.isAny())).verifiable(Times.never());
+        setupCombineReports(undefined);
+        setupWriteReport();
+        setupUpdateWebsiteScanResult();
+
+        await testSubject.generateCombinedScanResults(privacyResults, pageScanResult);
+
+        expect(pageScanResult.reports).toContain(onDemandPageScanReport);
+    });
+
+    it('Creates a new report if blob is not found', async () => {
+        const blobNotFoundResponse: PrivacyReportReadResponse = {
+            error: {
+                errorCode: 'blobNotFound',
+            },
+        };
+        websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
+        combinedReportProviderMock.setup((c) => c.readCombinedResults(reportId)).returns(async () => blobNotFoundResponse);
+        setupCombineReports(undefined);
+        setupWriteReport();
+        setupUpdateWebsiteScanResult();
+
+        await testSubject.generateCombinedScanResults(privacyResults, pageScanResult);
+
+        expect(pageScanResult.reports).toContain(onDemandPageScanReport);
+    });
+
+    it('Combines with existing combined report if it exists', async () => {
+        const etag = 'etag';
+        websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
+        setupReadReport(etag);
+        setupCombineReports(combinedReport);
+        setupWriteReport(etag);
+        setupUpdateWebsiteScanResult();
+
+        await testSubject.generateCombinedScanResults(privacyResults, pageScanResult);
+
+        expect(pageScanResult.reports).toContain(onDemandPageScanReport);
+    });
+
+    it('Throws if report write fails', async () => {
+        const errorWriteResponse: PrivacyReportWriteResponse = {
+            error: {
+                errorCode: 'etagMismatch',
+            },
+        };
+        websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
+        setupReadReport('etag');
+        setupCombineReports(combinedReport);
+        combinedReportProviderMock
+            .setup((c) => c.writeCombinedReport(It.isAny(), It.isAny()))
+            .returns(async () => errorWriteResponse)
+            .verifiable();
+        websiteScanResultProviderMock.setup((w) => w.mergeOrCreate(It.isAny(), It.isAny())).verifiable(Times.never());
+
+        expect(async () => testSubject.generateCombinedScanResults(privacyResults, pageScanResult)).rejects.toThrow();
+    });
+
+    it('Handles pageScanResult with undefined report array', async () => {
+        pageScanResult.reports = undefined;
+        const etag = 'etag';
+        websiteScanResultProviderMock.setup((w) => w.read(websiteScanResult.id)).returns(async () => websiteScanResult);
+        setupReadReport(etag);
+        setupCombineReports(combinedReport);
+        setupWriteReport(etag);
+        setupUpdateWebsiteScanResult();
+
+        await testSubject.generateCombinedScanResults(privacyResults, pageScanResult);
+
+        expect(pageScanResult.reports).toBeDefined();
+        expect(pageScanResult.reports).toContain(onDemandPageScanReport);
+    });
+
+    function setupRetryHelperMock(): void {
+        retryHelperMock
+            .setup(async (o) => o.executeWithRetries(It.isAny(), It.isAny(), 5, 1000))
+            .returns(async (action: () => Promise<void>, errorHandler: (err: Error) => Promise<void>, maxRetries: number) => action())
+            .verifiable(Times.once());
+    }
+
+    function setupCombineReports(existingCombinedReport: PrivacyScanCombinedReport): void {
+        privacyReportReducerMock
+            .setup((r) =>
+                r.reduceResults(privacyResults, existingCombinedReport, {
+                    url: pageScanResult.url,
+                    scanId: pageScanResult.id,
+                    websiteScanId: websiteScanResult.id,
+                }),
+            )
+            .returns(() => combinedReport);
+    }
+
+    function setupReadReport(etag: string): void {
+        const readResponse: PrivacyReportReadResponse = {
+            results: combinedReport,
+            etag: etag,
+        };
+        combinedReportProviderMock
+            .setup((c) => c.readCombinedResults(reportId))
+            .returns(async () => readResponse)
+            .verifiable();
+    }
+
+    function setupWriteReport(etag?: string): void {
+        const generatedReport: GeneratedReport = {
+            id: reportId,
+            content: JSON.stringify(combinedReport),
+            format: 'consolidated.json',
+        };
+        const writeResponse: PrivacyReportWriteResponse = {
+            report: onDemandPageScanReport,
+        };
+        combinedReportProviderMock
+            .setup((c) => c.writeCombinedReport(generatedReport, etag))
+            .returns(async () => writeResponse)
+            .verifiable();
+    }
+
+    function setupUpdateWebsiteScanResult(): void {
+        websiteScanResultProviderMock
+            .setup((w) => w.mergeOrCreate(pageScanResult.id, { id: websiteScanResult.id, reports: [onDemandPageScanReport] }))
+            .verifiable();
+    }
+});

--- a/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.ts
+++ b/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.ts
@@ -96,7 +96,7 @@ export class CombinedPrivacyScanResultProcessor {
 
     private async getCombinedReport(blobId: string | undefined): Promise<PrivacyReportReadResponse | undefined> {
         if (blobId === undefined) {
-            this.logger.logInfo('No combined axe scan results blob associated with this website scan. Creating a new blob.');
+            this.logger.logInfo('No combined privacy scan results blob associated with this website scan. Creating a new blob.');
 
             return undefined;
         }
@@ -104,19 +104,21 @@ export class CombinedPrivacyScanResultProcessor {
         const readResponse = await this.combinedReportProvider.readCombinedReport(blobId);
         if (readResponse.error) {
             if (readResponse.error.errorCode === 'blobNotFound') {
-                this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.');
+                this.logger.logWarn('Combined privacy scan results not found in a blob storage. Creating a new blob.');
 
                 return undefined;
             }
 
-            this.logger.logError('Failed to read combined axe results blob.', {
+            this.logger.logError('Failed to read combined privacy results blob.', {
                 error: JSON.stringify(readResponse.error),
             });
 
-            throw new Error(`Failed to read combined axe results blob. Blob Id: ${blobId} Error: ${JSON.stringify(readResponse.error)}`);
+            throw new Error(
+                `Failed to read combined privacy results blob. Blob Id: ${blobId} Error: ${JSON.stringify(readResponse.error)}`,
+            );
         }
 
-        this.logger.logInfo('Successfully retrieved combined axe scan results from a blob storage.');
+        this.logger.logInfo('Successfully retrieved combined privacy scan results from a blob storage.');
 
         return readResponse;
     }
@@ -135,12 +137,14 @@ export class CombinedPrivacyScanResultProcessor {
             etag,
         );
         if (writeResponse.error) {
-            this.logger.logError('Failed to write new combined axe scan results blob.', {
+            this.logger.logError('Failed to write new combined privacy scan results blob.', {
                 error: JSON.stringify(writeResponse.error),
             });
 
             throw new Error(
-                `Failed to write new combined axe scan results blob. Blob Id: ${reportId} Error: ${JSON.stringify(writeResponse.error)}`,
+                `Failed to write new combined privacy scan results blob. Blob Id: ${reportId} Error: ${JSON.stringify(
+                    writeResponse.error,
+                )}`,
             );
         }
 

--- a/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.ts
+++ b/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.ts
@@ -101,7 +101,7 @@ export class CombinedPrivacyScanResultProcessor {
             return undefined;
         }
 
-        const readResponse = await this.combinedReportProvider.readCombinedResults(blobId);
+        const readResponse = await this.combinedReportProvider.readCombinedReport(blobId);
         if (readResponse.error) {
             if (readResponse.error.errorCode === 'blobNotFound') {
                 this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.');

--- a/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.ts
+++ b/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { GlobalLogger } from 'logger';
+import { GuidGenerator, RetryHelper, System } from 'common';
+import { PrivacyReportReadResponse, PrivacyScanCombinedReportProvider, WebsiteScanResultProvider } from 'service-library';
+import { PrivacyScanResult } from 'scanner-global-library';
+import {
+    OnDemandPageScanResult,
+    WebsiteScanResult,
+    WebsiteScanRef,
+    PrivacyScanCombinedReport,
+    OnDemandPageScanReport,
+} from 'storage-documents';
+import { PrivacyReportReducer } from './privacy-report-reducer';
+
+@injectable()
+export class CombinedPrivacyScanResultProcessor {
+    private readonly maxRetryCount: number = 5;
+
+    private readonly msecBetweenRetries: number = 1000;
+
+    constructor(
+        @inject(PrivacyScanCombinedReportProvider) protected readonly combinedReportProvider: PrivacyScanCombinedReportProvider,
+        @inject(PrivacyReportReducer) protected readonly privacyReportReducer: PrivacyReportReducer,
+        @inject(WebsiteScanResultProvider) protected readonly websiteScanResultProvider: WebsiteScanResultProvider,
+        @inject(RetryHelper) private readonly retryHelper: RetryHelper<void>,
+        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+    ) {}
+
+    public async generateCombinedScanResults(privacyScanResults: PrivacyScanResult, pageScanResult: OnDemandPageScanResult): Promise<void> {
+        await this.retryHelper.executeWithRetries(
+            async () => this.generateCombinedScanReportImpl(privacyScanResults, pageScanResult),
+            async (error: Error) => {
+                this.logger.logError(`Failure to generate combined scan result. Retrying on error.`, {
+                    error: System.serializeError(error),
+                });
+            },
+            this.maxRetryCount,
+            this.msecBetweenRetries,
+        );
+    }
+
+    private async generateCombinedScanReportImpl(
+        privacyScanResults: PrivacyScanResult,
+        pageScanResult: OnDemandPageScanResult,
+    ): Promise<void> {
+        const websiteScanRef = this.getWebsiteScanRefs(pageScanResult);
+        if (!websiteScanRef) {
+            return;
+        }
+
+        const websiteScanResult = await this.websiteScanResultProvider.read(websiteScanRef.id);
+        let combinedReportId = websiteScanResult.reports?.find((report) => report.format === 'consolidated.json')?.reportId;
+        const combinedReportReadResponse = await this.getCombinedReport(combinedReportId);
+
+        combinedReportId = combinedReportId || this.guidGenerator.createGuid();
+        this.logger.setCommonProperties({
+            combinedReportId,
+            websiteScanId: combinedReportId,
+        });
+
+        const combinedReport = this.privacyReportReducer.reduceResults(privacyScanResults, combinedReportReadResponse?.results, {
+            scanId: pageScanResult.id,
+            websiteScanId: websiteScanResult.id,
+            url: pageScanResult.url,
+        });
+        const report = await this.writeCombinedReport(combinedReportId, combinedReport, combinedReportReadResponse?.etag);
+
+        const updatedWebsiteScanResults = {
+            id: websiteScanResult.id,
+            reports: [report],
+        } as Partial<WebsiteScanResult>;
+        await this.websiteScanResultProvider.mergeOrCreate(pageScanResult.id, updatedWebsiteScanResults);
+
+        if (report) {
+            if (pageScanResult.reports) {
+                pageScanResult.reports.push(report);
+            } else {
+                pageScanResult.reports = [report];
+            }
+        }
+    }
+
+    private getWebsiteScanRefs(pageScanResult: OnDemandPageScanResult): WebsiteScanRef {
+        if (!pageScanResult.websiteScanRefs) {
+            return undefined;
+        }
+
+        return pageScanResult.websiteScanRefs.find(
+            (ref) => ref.scanGroupType === 'consolidated-scan-report' || ref.scanGroupType === 'deep-scan',
+        );
+    }
+
+    private async getCombinedReport(blobId: string | undefined): Promise<PrivacyReportReadResponse | undefined> {
+        if (blobId === undefined) {
+            this.logger.logInfo('No combined axe scan results blob associated with this website scan. Creating a new blob.');
+
+            return undefined;
+        }
+
+        const readResponse = await this.combinedReportProvider.readCombinedResults(blobId);
+        if (readResponse.error) {
+            if (readResponse.error.errorCode === 'blobNotFound') {
+                this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.');
+
+                return undefined;
+            }
+
+            this.logger.logError('Failed to read combined axe results blob.', {
+                error: JSON.stringify(readResponse.error),
+            });
+
+            throw new Error(`Failed to read combined axe results blob. Blob Id: ${blobId} Error: ${JSON.stringify(readResponse.error)}`);
+        }
+
+        this.logger.logInfo('Successfully retrieved combined axe scan results from a blob storage.');
+
+        return readResponse;
+    }
+
+    private async writeCombinedReport(
+        reportId: string,
+        combinedReport: PrivacyScanCombinedReport,
+        etag?: string,
+    ): Promise<OnDemandPageScanReport> {
+        const writeResponse = await this.combinedReportProvider.writeCombinedReport(
+            {
+                id: reportId,
+                content: JSON.stringify(combinedReport),
+                format: 'consolidated.json',
+            },
+            etag,
+        );
+        if (writeResponse.error) {
+            this.logger.logError('Failed to write new combined axe scan results blob.', {
+                error: JSON.stringify(writeResponse.error),
+            });
+
+            throw new Error(
+                `Failed to write new combined axe scan results blob. Blob Id: ${reportId} Error: ${JSON.stringify(writeResponse.error)}`,
+            );
+        }
+
+        this.logger.logInfo(`The '${writeResponse.report.format}' report saved to a blob storage.`, {
+            reportId: writeResponse.report.reportId,
+            blobUrl: writeResponse.report.href,
+        });
+
+        return writeResponse.report;
+    }
+}

--- a/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.spec.ts
+++ b/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.spec.ts
@@ -1,0 +1,314 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { GuidGenerator } from 'common';
+import { IMock, Mock } from 'typemoq';
+import * as mockDate from 'mockdate';
+import { PrivacyScanResult } from 'scanner-global-library';
+import { FailedUrl, PrivacyPageScanReport, PrivacyScanCombinedReport, PrivacyScanStatus } from 'storage-documents';
+import _ from 'lodash';
+import { PrivacyReportMetadata, PrivacyReportReducer } from './privacy-report-reducer';
+
+describe(PrivacyReportReducer, () => {
+    const metadata: PrivacyReportMetadata = {
+        scanId: 'scan id',
+        websiteScanId: 'website scan id',
+        url: 'url',
+    };
+    const startDate = new Date(1, 2, 3, 4);
+    const currentDate = new Date(5, 6, 7, 8);
+    const successfulScanResult: PrivacyScanResult = {
+        pageResponseCode: 200,
+        results: {
+            HttpStatusCode: 200,
+            FinishDateTime: currentDate,
+            NavigationalUri: 'navigational url',
+            SeedUri: 'seed url',
+            CookieCollectionConsentResults: [
+                {
+                    CookiesUsedForConsent: 'cookie1=value',
+                    CookiesBeforeConsent: [
+                        {
+                            Domain: 'domain1',
+                            Cookies: [{ Name: 'domain1cookie1', Domain: 'domain1' }],
+                        },
+                    ],
+                    CookiesAfterConsent: [
+                        {
+                            Domain: 'domain1',
+                            Cookies: [
+                                { Name: 'domain1cookie1', Domain: 'domain1' },
+                                { Name: 'domain1cookie2', Domain: 'domain1' },
+                            ],
+                        },
+                        {
+                            Domain: 'domain2',
+                            Cookies: [{ Name: 'domain2cookie1', Domain: 'domain2' }],
+                        },
+                    ],
+                },
+                {
+                    CookiesUsedForConsent: 'cookie2=value',
+                    CookiesBeforeConsent: [],
+                    CookiesAfterConsent: [
+                        {
+                            Domain: 'domain2',
+                            Cookies: [{ Name: 'domain2cookie1', Domain: 'domain2' }],
+                        },
+                        {
+                            Domain: 'domain2',
+                            Cookies: [{ Name: 'domain2cookie2', Domain: 'domain2' }],
+                        },
+                    ],
+                },
+            ],
+            BannerDetected: true,
+            BannerDetectionXpathExpression: 'banner xpath',
+        },
+    };
+    const partialScanResult: PrivacyScanResult = {
+        pageResponseCode: 200,
+        error: 'Page reload error',
+        results: {
+            ..._.cloneDeep(successfulScanResult.results),
+            CookieCollectionConsentResults: [
+                ..._.cloneDeep(successfulScanResult.results.CookieCollectionConsentResults),
+                {
+                    CookiesUsedForConsent: 'cookie3=value',
+                    Error: 'First page reload failed',
+                },
+                {
+                    CookiesUsedForConsent: 'cookie4=value',
+                    Error: 'Second page reload failed',
+                    CookiesBeforeConsent: [
+                        {
+                            Domain: 'domain3',
+                            Cookies: [{ Name: 'domain3cookie1', Domain: 'domain3' }],
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+    let guidGeneratorMock: IMock<GuidGenerator>;
+
+    let testSubject: PrivacyReportReducer;
+
+    beforeEach(() => {
+        mockDate.set(currentDate);
+        guidGeneratorMock = Mock.ofType<GuidGenerator>();
+        guidGeneratorMock.setup((gg) => gg.getGuidTimestamp(metadata.scanId)).returns(() => startDate);
+
+        testSubject = new PrivacyReportReducer(guidGeneratorMock.object);
+    });
+
+    afterEach(() => {
+        mockDate.reset();
+    });
+
+    describe('Creates new combined report if none is provided', () => {
+        it('with successful scan result', () => {
+            const expectedReport: PrivacyScanCombinedReport = {
+                ScanId: metadata.websiteScanId,
+                ScanTeamId: 0,
+                ResultScanId: 0,
+                Status: 'Completed',
+                Urls: [metadata.url],
+                FailedUrls: [],
+                ScanCookies: [
+                    { Name: 'domain1cookie1', Domain: 'domain1' },
+                    { Name: 'domain1cookie2', Domain: 'domain1' },
+                    { Name: 'domain2cookie1', Domain: 'domain2' },
+                    { Name: 'domain2cookie2', Domain: 'domain2' },
+                ],
+                CookieCollectionUrlResults: [successfulScanResult.results],
+                StartDateTime: startDate,
+                FinishDateTime: currentDate,
+            };
+
+            const actualReport = testSubject.reduceResults(successfulScanResult, undefined, metadata);
+
+            expect(actualReport).toEqual(expectedReport);
+        });
+
+        it('with failed partial scan result', () => {
+            const failedUrl: FailedUrl = {
+                Url: partialScanResult.results.NavigationalUri,
+                SeedUri: partialScanResult.results.SeedUri,
+                HttpStatusCode: partialScanResult.pageResponseCode,
+                Reason: 'error="Page reload error"',
+                BannerDetected: partialScanResult.results.BannerDetected,
+                BannerDetectionXpathExpression: partialScanResult.results.BannerDetectionXpathExpression,
+            };
+
+            const expectedReport: PrivacyScanCombinedReport = {
+                ScanId: metadata.websiteScanId,
+                ScanTeamId: 0,
+                ResultScanId: 0,
+                Status: 'Failed',
+                Urls: [metadata.url],
+                FailedUrls: [failedUrl],
+                ScanCookies: [
+                    { Name: 'domain1cookie1', Domain: 'domain1' },
+                    { Name: 'domain1cookie2', Domain: 'domain1' },
+                    { Name: 'domain2cookie1', Domain: 'domain2' },
+                    { Name: 'domain2cookie2', Domain: 'domain2' },
+                    { Name: 'domain3cookie1', Domain: 'domain3' },
+                ],
+                CookieCollectionUrlResults: [partialScanResult.results],
+                StartDateTime: startDate,
+                FinishDateTime: currentDate,
+            };
+
+            const actualReport = testSubject.reduceResults(partialScanResult, undefined, metadata);
+
+            expect(actualReport).toEqual(expectedReport);
+        });
+
+        it('with failed scan and no scan results', () => {
+            const failedScanResult: PrivacyScanResult = {
+                error: 'Browser error',
+                pageResponseCode: 404,
+            };
+            const failedUrl: FailedUrl = {
+                Url: metadata.url,
+                SeedUri: metadata.url,
+                HttpStatusCode: 404,
+                Reason: 'error="Browser error"',
+                BannerDetected: undefined,
+                BannerDetectionXpathExpression: undefined,
+            };
+
+            const expectedReport: PrivacyScanCombinedReport = {
+                ScanId: metadata.websiteScanId,
+                ScanTeamId: 0,
+                ResultScanId: 0,
+                Status: 'Failed',
+                Urls: [metadata.url],
+                FailedUrls: [failedUrl],
+                ScanCookies: [],
+                CookieCollectionUrlResults: [],
+                StartDateTime: startDate,
+                FinishDateTime: currentDate,
+            };
+
+            const actualReport = testSubject.reduceResults(failedScanResult, undefined, metadata);
+
+            expect(actualReport).toEqual(expectedReport);
+        });
+    });
+
+    describe('Combines with existing report', () => {
+        let existingReport: PrivacyScanCombinedReport;
+
+        beforeEach(() => {
+            existingReport = {
+                ScanId: 'report scan id',
+                ScanTeamId: 0,
+                ResultScanId: 0,
+                Status: 'Completed',
+                Urls: ['url1', 'url2'],
+                FailedUrls: [],
+                ScanCookies: [
+                    { Name: 'domain1cookie1', Domain: 'domain1' },
+                    { Name: 'domain2cookie1', Domain: 'domain2' },
+                    { Name: 'domain4cookie1', Domain: 'domain4' },
+                ],
+                CookieCollectionUrlResults: [
+                    {
+                        HttpStatusCode: 200,
+                    } as PrivacyPageScanReport,
+                ],
+                StartDateTime: new Date(0, 0, 0, 0),
+                FinishDateTime: new Date(1, 1, 1, 1),
+            };
+        });
+
+        it.each(['Completed', 'Failed'] as PrivacyScanStatus[])('with successful scan result and existing report status=%s', (status) => {
+            existingReport.Status = status;
+
+            const expectedReport: PrivacyScanCombinedReport = {
+                ..._.cloneDeep(existingReport),
+                Status: status,
+                Urls: [...existingReport.Urls, metadata.url],
+                ScanCookies: [
+                    ...existingReport.ScanCookies,
+                    { Name: 'domain1cookie2', Domain: 'domain1' },
+                    { Name: 'domain2cookie2', Domain: 'domain2' },
+                ],
+                CookieCollectionUrlResults: [...existingReport.CookieCollectionUrlResults, successfulScanResult.results],
+                FinishDateTime: currentDate,
+            };
+
+            const actualReport = testSubject.reduceResults(successfulScanResult, existingReport, metadata);
+
+            expect(actualReport).toEqual(expectedReport);
+        });
+
+        it.each(['Completed', 'Failed'] as PrivacyScanStatus[])(
+            'with failed partial scan result and existing report status=%s',
+            (status) => {
+                existingReport.Status = status;
+
+                const failedUrl: FailedUrl = {
+                    Url: partialScanResult.results.NavigationalUri,
+                    SeedUri: partialScanResult.results.SeedUri,
+                    HttpStatusCode: partialScanResult.pageResponseCode,
+                    Reason: 'error="Page reload error"',
+                    BannerDetected: partialScanResult.results.BannerDetected,
+                    BannerDetectionXpathExpression: partialScanResult.results.BannerDetectionXpathExpression,
+                };
+                const expectedReport: PrivacyScanCombinedReport = {
+                    ..._.cloneDeep(existingReport),
+                    Status: 'Failed',
+                    Urls: [...existingReport.Urls, metadata.url],
+                    ScanCookies: [
+                        ...existingReport.ScanCookies,
+                        { Name: 'domain1cookie2', Domain: 'domain1' },
+                        { Name: 'domain2cookie2', Domain: 'domain2' },
+                        { Name: 'domain3cookie1', Domain: 'domain3' },
+                    ],
+                    CookieCollectionUrlResults: [...existingReport.CookieCollectionUrlResults, partialScanResult.results],
+                    FailedUrls: [failedUrl],
+                    FinishDateTime: currentDate,
+                };
+
+                const actualReport = testSubject.reduceResults(partialScanResult, existingReport, metadata);
+
+                expect(actualReport).toEqual(expectedReport);
+            },
+        );
+
+        it.each(['Completed', 'Failed'] as PrivacyScanStatus[])(
+            'with failed scan, no scan results, and existing report status=%s',
+            (status) => {
+                existingReport.Status = status;
+
+                const failedScanResult: PrivacyScanResult = {
+                    error: 'Browser error',
+                    pageResponseCode: 404,
+                };
+                const failedUrl: FailedUrl = {
+                    Url: metadata.url,
+                    SeedUri: metadata.url,
+                    HttpStatusCode: 404,
+                    Reason: 'error="Browser error"',
+                };
+
+                const expectedReport: PrivacyScanCombinedReport = {
+                    ..._.cloneDeep(existingReport),
+                    Status: 'Failed',
+                    Urls: [...existingReport.Urls, metadata.url],
+                    FailedUrls: [failedUrl],
+                    FinishDateTime: currentDate,
+                };
+
+                const actualReport = testSubject.reduceResults(failedScanResult, existingReport, metadata);
+
+                expect(actualReport).toEqual(expectedReport);
+            },
+        );
+    });
+});

--- a/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.spec.ts
+++ b/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.spec.ts
@@ -112,8 +112,6 @@ describe(PrivacyReportReducer, () => {
         it('with successful scan result', () => {
             const expectedReport: PrivacyScanCombinedReport = {
                 ScanId: metadata.websiteScanId,
-                ScanTeamId: 0,
-                ResultScanId: 0,
                 Status: 'Completed',
                 Urls: [metadata.url],
                 FailedUrls: [],
@@ -145,8 +143,6 @@ describe(PrivacyReportReducer, () => {
 
             const expectedReport: PrivacyScanCombinedReport = {
                 ScanId: metadata.websiteScanId,
-                ScanTeamId: 0,
-                ResultScanId: 0,
                 Status: 'Failed',
                 Urls: [metadata.url],
                 FailedUrls: [failedUrl],
@@ -183,8 +179,6 @@ describe(PrivacyReportReducer, () => {
 
             const expectedReport: PrivacyScanCombinedReport = {
                 ScanId: metadata.websiteScanId,
-                ScanTeamId: 0,
-                ResultScanId: 0,
                 Status: 'Failed',
                 Urls: [metadata.url],
                 FailedUrls: [failedUrl],
@@ -206,8 +200,6 @@ describe(PrivacyReportReducer, () => {
         beforeEach(() => {
             existingReport = {
                 ScanId: 'report scan id',
-                ScanTeamId: 0,
-                ResultScanId: 0,
                 Status: 'Completed',
                 Urls: ['url1', 'url2'],
                 FailedUrls: [],

--- a/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.ts
+++ b/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { GuidGenerator } from 'common';
+import { inject, injectable } from 'inversify';
+import { PrivacyScanResult } from 'scanner-global-library';
+import { ConsentResult, Cookie, PrivacyScanCombinedReport } from 'storage-documents';
+import _ from 'lodash';
+
+export type PrivacyReportMetadata = {
+    scanId: string;
+    websiteScanId: string;
+    url: string;
+};
+
+@injectable()
+export class PrivacyReportReducer {
+    constructor(@inject(GuidGenerator) private readonly guidGenerator: GuidGenerator) {}
+
+    public reduceResults(
+        scanResults: PrivacyScanResult,
+        existingCombinedReport: PrivacyScanCombinedReport | undefined,
+        metadata: PrivacyReportMetadata,
+    ): PrivacyScanCombinedReport {
+        let combinedReport = existingCombinedReport ?? this.createNewCombinedReport(metadata);
+
+        combinedReport.Urls.push(metadata.url);
+        if (scanResults.error) {
+            combinedReport = this.addFailedUrl(scanResults, combinedReport, metadata.url);
+        }
+        if (scanResults.results) {
+            combinedReport = this.addCookieCollectionResults(scanResults, combinedReport);
+        }
+
+        combinedReport.FinishDateTime = scanResults.results?.FinishDateTime ?? new Date();
+
+        return combinedReport;
+    }
+
+    private addFailedUrl(
+        scanResults: PrivacyScanResult,
+        combinedReport: PrivacyScanCombinedReport,
+        url: string,
+    ): PrivacyScanCombinedReport {
+        combinedReport.FailedUrls.push({
+            Url: scanResults.results?.NavigationalUri ?? url,
+            SeedUri: scanResults.results?.SeedUri ?? url,
+            HttpStatusCode: scanResults.pageResponseCode,
+            Reason: `error=${JSON.stringify(scanResults.error)}`,
+            BannerDetected: scanResults.results?.BannerDetected,
+            BannerDetectionXpathExpression: scanResults.results?.BannerDetectionXpathExpression,
+        });
+        combinedReport.Status = 'Failed';
+
+        return combinedReport;
+    }
+
+    private addCookieCollectionResults(
+        scanResults: PrivacyScanResult,
+        combinedReport: PrivacyScanCombinedReport,
+    ): PrivacyScanCombinedReport {
+        combinedReport.CookieCollectionUrlResults.push(scanResults.results);
+        scanResults.results.CookieCollectionConsentResults.forEach((consentResult) => {
+            combinedReport.ScanCookies = _.unionBy(
+                combinedReport.ScanCookies,
+                this.getCookiesFromConsentResult(consentResult),
+                JSON.stringify,
+            );
+        });
+
+        return combinedReport;
+    }
+
+    private getCookiesFromConsentResult(consentResult: ConsentResult): Cookie[] {
+        const cookiesBeforeConsent = _.flatMap(consentResult.CookiesBeforeConsent ?? [], (cookieByDomain) => cookieByDomain.Cookies);
+        const cookiesAfterConsent = _.flatMap(consentResult.CookiesAfterConsent ?? [], (cookieByDomain) => cookieByDomain.Cookies);
+
+        return _.unionBy(cookiesBeforeConsent, cookiesAfterConsent, JSON.stringify);
+    }
+
+    private createNewCombinedReport(metadata: PrivacyReportMetadata): PrivacyScanCombinedReport {
+        return {
+            ScanId: metadata.websiteScanId,
+            ScanTeamId: 0, //?
+            ResultScanId: 0, //?
+            Status: 'Completed',
+            Urls: [],
+            FailedUrls: [],
+            ScanCookies: [],
+            CookieCollectionUrlResults: [],
+            StartDateTime: this.guidGenerator.getGuidTimestamp(metadata.scanId),
+            FinishDateTime: new Date(),
+        };
+    }
+}

--- a/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.ts
+++ b/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.ts
@@ -81,8 +81,6 @@ export class PrivacyReportReducer {
     private createNewCombinedReport(metadata: PrivacyReportMetadata): PrivacyScanCombinedReport {
         return {
             ScanId: metadata.websiteScanId,
-            ScanTeamId: 0, //?
-            ResultScanId: 0, //?
             Status: 'Completed',
             Urls: [],
             FailedUrls: [],

--- a/packages/privacy-scan-runner/src/runner/runner.spec.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.spec.ts
@@ -20,6 +20,7 @@ import { ScanMetadataConfig } from '../scan-metadata-config';
 import { PageScanProcessor } from '../scanner/page-scan-processor';
 import { ScanRunnerTelemetryManager } from '../scan-runner-telemetry-manager';
 import { PrivacyScanMetadata } from '../types/privacy-scan-metadata';
+import { CombinedPrivacyScanResultProcessor } from '../combined-report/combined-privacy-scan-result-processor';
 import { Runner } from './runner';
 
 const maxFailedScanRetryCount = 1;
@@ -33,6 +34,7 @@ let scanRunnerTelemetryManagerMock: IMock<ScanRunnerTelemetryManager>;
 let serviceConfigMock: IMock<ServiceConfiguration>;
 let loggerMock: IMock<GlobalLogger>;
 let guidGeneratorMock: IMock<GuidGenerator>;
+let combinedResultsProcessorMock: IMock<CombinedPrivacyScanResultProcessor>;
 let runner: Runner;
 let scanMetadataInput: PrivacyScanMetadata;
 let scanMetadata: PrivacyScanMetadata;
@@ -54,6 +56,7 @@ describe(Runner, () => {
         serviceConfigMock = Mock.ofType(ServiceConfiguration);
         loggerMock = Mock.ofType<GlobalLogger>();
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
+        combinedResultsProcessorMock = Mock.ofType<CombinedPrivacyScanResultProcessor>();
 
         dateNow = new Date();
         MockDate.set(dateNow);
@@ -93,6 +96,7 @@ describe(Runner, () => {
             serviceConfigMock.object,
             loggerMock.object,
             guidGeneratorMock.object,
+            combinedResultsProcessorMock.object,
         );
     });
 
@@ -105,6 +109,7 @@ describe(Runner, () => {
         reportWriterMock.verifyAll();
         scanRunnerTelemetryManagerMock.verifyAll();
         loggerMock.verifyAll();
+        combinedResultsProcessorMock.verifyAll();
     });
 
     it('exit runner if unable to update db document state to `running`', async () => {
@@ -229,6 +234,8 @@ function setupProcessScanResult(): void {
             .verifiable();
         pageScanResult.reports = reports;
     }
+
+    combinedResultsProcessorMock.setup((c) => c.generateCombinedScanResults(privacyScanResults, pageScanResult)).verifiable();
 
     pageScanResult.run.pageResponseCode = privacyScanResults.pageResponseCode;
 }

--- a/packages/privacy-scan-runner/src/runner/runner.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.ts
@@ -12,6 +12,7 @@ import { ScanMetadataConfig } from '../scan-metadata-config';
 import { ScanRunnerTelemetryManager } from '../scan-runner-telemetry-manager';
 import { PageScanProcessor } from '../scanner/page-scan-processor';
 import { PrivacyScanMetadata } from '../types/privacy-scan-metadata';
+import { CombinedPrivacyScanResultProcessor } from '../combined-report/combined-privacy-scan-result-processor';
 
 @injectable()
 export class Runner {
@@ -25,6 +26,7 @@ export class Runner {
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+        @inject(CombinedPrivacyScanResultProcessor) private readonly combinedResultProcessor: CombinedPrivacyScanResultProcessor,
     ) {}
 
     public async run(): Promise<void> {
@@ -105,6 +107,8 @@ export class Runner {
                 pageScanResult.scannedUrl = privacyScanResult.scannedUrl;
             }
         }
+
+        await this.combinedResultProcessor.generateCombinedScanResults(privacyScanResult, pageScanResult);
 
         pageScanResult.run.pageResponseCode = privacyScanResult.pageResponseCode;
 

--- a/packages/privacy-scan-runner/src/scanner/privacy-scanner.spec.ts
+++ b/packages/privacy-scan-runner/src/scanner/privacy-scanner.spec.ts
@@ -43,6 +43,7 @@ describe(PrivacyScanner, () => {
     it('should launch browser page with given url and scan the page', async () => {
         const expectedResult = { state: 'pass' } as PrivacyScanResult;
         setupWaitForPromisetoReturnOriginalPromise();
+        pageMock.setup((p) => p.scanForPrivacy()).returns(async () => expectedResult);
 
         const actualResult = await privacyScanner.scan(pageMock.object);
         expect(actualResult).toEqual(expectedResult);
@@ -50,9 +51,8 @@ describe(PrivacyScanner, () => {
 
     it('should throw errors', async () => {
         const scanError = { error: 'scan error', pageResponseCode: 101 };
-        privacyScanner = new PrivacyScanner(promiseUtilsMock.object, serviceConfigMock.object, loggerMock.object, () => {
-            throw scanError;
-        });
+        pageMock.setup((p) => p.scanForPrivacy()).throws(scanError as unknown as Error);
+        privacyScanner = new PrivacyScanner(promiseUtilsMock.object, serviceConfigMock.object, loggerMock.object);
 
         setupWaitForPromisetoReturnOriginalPromise();
         loggerMock

--- a/packages/privacy-scan-runner/src/scanner/privacy-scanner.ts
+++ b/packages/privacy-scan-runner/src/scanner/privacy-scanner.ts
@@ -12,7 +12,6 @@ export class PrivacyScanner {
         @inject(PromiseUtils) private readonly promiseUtils: PromiseUtils,
         @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
-        private readonly scannerImpl: () => Promise<PrivacyScanResult> = () => Promise.resolve({ state: 'pass' } as PrivacyScanResult), // TBD
     ) {}
 
     public async scan(page: Page): Promise<PrivacyScanResult> {
@@ -34,7 +33,7 @@ export class PrivacyScanner {
     private async scanImpl(page: Page): Promise<PrivacyScanResult> {
         try {
             this.logger.logInfo(`Starting privacy scan of a webpage.`);
-            const scanResult = await this.scannerImpl(); // TDB
+            const scanResult = await page.scanForPrivacy();
             this.logger.logInfo(`Privacy scanning of a webpage successfully completed.`);
 
             return scanResult;

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -251,6 +251,7 @@ describe(Page, () => {
                     ...privacyResults,
                     HttpStatusCode: 200,
                 },
+                pageResponseCode: 200,
             } as PrivacyScanResult;
 
             const privacyScanResults = await page.scanForPrivacy();
@@ -299,6 +300,7 @@ describe(Page, () => {
                     ...privacyResults,
                     HttpStatusCode: 200,
                 },
+                pageResponseCode: 200,
                 scannedUrl: redirectUrl,
             } as PrivacyScanResult;
             loggerMock.setup((o) => o.logWarn(`Scanning performed on redirected page`, { redirectedUrl: redirectUrl })).verifiable();
@@ -321,6 +323,7 @@ describe(Page, () => {
                     ...privacyResults,
                     HttpStatusCode: 200,
                 },
+                pageResponseCode: 200,
                 scannedUrl: redirectUrl,
             } as PrivacyScanResult;
             loggerMock.setup((o) => o.logWarn(`Scanning performed on redirected page`, { redirectedUrl: redirectUrl })).verifiable();
@@ -348,6 +351,7 @@ describe(Page, () => {
                     ...privacyResults,
                     HttpStatusCode: 200,
                 },
+                pageResponseCode: 200,
                 error: 'Failed to collect cookies for 1 test cases',
             } as PrivacyScanResult;
 

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -159,6 +159,7 @@ export class Page {
                 ...privacyResult,
                 HttpStatusCode: navigationStatusCode,
             },
+            pageResponseCode: navigationStatusCode,
         };
 
         if (

--- a/packages/service-library/src/data-providers/privacy-scan-combined-report-provider.spec.ts
+++ b/packages/service-library/src/data-providers/privacy-scan-combined-report-provider.spec.ts
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Readable } from 'stream';
+import { BlobContentDownloadResponse, BlobSaveCondition, BlobStorageClient, BlobContentUploadResponse } from 'azure-services';
+import { IMock, Mock } from 'typemoq';
+import { BodyParser, System } from 'common';
+import { PrivacyScanCombinedReport } from 'storage-documents';
+import { GeneratedReport, PrivacyReportWriteResponse } from '..';
+import { DataProvidersCommon } from './data-providers-common';
+import { PrivacyScanCombinedReportProvider } from './privacy-scan-combined-report-provider';
+
+describe(PrivacyScanCombinedReportProvider, () => {
+    const fileId = 'file id';
+    const filePath = 'file path';
+    const combinedReport = {
+        Status: 'Completed',
+    } as PrivacyScanCombinedReport;
+    const resultsString = JSON.stringify(combinedReport);
+    const generatedReport: GeneratedReport = {
+        content: resultsString,
+        id: fileId,
+        format: 'consolidated.json',
+    };
+
+    const etag = 'etag';
+    const readableStream = {
+        readable: true,
+    } as NodeJS.ReadableStream;
+
+    let blobStorageClientMock: IMock<BlobStorageClient>;
+    let dataProvidersCommonMock: IMock<DataProvidersCommon>;
+    let bodyParserMock: IMock<BodyParser>;
+
+    let testSubject: PrivacyScanCombinedReportProvider;
+
+    beforeEach(() => {
+        blobStorageClientMock = Mock.ofType<BlobStorageClient>();
+        dataProvidersCommonMock = Mock.ofType<DataProvidersCommon>();
+        bodyParserMock = Mock.ofType<BodyParser>();
+        dataProvidersCommonMock.setup((dp) => dp.getBlobName(fileId)).returns(() => filePath);
+
+        testSubject = new PrivacyScanCombinedReportProvider(
+            blobStorageClientMock.object,
+            dataProvidersCommonMock.object,
+            bodyParserMock.object,
+        );
+    });
+
+    afterEach(() => {
+        blobStorageClientMock.verifyAll();
+    });
+
+    describe('writeCombinedReport', () => {
+        it('without etag', async () => {
+            const expectedResult: PrivacyReportWriteResponse = {
+                etag,
+                report: {
+                    reportId: fileId,
+                    href: filePath,
+                    format: 'consolidated.json',
+                },
+            };
+            setupSave(resultsString, 200);
+
+            const result = await testSubject.writeCombinedReport(generatedReport);
+
+            expect(result).toEqual(expectedResult);
+        });
+
+        it('with etag', async () => {
+            const expectedResult = {
+                etag,
+                report: {
+                    reportId: fileId,
+                    href: filePath,
+                    format: 'consolidated.json',
+                },
+            };
+            setupSave(resultsString, 200, { ifMatchEtag: etag });
+
+            const result = await testSubject.writeCombinedReport(generatedReport, etag);
+
+            expect(result).toEqual(expectedResult);
+        });
+
+        it('returns etagMismatch error', async () => {
+            setupSave(resultsString, 412, { ifMatchEtag: etag });
+            const expectedResult = {
+                error: {
+                    errorCode: 'etagMismatch',
+                },
+            };
+
+            const result = await testSubject.writeCombinedReport(generatedReport, etag);
+
+            expect(result).toEqual(expectedResult);
+        });
+
+        it('returns unrecognized error', async () => {
+            setupSave(resultsString, 404, { ifMatchEtag: etag });
+
+            const expectedResult = {
+                error: {
+                    errorCode: 'httpStatusError',
+                    data: '404',
+                },
+            };
+
+            const result = await testSubject.writeCombinedReport(generatedReport, etag);
+
+            expect(result).toEqual(expectedResult);
+        });
+    });
+
+    describe('readCombinedReport', () => {
+        it('read combined report', async () => {
+            setupReadBlob();
+            setupReadStream(resultsString);
+            const expectedResults = {
+                results: combinedReport,
+                etag: etag,
+            };
+
+            const actualResults = await testSubject.readCombinedReport(fileId);
+
+            expect(actualResults).toEqual(expectedResults);
+        });
+
+        it('handles document not found', async () => {
+            setupDocumentNotFound();
+            const expectedResults = {
+                error: {
+                    errorCode: 'blobNotFound',
+                },
+            };
+
+            const actualResults = await testSubject.readCombinedReport(fileId);
+
+            expect(actualResults).toEqual(expectedResults);
+        });
+
+        it('handles stream read failure', async () => {
+            setupReadBlob();
+            const error = new Error('error');
+            bodyParserMock.setup((bp) => bp.getRawBody(readableStream as Readable)).throws(error);
+            const expectedResults = {
+                error: {
+                    errorCode: 'streamError',
+                    data: System.serializeError(error),
+                },
+            };
+
+            const actualResults = await testSubject.readCombinedReport(fileId);
+
+            expect(actualResults).toEqual(expectedResults);
+        });
+
+        it('handles unparsable string', async () => {
+            const unparsableString = '{ unparsable content string';
+            setupReadBlob();
+            setupReadStream(unparsableString);
+
+            const actualResults = await testSubject.readCombinedReport(fileId);
+
+            expect(actualResults.error.errorCode).toEqual('jsonParseError');
+            expect(actualResults.error.data).toContain(`{\n  name: 'SyntaxError',\n  message: 'Unexpected token u in JSON at position 2',`);
+        });
+    });
+
+    function setupReadStream(content: string): void {
+        bodyParserMock.setup((bp) => bp.getRawBody(readableStream as Readable)).returns(() => Promise.resolve(Buffer.from(content)));
+    }
+
+    function setupReadBlob(): void {
+        const response = {
+            notFound: false,
+            content: readableStream,
+            etag: etag,
+        } as BlobContentDownloadResponse;
+        blobStorageClientMock
+            .setup((bc) => bc.getBlobContent(DataProvidersCommon.reportBlobContainerName, filePath))
+            .returns(async () => response)
+            .verifiable();
+    }
+
+    function setupDocumentNotFound(): void {
+        const response = {
+            notFound: true,
+            content: null,
+        } as BlobContentDownloadResponse;
+        blobStorageClientMock
+            .setup((bc) => bc.getBlobContent(DataProvidersCommon.reportBlobContainerName, filePath))
+            .returns(async () => response)
+            .verifiable();
+    }
+
+    function setupSave(content: string, statusCode: number, condition?: BlobSaveCondition): void {
+        const response = { statusCode, etag } as BlobContentUploadResponse;
+        blobStorageClientMock
+            .setup((bc) => bc.uploadBlobContent(DataProvidersCommon.reportBlobContainerName, filePath, content, condition))
+            .returns(() => Promise.resolve(response))
+            .verifiable();
+    }
+});

--- a/packages/service-library/src/data-providers/privacy-scan-combined-report-provider.ts
+++ b/packages/service-library/src/data-providers/privacy-scan-combined-report-provider.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Readable } from 'stream';
+import { BlobContentDownloadResponse, BlobStorageClient } from 'azure-services';
+import { inject, injectable } from 'inversify';
+import { OnDemandPageScanReport, PrivacyScanCombinedReport } from 'storage-documents';
+import { BodyParser, System } from 'common';
+import { DataProvidersCommon } from './data-providers-common';
+import { GeneratedReport } from './report-writer';
+
+export type PrivacyReportReadErrorCode = 'blobNotFound' | 'jsonParseError' | 'streamError';
+export type PrivacyReportWriteErrorCode = 'etagMismatch' | 'httpStatusError';
+
+export type PrivacyReportError<ErrorCodeType> = {
+    errorCode: ErrorCodeType;
+    data?: string;
+};
+
+export type PrivacyReportReadResponse = {
+    error?: PrivacyReportError<PrivacyReportReadErrorCode>;
+    results?: PrivacyScanCombinedReport;
+    etag?: string;
+};
+
+export type PrivacyReportWriteResponse = {
+    error?: PrivacyReportError<PrivacyReportWriteErrorCode>;
+    etag?: string;
+    report?: OnDemandPageScanReport;
+};
+
+@injectable()
+export class PrivacyScanCombinedReportProvider {
+    private static readonly preconditionFailedStatusCode = 412;
+
+    constructor(
+        @inject(BlobStorageClient) private readonly blobStorageClient: BlobStorageClient,
+        @inject(DataProvidersCommon) private readonly dataProvidersCommon: DataProvidersCommon,
+        @inject(BodyParser) private readonly bodyParser: BodyParser,
+    ) {}
+
+    public async writeCombinedReport(report: GeneratedReport, etag?: string): Promise<PrivacyReportWriteResponse> {
+        const filePath = this.dataProvidersCommon.getBlobName(report.id);
+        const condition = etag ? { ifMatchEtag: etag } : undefined;
+        const response = await this.blobStorageClient.uploadBlobContent(
+            DataProvidersCommon.reportBlobContainerName,
+            filePath,
+            report.content,
+            condition,
+        );
+
+        if (this.statusSuccessful(response.statusCode)) {
+            return {
+                etag: response.etag,
+                report: {
+                    format: report.format,
+                    href: filePath,
+                    reportId: report.id,
+                },
+            };
+        }
+
+        if (response.statusCode === PrivacyScanCombinedReportProvider.preconditionFailedStatusCode) {
+            return {
+                error: {
+                    errorCode: 'etagMismatch',
+                },
+            };
+        }
+
+        return {
+            error: {
+                errorCode: 'httpStatusError',
+                data: `${response.statusCode}`,
+            },
+        };
+    }
+
+    public async readCombinedReport(fileId: string): Promise<PrivacyReportReadResponse> {
+        const downloadResponse = await this.readBlob(fileId);
+        if (downloadResponse.notFound) {
+            return {
+                error: { errorCode: 'blobNotFound' },
+            };
+        }
+
+        let contentString: string;
+        try {
+            contentString = (await this.bodyParser.getRawBody(downloadResponse.content as Readable)).toString();
+        } catch (error) {
+            return {
+                error: {
+                    errorCode: 'streamError',
+                    data: System.serializeError(error),
+                },
+            };
+        }
+
+        try {
+            const content = JSON.parse(contentString);
+
+            return {
+                results: content,
+                etag: downloadResponse.etag,
+            };
+        } catch (error) {
+            return {
+                error: {
+                    errorCode: 'jsonParseError',
+                    data: System.serializeError(error),
+                },
+            };
+        }
+    }
+
+    private async readBlob(fileId: string): Promise<BlobContentDownloadResponse> {
+        return this.blobStorageClient.getBlobContent(
+            DataProvidersCommon.reportBlobContainerName,
+            this.dataProvidersCommon.getBlobName(fileId),
+        );
+    }
+
+    private statusSuccessful(statusCode: number): boolean {
+        return statusCode >= 200 && statusCode < 300;
+    }
+}

--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -28,3 +28,4 @@ export { WebsiteScanResultProvider } from './data-providers/website-scan-result-
 export * from './data-providers/combined-scan-results-provider';
 export { BatchRequestLoader } from './dev-utilities/batch-request-loader';
 export { ReportWriter, GeneratedReport } from './data-providers/report-writer';
+export * from './data-providers/privacy-scan-combined-report-provider';

--- a/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
+++ b/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
@@ -6,7 +6,7 @@ import { ScanRunErrorCodeName } from '../scan-run-error-codes';
 import { WebApiError } from '../web-api-error-codes';
 
 export declare type LinkType = 'self';
-export declare type ReportFormat = 'sarif' | 'html' | 'consolidated.html' | 'json';
+export declare type ReportFormat = 'sarif' | 'html' | 'consolidated.html' | 'json' | 'consolidated.json';
 export declare type ScanState = 'pending' | 'pass' | 'fail';
 export declare type RunState = 'pending' | 'accepted' | 'queued' | 'running' | 'completed' | 'failed';
 export declare type NotificationState = 'pending' | 'queued' | 'queueFailed' | 'sending' | 'sent' | 'sendFailed';

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -6,7 +6,7 @@ import { StorageDocument } from './storage-document';
 import { ScanGroupType } from './website-scan-result';
 import { PrivacyScan } from './on-demand-page-scan-batch-request';
 
-export declare type ReportFormat = 'sarif' | 'html' | 'consolidated.html' | 'json';
+export declare type ReportFormat = 'sarif' | 'html' | 'consolidated.html' | 'json' | 'consolidated.json';
 export declare type ScanState = 'pending' | 'pass' | 'fail';
 export declare type OnDemandPageScanRunState = 'pending' | 'accepted' | 'queued' | 'running' | 'completed' | 'failed';
 export declare type NotificationState = 'pending' | 'queued' | 'queueFailed' | 'sending' | 'sent' | 'sendFailed';

--- a/packages/storage-documents/src/privacy-scan-types/privacy-scan-combined-report.ts
+++ b/packages/storage-documents/src/privacy-scan-types/privacy-scan-combined-report.ts
@@ -8,8 +8,6 @@ export type PrivacyScanStatus = 'Completed' | 'Failed';
 // Data type used by WCP
 export interface PrivacyScanCombinedReport {
     ScanId: string;
-    ScanTeamId: number;
-    ResultScanId: number;
     Status: PrivacyScanStatus;
     Urls: string[];
     FailedUrls: FailedUrl[];

--- a/packages/storage-documents/src/privacy-scan-types/privacy-scan-combined-report.ts
+++ b/packages/storage-documents/src/privacy-scan-types/privacy-scan-combined-report.ts
@@ -14,7 +14,7 @@ export interface PrivacyScanCombinedReport {
     Urls: string[];
     FailedUrls: FailedUrl[];
     ScanCookies: Cookie[];
-    CookieCollectionUrlResults: PrivacyPageScanReport;
+    CookieCollectionUrlResults: PrivacyPageScanReport[];
     StartDateTime: Date;
     FinishDateTime: Date;
 }
@@ -24,6 +24,6 @@ export interface FailedUrl {
     SeedUri: string;
     Reason: string; // "error=Error message"
     HttpStatusCode: number;
-    BannerDetected: boolean;
-    BannerDetectionXpathExpression: string;
+    BannerDetected?: boolean;
+    BannerDetectionXpathExpression?: string;
 }


### PR DESCRIPTION
#### Details

- Run privacy scanner in batch job and save individual report in json format
- Combine individual privacy reports for scans that share the same consolidatedId and baseUrl and save the combined report in json format

##### Motivation

This PR connects all pieces of the privacy scanner so the service can run a privacy scan end-to-end and generate both individual and combined reports

##### Context

A future PR will move combined report generation logic into the new report generator job

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
