### PR TITLE
Privacy scan bugfix

### DIFF
--- a/packages/functional-tests/src/functional-test-group-types.ts
+++ b/packages/functional-tests/src/functional-test-group-types.ts
@@ -18,6 +18,7 @@ import { ScanQueuingTestGroup } from './test-groups/scan-queuing-test-group';
 import { ScanReportTestGroup } from './test-groups/scan-reports-test-group';
 import { ScanStatusTestGroup } from './test-groups/scan-status-test-group';
 import { DeepScanPreCompletionNotificationTestGroup } from './test-groups/deep-scan-pre-completion-notification-test-group';
+import { PrivacyScanReportsTestGroup } from './test-groups/privacy-scan-reports-test-group';
 
 export type TestGroupName =
     | 'PostScan'
@@ -32,6 +33,7 @@ export type TestGroupName =
     | 'DeepScanPostCompletion'
     | 'DeepScanReports'
     | 'DeepScanStatusConsistency'
+    | 'PrivacyScanReports'
     | 'Finalizer';
 
 export type TestGroupConstructor = new (
@@ -53,5 +55,6 @@ export const functionalTestGroupTypes: { [key in TestGroupName]: TestGroupConstr
     DeepScanPostCompletion: DeepScanPostCompletionTestGroup,
     DeepScanReports: DeepScanReportsTestGroup,
     DeepScanStatusConsistency: DeepScanStatusConsistencyTestGroup,
+    PrivacyScanReports: PrivacyScanReportsTestGroup,
     Finalizer: FinalizerTestGroup,
 };

--- a/packages/functional-tests/src/test-groups/privacy-scan-reports-test-group.ts
+++ b/packages/functional-tests/src/test-groups/privacy-scan-reports-test-group.ts
@@ -10,24 +10,20 @@ import { FunctionalTestGroup } from './functional-test-group';
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-export class ConsolidatedScanReportsTestGroup extends FunctionalTestGroup {
+export class PrivacyScanReportsTestGroup extends FunctionalTestGroup {
     @test(TestEnvironment.all)
     public async testReportFormats(): Promise<void> {
         const response = await this.a11yServiceClient.getScanStatus(this.testContextData.scanId);
         const reports = (<ScanRunResultResponse>response.body).reports;
 
-        expect(reports, 'Expected three reports to be returned').to.have.lengthOf(3);
+        expect(reports, 'Expected three reports to be returned').to.have.lengthOf(2);
         expect(
-            _.some(reports, (report) => report.format === 'sarif'),
-            'Expected at least one sarif report',
+            _.some(reports, (report) => report.format === 'json'),
+            'Expected at least one json report',
         ).to.be.true;
         expect(
-            _.some(reports, (report) => report.format === 'html'),
-            'Expected at least one html report',
-        ).to.be.true;
-        expect(
-            _.some(reports, (report) => report.format === 'html'),
-            'Expected at least one consolidated.html report',
+            _.some(reports, (report) => report.format === 'consolidated.json'),
+            'Expected at least one consolidated report',
         ).to.be.true;
     }
 

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -142,7 +142,7 @@ export class Page {
         const reloadPageFunc = async (page: Puppeteer.Page) => {
             await this.navigateToUrl(page.url());
 
-            return { success: this.navigationResponse.ok(), error: this.lastBrowserError };
+            return { success: this.navigationResponse?.ok() === true, error: this.lastBrowserError };
         };
 
         let privacyResult: PrivacyResults;

--- a/packages/web-api-client/src/a11y-service-client.spec.ts
+++ b/packages/web-api-client/src/a11y-service-client.spec.ts
@@ -252,6 +252,32 @@ describe(A11yServiceClient, () => {
             expect(actualResponse).toEqual(response);
         });
 
+        it('with privacyScan=true', async () => {
+            const scanOptions: PostScanRequestOptions = {
+                privacyScan: true,
+                priority,
+            };
+            const requestBody: ScanRunRequest = {
+                url: scanUrl,
+                priority,
+                privacyScan: {
+                    cookieBannerType: 'standard',
+                },
+            };
+            const requestOptions = { json: createPostScanRequestObj(requestBody) };
+
+            setupVerifiableSignRequestCall();
+            setupRetryHelperMock(false);
+            postMock
+                .setup((req) => req(`${baseUrl}/scans`, requestOptions))
+                .returns(async () => Promise.resolve(response))
+                .verifiable(Times.once());
+
+            const actualResponse = await testSubject.postScanUrl(scanUrl, scanOptions);
+
+            expect(actualResponse).toEqual(response);
+        });
+
         function createPostScanRequestObj(scanRunRequest: ScanRunRequest): ScanRunRequest[] {
             // fills in undefined fields
             return [

--- a/packages/web-api-client/src/a11y-service-client.ts
+++ b/packages/web-api-client/src/a11y-service-client.ts
@@ -60,6 +60,11 @@ export class A11yServiceClient {
                 ...options.deepScanOptions,
             };
         }
+        if (options?.privacyScan) {
+            scanRequestData.privacyScan = {
+                cookieBannerType: 'standard',
+            };
+        }
 
         return this.postScanUrlWithRequest(scanRequestData);
     }

--- a/packages/web-api-client/src/request-options.ts
+++ b/packages/web-api-client/src/request-options.ts
@@ -7,6 +7,7 @@ export type PostScanRequestOptions = {
     consolidatedId?: string;
     deepScan?: boolean;
     deepScanOptions?: DeepScanOptions;
+    privacyScan?: boolean;
 };
 
 export type DeepScanOptions = {

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
@@ -48,6 +48,10 @@ describe('E2EScanScenarioDefinitions', () => {
                     discoveryPatterns: [`url-to-scan/linked1[.*]`],
                 },
             },
+            {
+                consolidatedId: `consolidated-id-base-test-release-version-privacy-${fakeDate.getTime()}`,
+                privacyScan: true,
+            },
         ];
 
         MockDate.set(fakeDate);

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -43,6 +43,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             },
         };
     },
+    // Deep scan
     (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
         const baseUrl = availabilityConfig.urlToScan;
 
@@ -69,6 +70,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             },
         };
     },
+    // Deep scan with knownPages
     (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
         const baseUrl = availabilityConfig.urlToScan;
 
@@ -98,6 +100,7 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             },
         };
     },
+    // Deep scan with discovery pattern
     (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
         const baseUrl = availabilityConfig.urlToScan;
 
@@ -119,6 +122,22 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             testGroups: {
                 postScanCompletionTests: ['DeepScanStatusConsistency'],
                 postDeepScanCompletionTests: ['DeepScanPostCompletion', 'DeepScanReports', 'ConsolidatedScanReports'],
+            },
+        };
+    },
+    // privacy scan with consolidated report
+    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
+        return {
+            readableName: 'PrivacyScan',
+            scanOptions: {
+                consolidatedId: `${availabilityConfig.consolidatedIdBase}-${webApiConfig.releaseId}-privacy-${Date.now()}`,
+                privacyScan: true,
+            },
+            initialTestContextData: {
+                scanUrl: availabilityConfig.urlToScan,
+            },
+            testGroups: {
+                scanReportTests: ['PrivacyScanReports'],
             },
         };
     },


### PR DESCRIPTION
#### Details

- Page reload handles undefined navigation response
- Deduplicate URLs in combined privacy report (currently, we may get duplicate results if a scan fails and reruns)
- Add an E2E test with the privacy scan flag

##### Motivation

Fixes some minor bugs in the privacy scanner and ensures E2E test coverage

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
