### PR TITLE
Include third party cookies in privacy scan results

### DIFF
--- a/packages/privacy-scan-core/src/cookie-collector.spec.ts
+++ b/packages/privacy-scan-core/src/cookie-collector.spec.ts
@@ -9,6 +9,7 @@ import { ConsentResult, CookieByDomain } from 'storage-documents';
 import _ from 'lodash';
 import { CookieCollector } from './cookie-collector';
 import { CookieScenario } from './cookie-scenarios';
+import { getPromisableDynamicMock } from './test-utilities/promisable-mock';
 import { ReloadPageFunc, ReloadPageResponse } from '.';
 
 describe(CookieCollector, () => {
@@ -23,12 +24,14 @@ describe(CookieCollector, () => {
     let pageCookiesByDomain: CookieByDomain[];
     let puppeteerPageMock: IMock<Puppeteer.Page>;
     let reloadPageMock: IMock<ReloadPageFunc>;
+    let targetClientMock: IMock<Puppeteer.CDPSession>;
 
     let testSubject: CookieCollector;
 
     beforeEach(() => {
         puppeteerPageMock = Mock.ofType<Puppeteer.Page>();
         reloadPageMock = Mock.ofInstance(() => undefined);
+        targetClientMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.CDPSession>());
         pageCookies = [
             {
                 name: 'domain1cookie1',
@@ -59,7 +62,7 @@ describe(CookieCollector, () => {
                 Cookies: [{ Name: 'domain2cookie', Domain: 'domain2', Expires: expiryDate }],
             },
         ];
-        puppeteerPageMock.setup((p) => p.cookies()).returns(async () => pageCookies);
+        setupGetCookies(pageCookies);
         puppeteerPageMock.setup((p) => p.url()).returns(() => url);
 
         testSubject = new CookieCollector();
@@ -68,6 +71,7 @@ describe(CookieCollector, () => {
     afterEach(() => {
         puppeteerPageMock.verifyAll();
         reloadPageMock.verifyAll();
+        targetClientMock.verifyAll();
     });
 
     it('Returns error if first reload fails', async () => {
@@ -151,5 +155,19 @@ describe(CookieCollector, () => {
             })
             .verifiable();
         reloadPageMock.setup((r) => r(puppeteerPageMock.object)).returns(async () => reloadResponse);
+    }
+
+    function setupGetCookies(cookies: Puppeteer.Cookie[]): void {
+        const clientMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.CDPSession>());
+        const targetStub = {
+            createCDPSession: async () => clientMock.object,
+        } as Puppeteer.Target;
+        const getCookiesResponse = { cookies };
+        puppeteerPageMock.setup((p) => p.target()).returns(() => targetStub);
+        clientMock.setup((c) => c.send('Network.getAllCookies')).returns(async () => getCookiesResponse);
+        clientMock
+            .setup((c) => c.detach())
+            .returns(async () => null)
+            .verifiable();
     }
 });

--- a/packages/privacy-scan-core/src/test-utilities/promisable-mock.ts
+++ b/packages/privacy-scan-core/src/test-utilities/promisable-mock.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { IMock } from 'typemoq';
+
+export function getPromisableDynamicMock<T>(mock: IMock<T>): IMock<T> {
+    // workaround for issue https://github.com/florinn/typemoq/issues/70
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock.setup((x: any) => x.then).returns(() => undefined);
+
+    return mock;
+}

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -18,7 +18,7 @@ import { MockableLogger } from './test-utilities/mockable-logger';
 import { getPromisableDynamicMock } from './test-utilities/promisable-mock';
 import { WebDriver } from './web-driver';
 import { PageNavigator } from './page-navigator';
-import { PrivacyScanResult } from '.';
+import { PrivacyScanResult } from './privacy-scan-result';
 
 const url = 'url';
 const redirectUrl = 'redirect url';


### PR DESCRIPTION
#### Details

Use the Chrome devtools protocol instead of puppeteer's cookies() method to get cookies.

##### Motivation

Puppeteer's cookies() method only returns first party cookies. We need to be able to return third-party cookies as well.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
