### PR TITLE
Report generator part 3

### DIFF
--- a/packages/axe-result-converter/jest.config.js
+++ b/packages/axe-result-converter/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/azure-services/jest.config.js
+++ b/packages/azure-services/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 

--- a/packages/common/jest.config.js
+++ b/packages/common/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/crawler/jest.config.js
+++ b/packages/crawler/jest.config.js
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 

--- a/packages/e2e-web-apis/jest.config.js
+++ b/packages/e2e-web-apis/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/functional-tests/jest.config.js
+++ b/packages/functional-tests/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/health-client/jest.config.js
+++ b/packages/health-client/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/logger/jest.config.js
+++ b/packages/logger/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/parallel-workers/jest.config.js
+++ b/packages/parallel-workers/jest.config.js
@@ -7,4 +7,8 @@ const package = require('./package');
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/privacy-scan-core/jest.config.js
+++ b/packages/privacy-scan-core/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/privacy-scan-job-manager/jest.config.js
+++ b/packages/privacy-scan-job-manager/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/report-generator-job-manager/jest.config.js
+++ b/packages/report-generator-job-manager/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/scanner-global-library/jest.config.js
+++ b/packages/scanner-global-library/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/service-library/jest.config.js
+++ b/packages/service-library/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -40,6 +40,8 @@
     "dependencies": {
         "@azure/cosmos": "^3.15.1",
         "@azure/functions": "^3.0.0",
+        "accessibility-insights-report": "4.2.0",
+        "axe-core": "4.3.2",
         "axe-result-converter": "^1.0.0",
         "azure-services": "^1.0.0",
         "common": "^1.0.0",

--- a/packages/service-library/src/combined-report-provider/axe-result-to-consolidated-html-converter.ts
+++ b/packages/service-library/src/combined-report-provider/axe-result-to-consolidated-html-converter.ts
@@ -1,14 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ReporterFactory } from 'accessibility-insights-report';
+import { reporterFactory } from 'accessibility-insights-report';
 import axe from 'axe-core';
 import { inject, injectable } from 'inversify';
 import { ReportFormat, CombinedScanResults } from 'storage-documents';
 import { CombinedReportDataConverter, ScanResultData } from 'axe-result-converter';
-import { iocTypeNames } from '../ioc-types';
-import { htmlReportStrings } from './html-report-strings';
-import { AxeResultConverterOptions } from './axe-result-converter';
+
+export interface ReportMetadata {
+    serviceName: string;
+    baseUrl: string;
+    userAgent: string;
+    browserResolution: string;
+    scanStarted: Date;
+}
 
 @injectable()
 export class AxeResultToConsolidatedHtmlConverter {
@@ -16,16 +21,16 @@ export class AxeResultToConsolidatedHtmlConverter {
 
     constructor(
         @inject(CombinedReportDataConverter) private readonly combinedReportDataConverter: CombinedReportDataConverter,
-        @inject(iocTypeNames.ReporterFactory) private readonly reporterFactoryFunc: ReporterFactory,
+        private readonly reporterFactoryFunc: typeof reporterFactory = reporterFactory,
         private readonly axeCore: typeof axe = axe,
     ) {}
 
-    public convert(combinedScanResults: CombinedScanResults, options: AxeResultConverterOptions): string {
+    public convert(combinedScanResults: CombinedScanResults, options: ReportMetadata): string {
         const reporter = this.reporterFactoryFunc();
         const scanResultData: ScanResultData = {
             baseUrl: options.baseUrl ?? 'n/a',
             basePageTitle: '', // not used
-            scanEngineName: htmlReportStrings.serviceName,
+            scanEngineName: options.serviceName,
             axeCoreVersion: this.axeCore.version,
             browserUserAgent: options.userAgent,
             browserResolution: options.browserResolution,

--- a/packages/service-library/src/combined-report-provider/combined-axe-result-builder.spec.ts
+++ b/packages/service-library/src/combined-report-provider/combined-axe-result-builder.spec.ts
@@ -6,12 +6,16 @@ import 'reflect-metadata';
 import axe, { AxeResults } from 'axe-core';
 import { AxeResultsReducer } from 'axe-result-converter';
 import { cloneDeep } from 'lodash';
-import { CombinedScanResultsProvider, CombinedScanResultsReadResponse, CombinedScanResultsWriteResponse } from 'service-library';
 import { CombinedScanResults } from 'storage-documents';
 import { IMock, It, Mock } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
-import { CombinedResultsBlob } from '../types/combined-results-blob';
+import {
+    CombinedScanResultsProvider,
+    CombinedScanResultsReadResponse,
+    CombinedScanResultsWriteResponse,
+} from '../data-providers/combined-scan-results-provider';
 import { CombinedAxeResultBuilder } from './combined-axe-result-builder';
+import { CombinedResultsBlob } from './combined-results-blob-provider';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/packages/service-library/src/combined-report-provider/combined-axe-result-builder.ts
+++ b/packages/service-library/src/combined-report-provider/combined-axe-result-builder.ts
@@ -5,9 +5,9 @@ import axe from 'axe-core';
 import { AxeResultsReducer } from 'axe-result-converter';
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
-import { CombinedScanResultsProvider } from 'service-library';
 import { CombinedScanResults } from 'storage-documents';
-import { CombinedResultsBlob } from '../types/combined-results-blob';
+import { CombinedScanResultsProvider } from '../data-providers/combined-scan-results-provider';
+import { CombinedResultsBlob } from './combined-results-blob-provider';
 
 @injectable()
 export class CombinedAxeResultBuilder {

--- a/packages/service-library/src/combined-report-provider/combined-report-generator.spec.ts
+++ b/packages/service-library/src/combined-report-provider/combined-report-generator.spec.ts
@@ -7,32 +7,32 @@ import { GuidGenerator } from 'common';
 import { AxeScanResults } from 'scanner-global-library';
 import { CombinedScanResults, WebsiteScanResult } from 'storage-documents';
 import { IMock, Mock } from 'typemoq';
-import { GeneratedReport, ReportGenerator } from '../report-generator/report-generator';
-import { MockableLogger } from '../test-utilities/mockable-logger';
+import { GeneratedReport } from '../data-providers/report-writer';
 import { CombinedReportGenerator } from './combined-report-generator';
+import { AxeResultToConsolidatedHtmlConverter } from './axe-result-to-consolidated-html-converter';
 
 describe(CombinedReportGenerator, () => {
-    let loggerMock: IMock<MockableLogger>;
     let guidGeneratorMock: IMock<GuidGenerator>;
-    let reportGeneratorMock: IMock<ReportGenerator>;
+    let axeResultToConsolidatedHtmlConverterMock: IMock<AxeResultToConsolidatedHtmlConverter>;
     let scanStarted: Date;
     let websiteScanResult: WebsiteScanResult;
     let combinedScanResults: CombinedScanResults;
     let generatedReportStub: GeneratedReport;
+    let testSubject: CombinedReportGenerator;
+
+    const hrefStub = 'href-stub';
+    const reportId = 'new-report-id';
+    const reportContent = 'consolidated report content';
     const baseUrl = 'baseUrl';
     const passedAxeScanResults: AxeScanResults = {
         userAgent: 'userAgent',
         browserResolution: '1920x1080',
     };
-    let hrefStub: string;
-
-    let testSubject: CombinedReportGenerator;
 
     beforeEach(() => {
         scanStarted = new Date(2020, 11, 12);
-        loggerMock = Mock.ofType(MockableLogger);
         guidGeneratorMock = Mock.ofType(GuidGenerator);
-        reportGeneratorMock = Mock.ofType<ReportGenerator>();
+        axeResultToConsolidatedHtmlConverterMock = Mock.ofType<AxeResultToConsolidatedHtmlConverter>();
 
         websiteScanResult = {
             baseUrl,
@@ -49,23 +49,20 @@ describe(CombinedReportGenerator, () => {
         } as CombinedScanResults;
 
         generatedReportStub = {
-            content: 'consolidated report content',
+            id: reportId,
+            content: reportContent,
             format: 'consolidated.html',
         } as GeneratedReport;
 
-        hrefStub = 'href-stub';
-
-        testSubject = new CombinedReportGenerator(reportGeneratorMock.object, guidGeneratorMock.object, loggerMock.object);
+        testSubject = new CombinedReportGenerator(axeResultToConsolidatedHtmlConverterMock.object, guidGeneratorMock.object);
     });
 
     afterEach(() => {
         guidGeneratorMock.verifyAll();
-        loggerMock.verifyAll();
-        reportGeneratorMock.verifyAll();
+        axeResultToConsolidatedHtmlConverterMock.verifyAll();
     });
 
     it('generate combined scan report with existing combined result', () => {
-        const reportId = 'existing-report-id';
         websiteScanResult.reports = [
             {
                 reportId,
@@ -74,56 +71,64 @@ describe(CombinedReportGenerator, () => {
             },
         ];
 
-        setupGetConsolidatedReportCall(reportId);
+        setupAxeResultToConsolidatedHtmlConverterMock();
 
-        testSubject.generate(
+        const actualResult = testSubject.generate(
             combinedScanResults,
             websiteScanResult,
             passedAxeScanResults.userAgent,
             passedAxeScanResults.browserResolution,
         );
+
+        expect(actualResult).toEqual(generatedReportStub);
     });
 
     it('generate combined scan report with non-existing combined result', () => {
-        const reportId = 'new-report-id';
-
         guidGeneratorMock.setup((mock) => mock.createGuid()).returns(() => reportId);
-        setupGetConsolidatedReportCall(reportId);
+        setupAxeResultToConsolidatedHtmlConverterMock();
 
-        testSubject.generate(
+        const actualResult = testSubject.generate(
             combinedScanResults,
             websiteScanResult,
             passedAxeScanResults.userAgent,
             passedAxeScanResults.browserResolution,
         );
+
+        expect(actualResult).toEqual(generatedReportStub);
     });
 
     it('generate combined scan report with combined result without reports', () => {
-        const reportId = 'new-report-id';
         websiteScanResult.reports = [];
 
         guidGeneratorMock.setup((mock) => mock.createGuid()).returns(() => reportId);
-        setupGetConsolidatedReportCall(reportId);
+        setupAxeResultToConsolidatedHtmlConverterMock();
 
-        testSubject.generate(
+        const actualResult = testSubject.generate(
             combinedScanResults,
             websiteScanResult,
             passedAxeScanResults.userAgent,
             passedAxeScanResults.browserResolution,
         );
+
+        expect(actualResult).toEqual(generatedReportStub);
     });
 
-    function setupGetConsolidatedReportCall(givenReportId: string): void {
-        reportGeneratorMock
-            .setup((r) =>
-                r.generateConsolidatedReport(combinedScanResults, {
-                    reportId: givenReportId,
+    function setupAxeResultToConsolidatedHtmlConverterMock(): void {
+        axeResultToConsolidatedHtmlConverterMock
+            .setup((o) => o.targetReportFormat)
+            .returns(() => 'consolidated.html')
+            .verifiable();
+        axeResultToConsolidatedHtmlConverterMock
+            .setup((o) =>
+                o.convert(combinedScanResults, {
+                    serviceName: 'Accessibility Insights Service',
                     baseUrl,
                     userAgent: passedAxeScanResults.userAgent,
                     browserResolution: passedAxeScanResults.browserResolution,
                     scanStarted,
                 }),
             )
-            .returns(() => generatedReportStub);
+            .returns(() => reportContent)
+            .verifiable();
     }
 });

--- a/packages/service-library/src/combined-report-provider/combined-results-blob-provider.spec.ts
+++ b/packages/service-library/src/combined-report-provider/combined-results-blob-provider.spec.ts
@@ -4,11 +4,10 @@
 import 'reflect-metadata';
 
 import { GuidGenerator } from 'common';
-import { CombinedScanResultsProvider, CombinedScanResultsReadResponse } from 'service-library';
 import { IMock, Mock } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
-import { CombinedResultsBlob } from '../types/combined-results-blob';
-import { CombinedResultsBlobProvider } from './combined-results-blob-provider';
+import { CombinedScanResultsProvider, CombinedScanResultsReadResponse } from '../data-providers/combined-scan-results-provider';
+import { CombinedResultsBlobProvider, CombinedResultsBlob } from './combined-results-blob-provider';
 
 describe(CombinedResultsBlobProvider, () => {
     let combinedScanResultsProviderMock: IMock<CombinedScanResultsProvider>;

--- a/packages/service-library/src/combined-report-provider/combined-results-blob-provider.ts
+++ b/packages/service-library/src/combined-report-provider/combined-results-blob-provider.ts
@@ -4,8 +4,12 @@
 import { GuidGenerator } from 'common';
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
-import { CombinedScanResultsProvider, CombinedScanResultsReadResponse } from 'service-library';
-import { CombinedResultsBlob } from '../types/combined-results-blob';
+import { CombinedScanResultsReadResponse, CombinedScanResultsProvider } from '../data-providers/combined-scan-results-provider';
+
+export interface CombinedResultsBlob {
+    response: CombinedScanResultsReadResponse;
+    blobId: string;
+}
 
 @injectable()
 export class CombinedResultsBlobProvider {
@@ -21,7 +25,7 @@ export class CombinedResultsBlobProvider {
 
         if (existingCombinedResultsBlobId === undefined) {
             actualBlobId = this.guidGenerator.createGuid();
-            this.logger.logInfo('No combined axe scan results blob associated with this website scan. Creating a new blob.');
+            this.logger.logInfo('Combined axe scan results not found in a blob storage. Creating a new blob.');
             blobReadResponse = this.combinedScanResultsProvider.getEmptyResponse();
         } else {
             blobReadResponse = await this.getCombinedResultsBlob(actualBlobId);
@@ -35,7 +39,6 @@ export class CombinedResultsBlobProvider {
 
     private async getCombinedResultsBlob(combinedResultsBlobId: string | undefined): Promise<CombinedScanResultsReadResponse> {
         const response = await this.combinedScanResultsProvider.readCombinedResults(combinedResultsBlobId);
-
         if (response.error) {
             if (response.error.errorCode === 'blobNotFound') {
                 this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.');

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.spec.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.spec.ts
@@ -4,18 +4,17 @@
 import 'reflect-metadata';
 
 import { IMock, Mock, It, Times } from 'typemoq';
-import { ReportWriter, WebsiteScanResultProvider } from 'service-library';
 import { RetryHelper } from 'common';
 import { AxeScanResults } from 'scanner-global-library';
 import { AxeResults } from 'axe-core';
 import { OnDemandPageScanResult, WebsiteScanResult, CombinedScanResults, OnDemandPageScanReport } from 'storage-documents';
 import { MockableLogger } from '../test-utilities/mockable-logger';
-import { CombinedResultsBlob } from '../types/combined-results-blob';
-import { GeneratedReport } from '../report-generator/report-generator';
+import { WebsiteScanResultProvider } from '../data-providers/website-scan-result-provider';
+import { GeneratedReport, ReportWriter } from '../data-providers/report-writer';
 import { CombinedScanResultProcessor } from './combined-scan-result-processor';
 import { CombinedAxeResultBuilder } from './combined-axe-result-builder';
 import { CombinedReportGenerator } from './combined-report-generator';
-import { CombinedResultsBlobProvider } from './combined-results-blob-provider';
+import { CombinedResultsBlobProvider, CombinedResultsBlob } from './combined-results-blob-provider';
 
 let combinedAxeResultBuilderMock: IMock<CombinedAxeResultBuilder>;
 let combinedReportGeneratorMock: IMock<CombinedReportGenerator>;

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
@@ -4,9 +4,10 @@
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { RetryHelper, System } from 'common';
-import { ReportWriter, WebsiteScanResultProvider } from 'service-library';
 import { AxeScanResults } from 'scanner-global-library';
 import { OnDemandPageScanResult, WebsiteScanResult, WebsiteScanRef } from 'storage-documents';
+import { WebsiteScanResultProvider } from '../data-providers/website-scan-result-provider';
+import { ReportWriter } from '../data-providers/report-writer';
 import { CombinedAxeResultBuilder } from './combined-axe-result-builder';
 import { CombinedReportGenerator } from './combined-report-generator';
 import { CombinedResultsBlobProvider } from './combined-results-blob-provider';

--- a/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
+++ b/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
@@ -73,9 +73,14 @@ export class ReportGeneratorRequestProvider {
         return this.cosmosContainerClient.queryDocuments<ScanReportGroup>(query, continuationToken);
     }
 
-    public async writeRequest(request: ReportGeneratorRequest): Promise<ReportGeneratorRequest> {
-        this.setSystemProperties(request);
-        const operationResponse = this.cosmosContainerClient.mergeOrWriteDocument(request);
+    public async writeRequest(request: Partial<ReportGeneratorRequest>): Promise<ReportGeneratorRequest> {
+        if (request.id === undefined) {
+            throw new Error(`Cannot write report generator request document without id: ${JSON.stringify(request)}`);
+        }
+
+        const persistedResult = request as ReportGeneratorRequest;
+        this.setSystemProperties(persistedResult);
+        const operationResponse = this.cosmosContainerClient.mergeOrWriteDocument(persistedResult);
 
         return (await operationResponse).item;
     }

--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -30,3 +30,6 @@ export { BatchRequestLoader } from './dev-utilities/batch-request-loader';
 export { ReportWriter, GeneratedReport } from './data-providers/report-writer';
 export * from './data-providers/privacy-scan-combined-report-provider';
 export * from './data-providers/report-generator-request-data-provider';
+export { ScanNotificationDispatcher } from './processors/scan-notification-dispatcher';
+export { ScanNotificationProcessor } from './processors/scan-notification-processor';
+export { RunnerScanMetadata } from './types/runner-scan-metadata';

--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -33,3 +33,4 @@ export * from './data-providers/report-generator-request-data-provider';
 export { ScanNotificationDispatcher } from './processors/scan-notification-dispatcher';
 export { ScanNotificationProcessor } from './processors/scan-notification-processor';
 export { RunnerScanMetadata } from './types/runner-scan-metadata';
+export { CombinedScanResultProcessor } from './combined-report-provider/combined-scan-result-processor';

--- a/packages/service-library/src/processors/scan-notification-dispatcher.spec.ts
+++ b/packages/service-library/src/processors/scan-notification-dispatcher.spec.ts
@@ -7,7 +7,6 @@ import { Queue, StorageConfig } from 'azure-services';
 import { RetryHelper, ScanRunTimeConfig, ServiceConfiguration } from 'common';
 import { cloneDeep } from 'lodash';
 import { Logger } from 'logger';
-import { OnDemandPageScanRunResultProvider } from 'service-library';
 import {
     ItemType,
     NotificationError,
@@ -18,14 +17,15 @@ import {
     ScanCompletedNotification,
 } from 'storage-documents';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { NotificationMessageDispatcher } from './notification-message-dispatcher';
+import { OnDemandPageScanRunResultProvider } from '../data-providers/on-demand-page-scan-run-result-provider';
+import { ScanNotificationDispatcher } from './scan-notification-dispatcher';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
 
 class MockableLogger extends Logger {}
 
-describe(NotificationMessageDispatcher, () => {
-    let notificationMessageDispatcher: NotificationMessageDispatcher;
+describe(ScanNotificationDispatcher, () => {
+    let notificationMessageDispatcher: ScanNotificationDispatcher;
     let onDemandPageScanRunResultProviderMock: IMock<OnDemandPageScanRunResultProvider>;
     let queueMock: IMock<Queue>;
     let loggerMock: IMock<MockableLogger>;
@@ -77,7 +77,7 @@ describe(NotificationMessageDispatcher, () => {
             .verifiable(Times.once());
         retryHelperMock = Mock.ofType<RetryHelper<void>>();
 
-        notificationMessageDispatcher = new NotificationMessageDispatcher(
+        notificationMessageDispatcher = new ScanNotificationDispatcher(
             onDemandPageScanRunResultProviderMock.object,
             serviceConfigMock.object,
             storageConfigStub,

--- a/packages/service-library/src/types/runner-scan-metadata.ts
+++ b/packages/service-library/src/types/runner-scan-metadata.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export interface ScanMetadata {
+export interface RunnerScanMetadata {
     id: string;
     url: string;
     deepScan?: boolean;

--- a/packages/storage-documents/jest.config.js
+++ b/packages/storage-documents/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -81,5 +81,6 @@ export interface OnDemandPageScanRunResult {
 
 export interface WebsiteScanRef {
     id: string;
+    scanGroupId: string;
     scanGroupType: ScanGroupType;
 }

--- a/packages/storage-documents/src/report-generator-request.ts
+++ b/packages/storage-documents/src/report-generator-request.ts
@@ -7,6 +7,7 @@ import { ItemType } from './item-type';
 
 export interface ReportGeneratorRequest extends StorageDocument {
     itemType: ItemType.reportGeneratorRequest;
+    scanId: string;
     scanGroupId: string;
     priority: number;
     reports?: OnDemandPageScanReport[];

--- a/packages/web-api-client/jest.config.js
+++ b/packages/web-api-client/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/web-api-scan-job-manager/jest.config.js
+++ b/packages/web-api-scan-job-manager/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/web-api-scan-request-sender/jest.config.js
+++ b/packages/web-api-scan-request-sender/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/web-api-scan-runner/jest.config.js
+++ b/packages/web-api-scan-runner/jest.config.js
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 

--- a/packages/web-api-scan-runner/src/combined-result/combined-scan-result-processor.spec.ts
+++ b/packages/web-api-scan-runner/src/combined-result/combined-scan-result-processor.spec.ts
@@ -91,10 +91,6 @@ describe(CombinedScanResultProcessor, () => {
         loggerMock.verifyAll();
     });
 
-    it('skip generating combined report if no scan group is defined', async () => {
-        await combinedScanResultProcessor.generateCombinedScanResults(axeScanResults, pageScanResult);
-    });
-
     it('generate combined report for consolidated scan request', async () => {
         pageScanResult = {
             id: 'id',

--- a/packages/web-api-scan-runner/src/combined-result/combined-scan-result-processor.ts
+++ b/packages/web-api-scan-runner/src/combined-result/combined-scan-result-processor.ts
@@ -42,10 +42,6 @@ export class CombinedScanResultProcessor {
 
     private async generateCombinedScanResultsImpl(axeScanResults: AxeScanResults, pageScanResult: OnDemandPageScanResult): Promise<void> {
         const websiteScanRef = this.getWebsiteScanRefs(pageScanResult);
-        if (!websiteScanRef) {
-            return;
-        }
-
         const websiteScanResult = await this.websiteScanResultProvider.read(websiteScanRef.id);
         const combinedResultsBlob = await this.combinedResultsBlobProvider.getBlob(websiteScanResult.combinedResultsBlobId);
         const combinedResultsBlobId = combinedResultsBlob.blobId;
@@ -81,10 +77,6 @@ export class CombinedScanResultProcessor {
     }
 
     private getWebsiteScanRefs(pageScanResult: OnDemandPageScanResult): WebsiteScanRef {
-        if (!pageScanResult.websiteScanRefs) {
-            return undefined;
-        }
-
         return pageScanResult.websiteScanRefs.find(
             (ref) => ref.scanGroupType === 'consolidated-scan-report' || ref.scanGroupType === 'deep-scan',
         );

--- a/packages/web-api-scan-runner/src/report-generator/report-generator.ts
+++ b/packages/web-api-scan-runner/src/report-generator/report-generator.ts
@@ -4,10 +4,9 @@
 import { GuidGenerator } from 'common';
 import { inject, injectable } from 'inversify';
 import { AxeScanResults } from 'scanner-global-library';
-import { ReportFormat, CombinedScanResults } from 'storage-documents';
+import { ReportFormat } from 'storage-documents';
 import { iocTypeNames } from '../ioc-types';
 import { AxeResultConverter, AxeResultConverterOptions } from './axe-result-converter';
-import { AxeResultToConsolidatedHtmlConverter } from './axe-result-to-consolidated-html-converter';
 
 export type GeneratedReport = {
     content: string;
@@ -20,7 +19,6 @@ export class ReportGenerator {
     constructor(
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
         @inject(iocTypeNames.AxeResultConverters) private readonly axeResultConverters: AxeResultConverter[],
-        @inject(AxeResultToConsolidatedHtmlConverter) private readonly combinedAxeResultConverter: AxeResultToConsolidatedHtmlConverter,
     ) {}
 
     public generateReports(axeResults: AxeScanResults): GeneratedReport[] {
@@ -35,13 +33,5 @@ export class ReportGenerator {
                 format: axeResultConverter.targetReportFormat,
             };
         });
-    }
-
-    public generateConsolidatedReport(combinedScanResults: CombinedScanResults, options: AxeResultConverterOptions): GeneratedReport {
-        return {
-            content: this.combinedAxeResultConverter.convert(combinedScanResults, options),
-            id: options.reportId,
-            format: this.combinedAxeResultConverter.targetReportFormat,
-        };
     }
 }

--- a/packages/web-api-scan-runner/src/runner-scan-metadata-config.spec.ts
+++ b/packages/web-api-scan-runner/src/runner-scan-metadata-config.spec.ts
@@ -5,19 +5,19 @@ import 'reflect-metadata';
 
 import { IMock, Mock, Times } from 'typemoq';
 import { Argv } from 'yargs';
-import { ScanMetadataConfig } from './scan-metadata-config';
-import { ScanMetadata } from './types/scan-metadata';
+import { RunnerScanMetadata } from 'service-library';
+import { RunnerScanMetadataConfig } from './runner-scan-metadata-config';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-describe(ScanMetadataConfig, () => {
-    let testSubject: ScanMetadataConfig;
+describe(RunnerScanMetadataConfig, () => {
+    let testSubject: RunnerScanMetadataConfig;
     let argvMock: IMock<Argv>;
     const argvVal = { foo: 'test' };
 
     beforeEach(() => {
         argvMock = Mock.ofType<Argv>();
-        testSubject = new ScanMetadataConfig(argvMock.object);
+        testSubject = new RunnerScanMetadataConfig(argvMock.object);
         argvMock
             .setup((a) => a.env())
             .returns(() => argvMock.object as any)
@@ -34,21 +34,21 @@ describe(ScanMetadataConfig, () => {
     });
 
     describe('yargs integration', () => {
-        const args: ScanMetadata = {
+        const args: RunnerScanMetadata = {
             id: 'scan id',
             url: 'url',
             deepScan: true,
         };
 
         beforeEach(() => {
-            testSubject = new ScanMetadataConfig();
-            Object.keys(args).forEach((varName: keyof ScanMetadata) => {
+            testSubject = new RunnerScanMetadataConfig();
+            Object.keys(args).forEach((varName: keyof RunnerScanMetadata) => {
                 process.env[varName] = `${args[varName]}`;
             });
         });
 
         afterEach(() => {
-            Object.keys(args).forEach((varName: keyof ScanMetadata) => {
+            Object.keys(args).forEach((varName: keyof RunnerScanMetadata) => {
                 process.env[varName] = undefined;
             });
         });

--- a/packages/web-api-scan-runner/src/runner-scan-metadata-config.ts
+++ b/packages/web-api-scan-runner/src/runner-scan-metadata-config.ts
@@ -3,10 +3,10 @@
 
 import { injectable } from 'inversify';
 import yargs, { Arguments, Argv } from 'yargs';
-import { ScanMetadata } from './types/scan-metadata';
+import { RunnerScanMetadata } from 'service-library';
 
 @injectable()
-export class ScanMetadataConfig {
+export class RunnerScanMetadataConfig {
     constructor(private readonly argvObj: Argv = yargs) {
         argvObj.options({
             deepScan: {
@@ -16,9 +16,9 @@ export class ScanMetadataConfig {
         });
     }
 
-    public getConfig(): ScanMetadata {
+    public getConfig(): RunnerScanMetadata {
         this.argvObj.env().demandOption(['id', 'url']);
 
-        return this.argvObj.argv as Arguments<ScanMetadata>;
+        return this.argvObj.argv as Arguments<RunnerScanMetadata>;
     }
 }

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -12,6 +12,7 @@ import {
     ReportGeneratorRequestProvider,
     ScanNotificationProcessor,
     RunnerScanMetadata,
+    CombinedScanResultProcessor,
 } from 'service-library';
 import { GlobalLogger } from 'logger';
 import * as MockDate from 'mockdate';
@@ -28,7 +29,6 @@ import { AxeResults } from 'axe-core';
 import { RunnerScanMetadataConfig } from '../runner-scan-metadata-config';
 import { PageScanProcessor } from '../scanner/page-scan-processor';
 import { ReportGenerator, GeneratedReport } from '../report-generator/report-generator';
-import { CombinedScanResultProcessor } from '../combined-result/combined-scan-result-processor';
 import { ScanRunnerTelemetryManager } from '../scan-runner-telemetry-manager';
 import { Runner } from './runner';
 

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -11,6 +11,7 @@ import {
     ReportGeneratorRequestProvider,
     ScanNotificationProcessor,
     RunnerScanMetadata,
+    CombinedScanResultProcessor,
 } from 'service-library';
 import {
     OnDemandPageScanReport,
@@ -26,7 +27,6 @@ import { isEmpty, isString } from 'lodash';
 import { ReportGenerator } from '../report-generator/report-generator';
 import { RunnerScanMetadataConfig } from '../runner-scan-metadata-config';
 import { ScanRunnerTelemetryManager } from '../scan-runner-telemetry-manager';
-import { CombinedScanResultProcessor } from '../combined-result/combined-scan-result-processor';
 import { PageScanProcessor } from '../scanner/page-scan-processor';
 
 @injectable()

--- a/packages/web-api-scan-runner/src/scanner/deep-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/deep-scanner.ts
@@ -7,9 +7,8 @@ import { inject, injectable } from 'inversify';
 import { isNil } from 'lodash';
 import { GlobalLogger } from 'logger';
 import { Page } from 'scanner-global-library';
-import { WebsiteScanResultProvider } from 'service-library';
+import { WebsiteScanResultProvider, RunnerScanMetadata } from 'service-library';
 import { OnDemandPageScanResult, WebsiteScanResult } from 'storage-documents';
-import { ScanMetadata } from '../types/scan-metadata';
 import { DiscoveredUrlProcessor, discoveredUrlProcessor } from '../crawl-runner/discovered-url-processor';
 import { CrawlRunner } from '../crawl-runner/crawl-runner';
 import { ScanFeedGenerator } from '../crawl-runner/scan-feed-generator';
@@ -26,7 +25,7 @@ export class DeepScanner {
         private readonly discoveryPatternGenerator: DiscoveryPatternFactory = getDiscoveryPatternForUrl,
     ) {}
 
-    public async runDeepScan(scanMetadata: ScanMetadata, pageScanResult: OnDemandPageScanResult, page: Page): Promise<void> {
+    public async runDeepScan(runnerScanMetadata: RunnerScanMetadata, pageScanResult: OnDemandPageScanResult, page: Page): Promise<void> {
         const websiteScanResult = await this.readWebsiteScanResult(pageScanResult);
         this.logger.setCommonProperties({
             websiteScanId: websiteScanResult.id,
@@ -44,10 +43,10 @@ export class DeepScanner {
         }
 
         const discoveryPatterns = websiteScanResult.discoveryPatterns ?? [this.discoveryPatternGenerator(websiteScanResult.baseUrl)];
-        const discoveredUrls = await this.crawlRunner.run(scanMetadata.url, discoveryPatterns, page.currentPage);
+        const discoveredUrls = await this.crawlRunner.run(runnerScanMetadata.url, discoveryPatterns, page.currentPage);
         const processedUrls = this.processUrls(discoveredUrls, deepScanDiscoveryLimit, websiteScanResult.knownPages);
         const websiteScanResultUpdated = await this.updateWebsiteScanResult(
-            scanMetadata.id,
+            runnerScanMetadata.id,
             websiteScanResult,
             processedUrls,
             discoveryPatterns,

--- a/packages/web-api-scan-runner/src/scanner/page-scan-processor.ts
+++ b/packages/web-api-scan-runner/src/scanner/page-scan-processor.ts
@@ -6,8 +6,8 @@ import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { AxeScanResults, Page, BrowserError } from 'scanner-global-library';
 import { OnDemandPageScanResult } from 'storage-documents';
+import { RunnerScanMetadata } from 'service-library';
 import { AxeScanner } from '../scanner/axe-scanner';
-import { ScanMetadata } from '../types/scan-metadata';
 import { DeepScanner } from './deep-scanner';
 
 @injectable()
@@ -21,16 +21,16 @@ export class PageScanProcessor {
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
     ) {}
 
-    public async scan(scanMetadata: ScanMetadata, pageScanResult: OnDemandPageScanResult): Promise<AxeScanResults> {
+    public async scan(runnerScanMetadata: RunnerScanMetadata, pageScanResult: OnDemandPageScanResult): Promise<AxeScanResults> {
         let axeScanResults: AxeScanResults;
         try {
-            await this.openPage(scanMetadata.url);
+            await this.openPage(runnerScanMetadata.url);
 
             axeScanResults = await this.scanForA11yIssues();
 
-            if (scanMetadata.deepScan) {
+            if (runnerScanMetadata.deepScan) {
                 if (this.page.isOpen()) {
-                    await this.deepScanner.runDeepScan(scanMetadata, pageScanResult, this.page);
+                    await this.deepScanner.runDeepScan(runnerScanMetadata, pageScanResult, this.page);
                     this.logger.logInfo('The deep scanner completed a page scan.');
                 } else {
                     this.logger.logError('Page is not ready. Unable to perform deep scan.');

--- a/packages/web-api-scan-runner/src/types/combined-results-blob.ts
+++ b/packages/web-api-scan-runner/src/types/combined-results-blob.ts
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-import { CombinedScanResultsReadResponse } from 'service-library';
-
-export interface CombinedResultsBlob {
-    response: CombinedScanResultsReadResponse;
-    blobId: string;
-}

--- a/packages/web-api-send-notification-job-manager/jest.config.js
+++ b/packages/web-api-send-notification-job-manager/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/web-api-send-notification-runner/jest.config.js
+++ b/packages/web-api-send-notification-runner/jest.config.js
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 

--- a/packages/web-api/jest.config.js
+++ b/packages/web-api/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
@@ -48,6 +48,7 @@ describe(BatchScanResultController, () => {
         websiteScanRefs: [
             {
                 id: 'websiteScanId',
+                scanGroupId: 'scanGroupId',
                 scanGroupType: 'deep-scan',
             },
         ],

--- a/packages/web-api/src/controllers/scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.spec.ts
@@ -53,6 +53,7 @@ describe(ScanResultController, () => {
         websiteScanRefs: [
             {
                 id: 'websiteScanId',
+                scanGroupId: 'scanGroupId',
                 scanGroupType: 'deep-scan',
             },
         ],

--- a/packages/web-workers/jest.config.js
+++ b/packages/web-workers/jest.config.js
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 const baseConfig = require('../../jest.config.base');
 const package = require('./package');
 
 module.exports = {
     ...baseConfig,
     displayName: package.name,
+    moduleNameMapper: {
+        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
+    },
 };

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -251,7 +251,11 @@ function setupOnDemandPageScanRunResultProviderMock(
                 const websiteScanRefs = websiteScanResults
                     .filter((r) => r.pageScans[0].scanId === request.scanId)
                     .map((r) => {
-                        return { id: r.id, scanGroupType: r.scanGroupType } as WebsiteScanRef;
+                        return {
+                            id: r.id,
+                            scanGroupId: r.scanGroupId,
+                            scanGroupType: r.scanGroupType,
+                        } as WebsiteScanRef;
                     });
                 const result: OnDemandPageScanResult = {
                     id: request.scanId,

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -91,7 +91,11 @@ export class ScanBatchRequestFeedController extends WebController {
             let websiteScanRefs: WebsiteScanRef;
             const websiteScanResult = this.createWebsiteScanResult(request);
             if (websiteScanResult) {
-                websiteScanRefs = { id: websiteScanResult.id, scanGroupType: websiteScanResult.scanGroupType };
+                websiteScanRefs = {
+                    id: websiteScanResult.id,
+                    scanGroupId: websiteScanResult.scanGroupId,
+                    scanGroupType: websiteScanResult.scanGroupType,
+                };
                 websiteScanResults.push({ scanId: request.scanId, websiteScanResult });
                 this.logger.logInfo('Referenced website scan result document to the new scan result document.', {
                     batchRequestId,


### PR DESCRIPTION
#### Details

Added creation of report generation request in a11y scan runner
Move scan notification under service-library package
Moved combined report provider under service-library package

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
