### PR TITLE
Allow page have open network connections on load

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js",

--- a/packages/scanner-global-library/src/page-navigator.spec.ts
+++ b/packages/scanner-global-library/src/page-navigator.spec.ts
@@ -42,7 +42,7 @@ describe(PageNavigator, () => {
         pageMock
             .setup(async (o) =>
                 o.goto(url, {
-                    waitUntil: 'networkidle0',
+                    waitUntil: 'networkidle2',
                     timeout: pageNavigator.gotoTimeoutMsecs,
                 }),
             )
@@ -74,7 +74,7 @@ describe(PageNavigator, () => {
         pageMock
             .setup(async (o) =>
                 o.goto(url, {
-                    waitUntil: 'networkidle0',
+                    waitUntil: 'networkidle2',
                     timeout: pageNavigator.gotoTimeoutMsecs,
                 }),
             )
@@ -114,7 +114,7 @@ describe(PageNavigator, () => {
         pageMock
             .setup(async (o) =>
                 o.goto(url, {
-                    waitUntil: 'networkidle0',
+                    waitUntil: 'networkidle2',
                     timeout: pageNavigator.gotoTimeoutMsecs,
                 }),
             )

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -34,7 +34,7 @@ export class PageNavigator {
         await this.pageConfigurator.configurePage(page);
 
         // Try load all page resources
-        let navigationResult = await this.navigateToUrl(url, page, 'networkidle0');
+        let navigationResult = await this.navigateToUrl(url, page, 'networkidle2');
         if (navigationResult.browserError?.errorType === 'UrlNavigationTimeout') {
             // Fallback to load partial page resources on navigation timeout.
             // This will help in cases when page has a streaming video controls.


### PR DESCRIPTION
#### Details

Allow web page have active connection to reduce browser page load wait time.

[Puppeteer API](https://www.puppeteersharp.com/api/PuppeteerSharp.WaitUntilNavigation.html)

Networkidle2 | Consider navigation to be finished when there are no more than 2 network connections for at least 500 ms
-- | --

##### Motivation

Addresses issue #2002

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: Fixes #2002
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
