### PR TITLE
(Node 16 update) Create NavigationHooks and make other refactors

### DIFF
--- a/packages/crawler/src/apify/apify-settings.ts
+++ b/packages/crawler/src/apify/apify-settings.ts
@@ -25,6 +25,6 @@ export const apifySettingsHandler: ApifySettingsHandler = {
     getApifySettings(): ApifySettings {
         return {
             ...process.env,
-        };
+        } as ApifySettings;
     },
 };

--- a/packages/crawler/src/crawler.spec.ts
+++ b/packages/crawler/src/crawler.spec.ts
@@ -9,15 +9,18 @@ import { CrawlerRunOptions } from './types/crawler-run-options';
 import { crawlerIocTypes } from './types/ioc-types';
 import { Crawler } from './crawler';
 import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
+import { CrawlerConfiguration } from './crawler/crawler-configuration';
 
 describe(Crawler, () => {
     let testSubject: Crawler<void>;
     let containerMock: IMock<Container>;
+    let crawlerConfigMock: IMock<CrawlerConfiguration>;
     let crawlerEngineMock: IMock<PuppeteerCrawlerEngine>;
     let containerBindMock: IMock<interfaces.BindingToSyntax<CrawlerRunOptions>>;
 
     beforeEach(() => {
         containerMock = Mock.ofType(Container);
+        crawlerConfigMock = Mock.ofType(CrawlerConfiguration);
         crawlerEngineMock = Mock.ofType(PuppeteerCrawlerEngine);
         containerBindMock = Mock.ofType<interfaces.BindingToSyntax<CrawlerRunOptions>>();
 
@@ -26,6 +29,7 @@ describe(Crawler, () => {
 
     afterEach(() => {
         containerMock.verifyAll();
+        crawlerConfigMock.verifyAll();
         crawlerEngineMock.verifyAll();
         containerBindMock.verifyAll();
     });
@@ -36,11 +40,11 @@ describe(Crawler, () => {
             .setup((c) => c.get(crawlerIocTypes.CrawlerEngine))
             .returns(() => crawlerEngineMock.object)
             .verifiable();
-        containerBindMock.setup((o) => o.toConstantValue(testInput)).verifiable();
         containerMock
-            .setup((c) => c.bind(crawlerIocTypes.CrawlerRunOptions))
-            .returns(() => containerBindMock.object)
+            .setup((c) => c.get(CrawlerConfiguration))
+            .returns(() => crawlerConfigMock.object)
             .verifiable();
+        crawlerConfigMock.setup((c) => c.setCrawlerRunOptions(testInput)).verifiable();
         const startCommand = jest.spyOn(crawlerEngineMock.object, 'start').mockImplementationOnce(async () => Promise.resolve());
 
         await testSubject.crawl(testInput);

--- a/packages/crawler/src/crawler.ts
+++ b/packages/crawler/src/crawler.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import { interfaces } from 'inversify';
+import { CrawlerConfiguration } from './crawler/crawler-configuration';
 import { CrawlerEngine } from './crawler/crawler-engine';
-import { registerCrawlerRunOptions } from './setup-crawler-container';
 import { CrawlerRunOptions } from './types/crawler-run-options';
 import { crawlerIocTypes } from './types/ioc-types';
 
@@ -11,7 +11,8 @@ export class Crawler<T> {
     constructor(private readonly container: interfaces.Container) {}
 
     public async crawl(crawlerRunOptions: CrawlerRunOptions): Promise<T> {
-        registerCrawlerRunOptions(this.container, crawlerRunOptions);
+        const crawlerConfig = this.container.get(CrawlerConfiguration);
+        crawlerConfig.setCrawlerRunOptions(crawlerRunOptions);
 
         return (this.container.get(crawlerIocTypes.CrawlerEngine) as CrawlerEngine<T>).start(crawlerRunOptions);
     }

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -183,6 +183,17 @@ describe(CrawlerConfiguration, () => {
         });
     });
 
+    describe('getChromePath', () => {
+        it('explicitly set chromePath', () => {
+            crawlerRunOptionsMock
+                .setup((o) => o.chromePath)
+                .returns(() => 'chrome path')
+                .verifiable();
+
+            expect(crawlerConfiguration.chromePath()).toEqual('chrome path');
+        });
+    });
+
     describe('getMaxRequestsPerCrawl', () => {
         it('with no value provided', () => {
             crawlerRunOptionsMock
@@ -256,6 +267,26 @@ describe(CrawlerConfiguration, () => {
             existingSettings.APIFY_HEADLESS = undefined;
 
             crawlerConfiguration.setDefaultApifySettings();
+        });
+
+        it('setLocalOutputDir', () => {
+            const outputDir = 'localOutputDir';
+            const expectedSettings = {
+                APIFY_LOCAL_STORAGE_DIR: outputDir,
+            };
+            apifySettingsHandlerMock.setup((ash) => ash.setApifySettings(expectedSettings)).verifiable();
+
+            crawlerConfiguration.setLocalOutputDir(outputDir);
+        });
+
+        it('setMemoryMBytes', () => {
+            const memoryMBytes = 1024;
+            const expectedSettings = {
+                APIFY_MEMORY_MBYTES: `${memoryMBytes}`,
+            };
+            apifySettingsHandlerMock.setup((ash) => ash.setApifySettings(expectedSettings)).verifiable();
+
+            crawlerConfiguration.setMemoryMBytes(memoryMBytes);
         });
 
         it('setChromePath', () => {

--- a/packages/crawler/src/crawler/simple-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/simple-crawler-engine.spec.ts
@@ -138,7 +138,8 @@ describe(SimpleCrawlerEngine, () => {
             debug: true,
         };
 
-        const testCrawlerConfiguration = new CrawlerConfiguration(testCrawlerRunOptions);
+        const testCrawlerConfiguration = new CrawlerConfiguration();
+        testCrawlerConfiguration.setCrawlerRunOptions(testCrawlerRunOptions);
         const requestQueueProvider = () =>
             apifyResourceCreator.createRequestQueue(testBaseUrl, {
                 clear: true,

--- a/packages/crawler/src/setup-crawler-container.spec.ts
+++ b/packages/crawler/src/setup-crawler-container.spec.ts
@@ -8,24 +8,14 @@ import { registerLoggerToContainer } from 'logger';
 import { CrawlerConfiguration } from './crawler/crawler-configuration';
 import { DataBase } from './level-storage/data-base';
 import { setupCloudCrawlerContainer, setupLocalCrawlerContainer } from './setup-crawler-container';
-import { CrawlerRunOptions } from './types/crawler-run-options';
 import { crawlerIocTypes } from './types/ioc-types';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
 describe(setupLocalCrawlerContainer, () => {
     it('resolves dependencies', () => {
-        const crawlerRunOptions = {
-            baseUrl: 'baseUrl',
-            restartCrawl: false,
-            inputFile: undefined,
-            existingUrls: undefined,
-            simulate: false,
-        } as CrawlerRunOptions;
-
         const container = new inversify.Container({ autoBindInjectable: true });
         setupLocalCrawlerContainer(container);
-        container.bind(crawlerIocTypes.CrawlerRunOptions).toConstantValue(crawlerRunOptions);
 
         expect(container.get(CrawlerConfiguration)).toBeDefined();
         expect(container.get(DataBase)).toBeDefined();
@@ -38,18 +28,9 @@ describe(setupLocalCrawlerContainer, () => {
 
 describe(setupCloudCrawlerContainer, () => {
     it('resolves dependencies', () => {
-        const crawlerRunOptions = {
-            baseUrl: 'baseUrl',
-            restartCrawl: false,
-            inputFile: undefined,
-            existingUrls: undefined,
-            simulate: false,
-        } as CrawlerRunOptions;
-
         const container = new inversify.Container({ autoBindInjectable: true });
         registerLoggerToContainer(container);
         setupCloudCrawlerContainer(container);
-        container.bind(crawlerIocTypes.CrawlerRunOptions).toConstantValue(crawlerRunOptions);
 
         expect(container.get(CrawlerConfiguration)).toBeDefined();
         expect(container.get(crawlerIocTypes.ApifyRequestQueueProvider)).toBeDefined();

--- a/packages/crawler/src/setup-crawler-container.ts
+++ b/packages/crawler/src/setup-crawler-container.ts
@@ -5,6 +5,7 @@ import { reporterFactory } from 'accessibility-insights-report';
 import * as inversify from 'inversify';
 import { ApifyResourceCreator } from './apify/apify-resource-creator';
 import { Crawler } from './crawler';
+import { CrawlerConfiguration } from './crawler/crawler-configuration';
 import { PuppeteerCrawlerEngine } from './crawler/puppeteer-crawler-engine';
 import { SimpleCrawlerEngine } from './crawler/simple-crawler-engine';
 import { DataBase } from './level-storage/data-base';
@@ -12,33 +13,28 @@ import { ClassicPageProcessor } from './page-processors/classic-page-processor';
 import { PageProcessor } from './page-processors/page-processor-base';
 import { SimulatorPageProcessor } from './page-processors/simulator-page-processor';
 import { UrlCollectionRequestProcessor } from './page-processors/url-collection-request-processor';
-import { CrawlerRunOptions } from './types/crawler-run-options';
 import { crawlerIocTypes } from './types/ioc-types';
 
 export function setupLocalCrawlerContainer(container: inversify.Container): inversify.Container {
     container.bind(DataBase).toSelf().inSingletonScope();
+    container.bind(CrawlerConfiguration).toSelf().inSingletonScope();
     container.bind(crawlerIocTypes.ReporterFactory).toConstantValue(reporterFactory);
     container.bind(crawlerIocTypes.CrawlerEngine).to(PuppeteerCrawlerEngine);
 
     setupSingletonProvider(crawlerIocTypes.ApifyRequestQueueProvider, container, async (context: inversify.interfaces.Context) => {
         const apifyResourceCreator = context.container.get(ApifyResourceCreator);
-        const crawlerRunOptions = context.container.get<CrawlerRunOptions>(crawlerIocTypes.CrawlerRunOptions);
+        const crawlerConfiguration = context.container.get(CrawlerConfiguration);
 
-        return apifyResourceCreator.createRequestQueue(crawlerRunOptions.baseUrl, {
-            clear: crawlerRunOptions.restartCrawl,
-            inputUrls: crawlerRunOptions.inputUrls,
-            page: crawlerRunOptions.baseCrawlPage,
-            discoveryPatterns: crawlerRunOptions.discoveryPatterns,
-        });
+        return apifyResourceCreator.createRequestQueue(crawlerConfiguration.baseUrl(), crawlerConfiguration.requestQueueOptions());
     });
 
     container
         .bind<inversify.interfaces.Factory<PageProcessor>>(crawlerIocTypes.PageProcessorFactory)
         .toFactory<PageProcessor>((context: inversify.interfaces.Context) => {
-            const crawlerRunOptions = context.container.get<CrawlerRunOptions>(crawlerIocTypes.CrawlerRunOptions);
+            const crawlerConfiguration = context.container.get(CrawlerConfiguration);
 
             return () => {
-                if (crawlerRunOptions.simulate) {
+                if (crawlerConfiguration.simulate()) {
                     return context.container.get(SimulatorPageProcessor);
                 } else {
                     return context.container.get(ClassicPageProcessor);
@@ -51,16 +47,12 @@ export function setupLocalCrawlerContainer(container: inversify.Container): inve
 
 export function setupCloudCrawlerContainer(container: inversify.Container): inversify.Container {
     container.bind(crawlerIocTypes.CrawlerEngine).to(SimpleCrawlerEngine);
+    container.bind(CrawlerConfiguration).toSelf().inSingletonScope();
     setupSingletonProvider(crawlerIocTypes.ApifyRequestQueueProvider, container, async (context: inversify.interfaces.Context) => {
         const apifyResourceCreator = context.container.get(ApifyResourceCreator);
-        const crawlerRunOptions = context.container.get<CrawlerRunOptions>(crawlerIocTypes.CrawlerRunOptions);
+        const crawlerConfiguration = context.container.get(CrawlerConfiguration);
 
-        return apifyResourceCreator.createRequestQueue(crawlerRunOptions.baseUrl, {
-            clear: crawlerRunOptions.restartCrawl,
-            inputUrls: crawlerRunOptions.inputUrls,
-            page: crawlerRunOptions.baseCrawlPage,
-            discoveryPatterns: crawlerRunOptions.discoveryPatterns,
-        });
+        return apifyResourceCreator.createRequestQueue(crawlerConfiguration.baseUrl(), crawlerConfiguration.requestQueueOptions());
     });
 
     container.bind(crawlerIocTypes.RequestProcessor).to(UrlCollectionRequestProcessor);
@@ -70,10 +62,6 @@ export function setupCloudCrawlerContainer(container: inversify.Container): inve
     });
 
     return container;
-}
-
-export function registerCrawlerRunOptions(container: inversify.interfaces.Container, crawlerRunOptions: CrawlerRunOptions): void {
-    container.bind(crawlerIocTypes.CrawlerRunOptions).toConstantValue(crawlerRunOptions);
 }
 
 function setupSingletonProvider<T>(

--- a/packages/crawler/src/types/ioc-types.ts
+++ b/packages/crawler/src/types/ioc-types.ts
@@ -6,7 +6,6 @@ import { PageProcessorBase } from '../page-processors/page-processor-base';
 
 export const crawlerIocTypes = {
     ReporterFactory: 'ReporterFactory',
-    CrawlerRunOptions: 'CrawlerRunOptions',
     PageProcessorFactory: 'Factory<PageProcessor>',
     ApifyRequestQueueProvider: 'Provider<ApifyRequestQueue>',
     ApifyKeyValueStore: 'ApifyKeyValueStore',

--- a/packages/scanner-global-library/src/index.ts
+++ b/packages/scanner-global-library/src/index.ts
@@ -10,5 +10,6 @@ export { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';
 export { Page } from './page';
 export { AxeScanResults } from './axe-scan-results';
 export { WebDriver } from './web-driver';
+export { NavigationHooks } from './navigation-hooks';
 export { PageNavigator, OnNavigationError } from './page-navigator';
 export { PrivacyScanResult } from './privacy-scan-result';

--- a/packages/scanner-global-library/src/navigation-hooks.spec.ts
+++ b/packages/scanner-global-library/src/navigation-hooks.spec.ts
@@ -12,7 +12,6 @@ import { BrowserError } from './browser-error';
 import { NavigationHooks } from './navigation-hooks';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
-const scrollTimeoutMsecs = 15000;
 const pageRenderingTimeoutMsecs = 1000;
 
 let pageConfiguratorMock: IMock<PageConfigurator>;
@@ -33,7 +32,6 @@ describe(NavigationHooks, () => {
             pageConfiguratorMock.object,
             pageResponseProcessorMock.object,
             pageHandlerMock.object,
-            scrollTimeoutMsecs,
             pageRenderingTimeoutMsecs,
         );
     });
@@ -58,7 +56,7 @@ describe(NavigationHooks, () => {
             .returns(() => undefined)
             .verifiable();
         pageHandlerMock
-            .setup(async (o) => o.waitForPageToCompleteRendering(pageMock.object, scrollTimeoutMsecs, pageRenderingTimeoutMsecs))
+            .setup(async (o) => o.waitForPageToCompleteRendering(pageMock.object, pageRenderingTimeoutMsecs))
             .returns(() => Promise.resolve())
             .verifiable();
 

--- a/packages/scanner-global-library/src/navigation-hooks.spec.ts
+++ b/packages/scanner-global-library/src/navigation-hooks.spec.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { IMock, Mock } from 'typemoq';
+import { Page, Response } from 'puppeteer';
+import { PageResponseProcessor } from './page-response-processor';
+import { PageConfigurator } from './page-configurator';
+import { PageHandler } from './page-handler';
+import { BrowserError } from './browser-error';
+import { NavigationHooks } from './navigation-hooks';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
+const scrollTimeoutMsecs = 15000;
+const pageRenderingTimeoutMsecs = 1000;
+
+let pageConfiguratorMock: IMock<PageConfigurator>;
+let pageHandlerMock: IMock<PageHandler>;
+let pageResponseProcessorMock: IMock<PageResponseProcessor>;
+let pageMock: IMock<Page>;
+
+let navigationHooks: NavigationHooks;
+
+describe(NavigationHooks, () => {
+    beforeEach(() => {
+        pageConfiguratorMock = Mock.ofType<PageConfigurator>();
+        pageHandlerMock = Mock.ofType<PageHandler>();
+        pageResponseProcessorMock = Mock.ofType<PageResponseProcessor>();
+        pageMock = Mock.ofType<Page>();
+
+        navigationHooks = new NavigationHooks(
+            pageConfiguratorMock.object,
+            pageResponseProcessorMock.object,
+            pageHandlerMock.object,
+            scrollTimeoutMsecs,
+            pageRenderingTimeoutMsecs,
+        );
+    });
+
+    afterEach(() => {
+        pageMock.verifyAll();
+        pageHandlerMock.verifyAll();
+        pageResponseProcessorMock.verifyAll();
+        pageConfiguratorMock.verifyAll();
+    });
+
+    it('preNavigation', async () => {
+        pageConfiguratorMock.setup((p) => p.configurePage(pageMock.object)).verifiable();
+
+        await navigationHooks.preNavigation(pageMock.object);
+    });
+
+    it('postNavigation with successful response', async () => {
+        const response = {} as Response;
+        pageResponseProcessorMock
+            .setup((o) => o.getResponseError(response))
+            .returns(() => undefined)
+            .verifiable();
+        pageHandlerMock
+            .setup(async (o) => o.waitForPageToCompleteRendering(pageMock.object, scrollTimeoutMsecs, pageRenderingTimeoutMsecs))
+            .returns(() => Promise.resolve())
+            .verifiable();
+
+        await navigationHooks.postNavigation(pageMock.object, {} as Response);
+    });
+
+    it('postNavigation with undefined response', async () => {
+        const expectedError: Partial<BrowserError> = {
+            errorType: 'NavigationError',
+            message: 'Unable to get a page response from the browser.',
+        };
+
+        let navigationError: BrowserError;
+        const onNavigationErrorStub = async (browserError: BrowserError, error?: any) => {
+            navigationError = browserError;
+        };
+
+        await navigationHooks.postNavigation(pageMock.object, undefined, onNavigationErrorStub);
+        expect(navigationError).toMatchObject(expectedError);
+    });
+
+    it('postNavigation with response error', async () => {
+        const response = {} as Response;
+        const browserError = {
+            errorType: 'EmptyPage',
+            message: 'message',
+            stack: 'stack',
+        } as BrowserError;
+        pageResponseProcessorMock
+            .setup((o) => o.getResponseError(response))
+            .returns(() => browserError)
+            .verifiable();
+        const onNavigationErrorMock = jest.fn();
+        onNavigationErrorMock.mockImplementation((browserErr) => Promise.resolve());
+
+        await navigationHooks.postNavigation(pageMock.object, response, onNavigationErrorMock);
+        expect(onNavigationErrorMock).toHaveBeenCalledWith(browserError);
+    });
+});

--- a/packages/scanner-global-library/src/navigation-hooks.ts
+++ b/packages/scanner-global-library/src/navigation-hooks.ts
@@ -15,7 +15,6 @@ export class NavigationHooks {
         @inject(PageConfigurator) public readonly pageConfigurator: PageConfigurator,
         @inject(PageResponseProcessor) protected readonly pageResponseProcessor: PageResponseProcessor,
         @inject(PageHandler) protected readonly pageRenderingHandler: PageHandler,
-        private readonly scrollTimeoutMsecs = 15000,
         private readonly pageRenderingTimeoutMsecs: number = 10000,
     ) {}
 
@@ -47,6 +46,6 @@ export class NavigationHooks {
             return;
         }
 
-        await this.pageRenderingHandler.waitForPageToCompleteRendering(page, this.scrollTimeoutMsecs, this.pageRenderingTimeoutMsecs);
+        await this.pageRenderingHandler.waitForPageToCompleteRendering(page, this.pageRenderingTimeoutMsecs);
     }
 }

--- a/packages/scanner-global-library/src/navigation-hooks.ts
+++ b/packages/scanner-global-library/src/navigation-hooks.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import _ from 'lodash';
+import * as Puppeteer from 'puppeteer';
+import { BrowserError } from './browser-error';
+import { PageConfigurator } from './page-configurator';
+import { PageHandler } from './page-handler';
+import { PageResponseProcessor } from './page-response-processor';
+
+@injectable()
+export class NavigationHooks {
+    constructor(
+        @inject(PageConfigurator) public readonly pageConfigurator: PageConfigurator,
+        @inject(PageResponseProcessor) protected readonly pageResponseProcessor: PageResponseProcessor,
+        @inject(PageHandler) protected readonly pageRenderingHandler: PageHandler,
+        private readonly scrollTimeoutMsecs = 15000,
+        private readonly pageRenderingTimeoutMsecs: number = 10000,
+    ) {}
+
+    public async preNavigation(page: Puppeteer.Page): Promise<void> {
+        // Configure page settings before navigating to URL
+        await this.pageConfigurator.configurePage(page);
+    }
+
+    public async postNavigation(
+        page: Puppeteer.Page,
+        response: Puppeteer.Response,
+        onNavigationError: (browserError: BrowserError, error?: unknown) => Promise<void> = () => Promise.resolve(),
+    ): Promise<void> {
+        if (_.isNil(response)) {
+            onNavigationError({
+                errorType: 'NavigationError',
+                message: 'Unable to get a page response from the browser.',
+                stack: new Error().stack,
+            });
+
+            return;
+        }
+
+        // Validate HTTP response
+        const responseError = this.pageResponseProcessor.getResponseError(response);
+        if (responseError !== undefined) {
+            onNavigationError(responseError);
+
+            return;
+        }
+
+        await this.pageRenderingHandler.waitForPageToCompleteRendering(page, this.scrollTimeoutMsecs, this.pageRenderingTimeoutMsecs);
+    }
+}

--- a/packages/scanner-global-library/src/page-navigator.spec.ts
+++ b/packages/scanner-global-library/src/page-navigator.spec.ts
@@ -3,42 +3,47 @@
 
 import 'reflect-metadata';
 
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { Page, Response } from 'puppeteer';
 import { PageResponseProcessor } from './page-response-processor';
-import { PageConfigurator } from './page-configurator';
-import { PageHandler } from './page-handler';
 import { PageNavigator } from './page-navigator';
 import { BrowserError } from './browser-error';
+import { NavigationHooks } from './navigation-hooks';
+import { PageConfigurator } from './page-configurator';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
 const url = 'url';
 
 let pageNavigator: PageNavigator;
 let pageResponseProcessorMock: IMock<PageResponseProcessor>;
-let pageConfiguratorMock: IMock<PageConfigurator>;
-let pageRenderingHandlerMock: IMock<PageHandler>;
+let navigationHooksMock: IMock<NavigationHooks>;
 let pageMock: IMock<Page>;
 
 describe(PageNavigator, () => {
     beforeEach(() => {
         pageResponseProcessorMock = Mock.ofType<PageResponseProcessor>();
-        pageConfiguratorMock = Mock.ofType<PageConfigurator>();
-        pageRenderingHandlerMock = Mock.ofType(PageHandler);
+        navigationHooksMock = Mock.ofType<NavigationHooks>();
         pageMock = Mock.ofType<Page>();
 
-        pageNavigator = new PageNavigator(pageConfiguratorMock.object, pageResponseProcessorMock.object, pageRenderingHandlerMock.object);
+        pageNavigator = new PageNavigator(pageResponseProcessorMock.object, navigationHooksMock.object);
     });
 
     afterEach(() => {
-        pageRenderingHandlerMock.verifyAll();
         pageResponseProcessorMock.verifyAll();
-        pageConfiguratorMock.verifyAll();
-        pageMock.verifyAll();
+        navigationHooksMock.verifyAll();
+    });
+
+    it('get pageConfigurator', () => {
+        const pageConfiguratorMock = Mock.ofType<PageConfigurator>();
+        navigationHooksMock.setup((o) => o.pageConfigurator).returns(() => pageConfiguratorMock.object);
+
+        expect(pageNavigator.pageConfigurator).toBe(pageConfiguratorMock.object);
     });
 
     it('navigate', async () => {
         const response = {} as Response;
+        const onNavigationErrorMock = jest.fn();
+
         pageMock
             .setup(async (o) =>
                 o.goto(url, {
@@ -48,20 +53,12 @@ describe(PageNavigator, () => {
             )
             .returns(() => Promise.resolve(response))
             .verifiable();
-        pageConfiguratorMock
-            .setup(async (o) => o.configurePage(pageMock.object))
-            .returns(() => Promise.resolve())
-            .verifiable();
-        pageResponseProcessorMock
-            .setup((o) => o.getResponseError(response))
-            .returns(() => undefined)
-            .verifiable();
-        pageRenderingHandlerMock
-            .setup(async (o) => o.waitForPageToCompleteRendering(pageMock.object, pageNavigator.pageRenderingTimeoutMsecs))
-            .returns(() => Promise.resolve())
-            .verifiable();
+        navigationHooksMock.setup((o) => o.preNavigation(pageMock.object)).verifiable();
+        navigationHooksMock.setup((o) => o.postNavigation(pageMock.object, response, onNavigationErrorMock)).verifiable();
 
-        await pageNavigator.navigate(url, pageMock.object);
+        await pageNavigator.navigate(url, pageMock.object, onNavigationErrorMock);
+
+        expect(onNavigationErrorMock).toBeCalledTimes(0);
     });
 
     it('navigate with timeout', async () => {
@@ -89,27 +86,25 @@ describe(PageNavigator, () => {
             )
             .returns(() => Promise.reject(timeoutError))
             .verifiable();
-        pageConfiguratorMock
-            .setup(async (o) => o.configurePage(pageMock.object))
-            .returns(() => Promise.resolve())
-            .verifiable();
         pageResponseProcessorMock
             .setup((o) => o.getNavigationError(timeoutError))
             .returns(() => browserError)
             .verifiable(Times.exactly(2));
+        navigationHooksMock.setup((o) => o.preNavigation(pageMock.object)).verifiable();
+        navigationHooksMock.setup((o) => o.postNavigation(pageMock.object, It.isAny(), It.isAny())).verifiable(Times.never());
         const onNavigationErrorMock = jest.fn();
         onNavigationErrorMock.mockImplementation((browserErr, err) => Promise.resolve());
 
         await pageNavigator.navigate(url, pageMock.object, onNavigationErrorMock);
+
         expect(onNavigationErrorMock).toHaveBeenCalledWith(browserError, timeoutError);
     });
 
-    it('navigate with response error', async () => {
-        const response = {} as Response;
+    it('navigate with browser error', async () => {
+        const error = new Error('navigation timeout');
         const browserError = {
-            errorType: 'EmptyPage',
-            message: 'message',
-            stack: 'stack',
+            errorType: 'NavigationError',
+            message: 'navigation error',
         } as BrowserError;
         pageMock
             .setup(async (o) =>
@@ -118,20 +113,17 @@ describe(PageNavigator, () => {
                     timeout: pageNavigator.gotoTimeoutMsecs,
                 }),
             )
-            .returns(() => Promise.resolve(response))
+            .returns(() => Promise.reject(error))
             .verifiable();
-        pageConfiguratorMock
-            .setup(async (o) => o.configurePage(pageMock.object))
-            .returns(() => Promise.resolve())
-            .verifiable();
+        navigationHooksMock.setup((o) => o.preNavigation(pageMock.object)).verifiable();
         pageResponseProcessorMock
-            .setup((o) => o.getResponseError(response))
+            .setup((o) => o.getNavigationError(error))
             .returns(() => browserError)
             .verifiable();
         const onNavigationErrorMock = jest.fn();
-        onNavigationErrorMock.mockImplementation((browserErr) => Promise.resolve());
+        onNavigationErrorMock.mockImplementation((browserErr, err) => Promise.resolve());
 
         await pageNavigator.navigate(url, pageMock.object, onNavigationErrorMock);
-        expect(onNavigationErrorMock).toHaveBeenCalledWith(browserError);
+        expect(onNavigationErrorMock).toHaveBeenCalledWith(browserError, error);
     });
 });

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -3,11 +3,11 @@
 
 import * as Puppeteer from 'puppeteer';
 import { injectable, inject } from 'inversify';
-import { isNil } from 'lodash';
-import { PageConfigurator } from './page-configurator';
+import _ from 'lodash';
 import { PageResponseProcessor } from './page-response-processor';
 import { BrowserError } from './browser-error';
-import { PageHandler } from './page-handler';
+import { NavigationHooks } from './navigation-hooks';
+import { PageConfigurator } from './page-configurator';
 
 export type OnNavigationError = (browserError: BrowserError, error?: unknown) => Promise<void>;
 
@@ -17,21 +17,21 @@ export class PageNavigator {
     // Refer to service configuration TaskRuntimeConfig.taskTimeoutInMinutes property
     public readonly gotoTimeoutMsecs = 60000;
 
-    public readonly pageRenderingTimeoutMsecs = 10000;
-
     constructor(
-        @inject(PageConfigurator) public readonly pageConfigurator: PageConfigurator,
-        @inject(PageResponseProcessor) protected readonly pageResponseProcessor: PageResponseProcessor,
-        @inject(PageHandler) protected readonly pageRenderingHandler: PageHandler,
+        @inject(PageResponseProcessor) public readonly pageResponseProcessor: PageResponseProcessor,
+        @inject(NavigationHooks) public readonly navigationHooks: NavigationHooks,
     ) {}
+
+    public get pageConfigurator(): PageConfigurator {
+        return this.navigationHooks.pageConfigurator;
+    }
 
     public async navigate(
         url: string,
         page: Puppeteer.Page,
-        onNavigationError: OnNavigationError = () => Promise.resolve(),
+        onNavigationError: (browserError: BrowserError, error?: unknown) => Promise<void> = () => Promise.resolve(),
     ): Promise<Puppeteer.Response> {
-        // Configure page settings before navigating to URL
-        await this.pageConfigurator.configurePage(page);
+        await this.navigationHooks.preNavigation(page);
 
         // Try load all page resources
         let navigationResult = await this.navigateToUrl(url, page, 'networkidle0');
@@ -46,31 +46,13 @@ export class PageNavigator {
             navigationResult = await this.navigateToUrl(url, page, 'load');
         }
 
-        if (!isNil(navigationResult.browserError)) {
+        if (!_.isNil(navigationResult.browserError)) {
             onNavigationError(navigationResult.browserError, navigationResult.error);
 
             return undefined;
         }
 
-        if (isNil(navigationResult.response)) {
-            onNavigationError({
-                errorType: 'NavigationError',
-                message: 'Unable to get a page response from the browser.',
-                stack: new Error().stack,
-            });
-
-            return undefined;
-        }
-
-        // Validate HTTP response
-        const responseError = this.pageResponseProcessor.getResponseError(navigationResult.response);
-        if (responseError !== undefined) {
-            onNavigationError(responseError);
-
-            return undefined;
-        }
-
-        await this.pageRenderingHandler.waitForPageToCompleteRendering(page, this.pageRenderingTimeoutMsecs);
+        this.navigationHooks.postNavigation(page, navigationResult.response, onNavigationError);
 
         return navigationResult.response;
     }

--- a/packages/service-library/src/dev-utilities/banner-detection-test.ts
+++ b/packages/service-library/src/dev-utilities/banner-detection-test.ts
@@ -5,7 +5,16 @@ import 'reflect-metadata';
 
 import fs from 'fs';
 import readline from 'readline';
-import { BrowserError, Page, PageConfigurator, PageHandler, PageNavigator, PageResponseProcessor, WebDriver } from 'scanner-global-library';
+import {
+    BrowserError,
+    NavigationHooks,
+    Page,
+    PageConfigurator,
+    PageHandler,
+    PageNavigator,
+    PageResponseProcessor,
+    WebDriver,
+} from 'scanner-global-library';
 import { ConsoleLoggerClient, GlobalLogger } from 'logger';
 import { PromiseUtils, ServiceConfiguration } from 'common';
 import yargs from 'yargs';
@@ -32,7 +41,11 @@ type BannerDetectionResults = {
 const serviceConfig = new ServiceConfiguration();
 const logger = new GlobalLogger([new ConsoleLoggerClient(serviceConfig, console)], process);
 const webDriver = new WebDriver(new PromiseUtils(), logger);
-const pageNavigator = new PageNavigator(new PageConfigurator(), new PageResponseProcessor(), new PageHandler(logger));
+const pageResponseProcessor = new PageResponseProcessor();
+const pageNavigator = new PageNavigator(
+    pageResponseProcessor,
+    new NavigationHooks(new PageConfigurator(), pageResponseProcessor, new PageHandler(logger)),
+);
 const privacyPageScanner = new PrivacyPageScanner(serviceConfig, new CookieCollector());
 const page = new Page(webDriver, undefined, pageNavigator, privacyPageScanner, logger);
 

--- a/packages/web-api-scan-runner/src/scanner/axe-scanner.spec.ts
+++ b/packages/web-api-scan-runner/src/scanner/axe-scanner.spec.ts
@@ -3,7 +3,6 @@
 
 import 'reflect-metadata';
 
-import { fail } from 'assert';
 import { AxeResults } from 'axe-core';
 import { PromiseUtils, ScanRunTimeConfig, ServiceConfiguration, System } from 'common';
 import { AxePuppeteerFactory, AxeScanResults, BrowserError, Page } from 'scanner-global-library';
@@ -79,9 +78,9 @@ describe(AxeScanner, () => {
         });
 
         it('should return timeout promise', async () => {
-            const errorMessage: string = 'An error occurred while scanning website page';
+            const axeResultsStub = 'axe results' as any as AxeResults;
 
-            setupPageErrorScanCall(errorMessage);
+            setupPageScanCall(axeResultsStub);
             setupWaitForPromiseToReturnTimeoutPromise();
 
             const scanResult = await axeScanner.scan(pageMock.object);
@@ -112,9 +111,7 @@ describe(AxeScanner, () => {
         function setupWaitForPromiseToReturnTimeoutPromise(): void {
             promiseUtilsMock
                 .setup((s) => s.waitFor(It.isAny(), scanConfig.scanTimeoutInMin * 60000, It.isAny()))
-                .returns(async (scanPromiseObj, timeout, timeoutCb) => {
-                    return timeoutCb();
-                })
+                .returns(async (scanPromiseObj, timeout, timeoutCb) => timeoutCb())
                 .verifiable();
         }
     });


### PR DESCRIPTION
#### Details

Make some refactors in anticipation of the Apify v2 and Node 16 update. This PR does not change any behavior or update any dependencies.

- Create NavigationHooks class and move pre-navigation logic and post-navigation verification into that class
  - the Apify v2 interface accepts preNavigationHook and postNavigationHook instead of a gotoFunction. Eventually, NavigationHooks will be passed to the crawler package instead of calling PageNavigator.navigate
- Replace CrawlerRunOptions container binding with a function to set CrawlerRunOptions in CrawlerConfiguration
  - Not related to the apify update, but makes it clearer that CrawlerRunOptions is set at runtime and makes it easier to debug when it is called before being set
- Remove an UnresolvedPromiseRejection warning in unit test
  - The warning will become a blocking error when we move to Node 16

##### Motivation

See above for explanations

##### Context

This is the first part of a series of PRs to migrate to Apify v2 and Node 16. This PR completes some refactors that can be done without updating packages. Another PR will complete those updates and make additional changes to accommodate updated interfaces.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group