### PR TITLE
Fix notification bug

### DIFF
--- a/packages/report-generator-runner/src/report-processor/accessibility-report-processor.spec.ts
+++ b/packages/report-generator-runner/src/report-processor/accessibility-report-processor.spec.ts
@@ -86,6 +86,14 @@ describe(AccessibilityReportProcessor, () => {
         );
     });
 
+    it('Generate report with no axe blob refs', async () => {
+        queuedRequest.request.reports = [];
+
+        await expect(accessibilityReportProcessor.generate(pageScanResult, queuedRequest)).rejects.toThrowError(
+            /No axe report blobs found. Scan group ID: scanGroupId/,
+        );
+    });
+
     function setupCombinedScanResultProcessor(): void {
         combinedScanResultProcessorMock
             .setup((o) => o.generateCombinedScanResults(It.isValue(axeScanResults), It.isValue(pageScanResult)))

--- a/packages/report-generator-runner/src/report-processor/accessibility-report-processor.ts
+++ b/packages/report-generator-runner/src/report-processor/accessibility-report-processor.ts
@@ -27,7 +27,12 @@ export class AccessibilityReportProcessor implements TargetReportProcessor {
     }
 
     private async getAxeScanResults(queuedRequest: QueuedRequest): Promise<AxeScanResults> {
-        const axeReport = queuedRequest.request.reports.find((r) => r.format === 'axe');
+        const axeReport = queuedRequest.request.reports?.find((r) => r.format === 'axe');
+        if (!axeReport) {
+            this.logger.logError('No axe report blobs found for this scan report group');
+
+            throw new Error(`No axe report blobs found. Scan group ID: ${queuedRequest.request.scanGroupId}`);
+        }
         const reportContent = await this.pageScanRunReportProvider.readReportContent(axeReport.reportId);
         if (reportContent.errorCode) {
             this.logger.logError('Failure to read axe report blob.', {

--- a/packages/report-generator-runner/src/runner/runner.spec.ts
+++ b/packages/report-generator-runner/src/runner/runner.spec.ts
@@ -43,6 +43,7 @@ describe(Runner, () => {
                 run: {
                     state: 'pending',
                 },
+                scanRunState: 'completed',
             },
             {
                 id: 'id-2',
@@ -51,6 +52,7 @@ describe(Runner, () => {
                 run: {
                     state: 'pending',
                 },
+                scanRunState: 'completed',
             },
             {
                 id: 'id-3',
@@ -59,6 +61,7 @@ describe(Runner, () => {
                 run: {
                     state: 'completed',
                 },
+                scanRunState: 'failed',
             },
         ] as ReportGeneratorRequest[];
 
@@ -128,6 +131,7 @@ describe(Runner, () => {
                 run: {
                     state: 'pending',
                 },
+                scanRunState: 'completed',
             },
             {
                 id: 'id-3',
@@ -136,6 +140,7 @@ describe(Runner, () => {
                 run: {
                     state: 'completed',
                 },
+                scanRunState: 'failed',
             },
         ] as ReportGeneratorRequest[];
         const queuedRequests = createQueuedRequests(reportGeneratorRequests);
@@ -158,6 +163,7 @@ describe(Runner, () => {
                 run: {
                     state: 'pending',
                 },
+                scanRunState: 'completed',
             },
             {
                 id: 'id-3',
@@ -166,6 +172,7 @@ describe(Runner, () => {
                 run: {
                     state: 'pending',
                 },
+                scanRunState: 'completed',
             },
         ] as ReportGeneratorRequest[];
         const resultRequestsUpdateByReportProcessor = [
@@ -176,6 +183,7 @@ describe(Runner, () => {
                 run: {
                     state: 'failed',
                 },
+                scanRunState: 'completed',
             },
             {
                 id: 'id-3',
@@ -184,6 +192,7 @@ describe(Runner, () => {
                 run: {
                     state: 'completed',
                 },
+                scanRunState: 'completed',
             },
         ] as ReportGeneratorRequest[];
         const queuedRequests = createQueuedRequests(reportGeneratorRequests);
@@ -287,7 +296,7 @@ function setupSetScanRunStatesToCompleted(queuedRequests: ReportGeneratorRequest
         return {
             id: request.id,
             run: {
-                state: request.run.state,
+                state: request.scanRunState === 'completed' ? request.run.state : request.scanRunState,
                 timestamp: dateNow.toJSON(),
                 error: isEmpty(request.run.error) ? null : request.run.error.toString().substring(0, 2048),
             },

--- a/packages/report-generator-runner/src/runner/runner.ts
+++ b/packages/report-generator-runner/src/runner/runner.ts
@@ -112,10 +112,13 @@ export class Runner {
 
     private async updateScanRunStatesToCompleted(queuedRequests: QueuedRequest[]): Promise<void> {
         const scansToUpdate = queuedRequests.map((queuedRequest) => {
+            const scanState =
+                queuedRequest.request.scanRunState === 'completed' ? queuedRequest.condition : queuedRequest.request.scanRunState;
+
             return {
                 id: queuedRequest.request.id,
                 run: {
-                    state: queuedRequest.condition,
+                    state: scanState,
                     timestamp: new Date().toJSON(),
                     error: isEmpty(queuedRequest.error) ? null : queuedRequest.error.toString().substring(0, 2048),
                 },

--- a/packages/storage-documents/src/report-generator-request.ts
+++ b/packages/storage-documents/src/report-generator-request.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { OnDemandPageScanReport, OnDemandPageScanRunResult } from './on-demand-page-scan-result';
+import { OnDemandPageScanReport, OnDemandPageScanRunResult, OnDemandPageScanRunState } from './on-demand-page-scan-result';
 import { StorageDocument } from './storage-document';
 import { ItemType } from './item-type';
 
@@ -14,6 +14,7 @@ export interface ReportGeneratorRequest extends StorageDocument {
     targetReport: TargetReport;
     priority: number;
     reports?: OnDemandPageScanReport[];
+    scanRunState: OnDemandPageScanRunState;
     /**
      * Supported run states: pending, running, completed, failed
      */

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -22,6 +22,7 @@ import {
     WebsiteScanResult,
     WebsiteScanRef,
     OnDemandPageScanRunResult,
+    OnDemandPageScanRunState,
     ReportGeneratorRequest,
 } from 'storage-documents';
 import { AxeScanResults } from 'scanner-global-library';
@@ -206,7 +207,7 @@ describe(Runner, () => {
         setupUpdateScanRunStateToRunning();
         setupScanRunnerTelemetryManager(false);
         setupPageScanProcessor(true, error);
-        setupReportGeneratorRequestProvider();
+        setupReportGeneratorRequestProvider('failed');
         pageScanResult.run.state = 'report';
         setupUpdateScanResult();
         await runner.run();
@@ -306,7 +307,7 @@ describe(Runner, () => {
     });
 });
 
-function setupReportGeneratorRequestProvider(): void {
+function setupReportGeneratorRequestProvider(scanState: OnDemandPageScanRunState = 'completed'): void {
     guidGeneratorMock
         .setup((o) => o.createGuidFromBaseGuid(runnerScanMetadata.id))
         .returns(() => 'guid')
@@ -318,6 +319,7 @@ function setupReportGeneratorRequestProvider(): void {
         targetReport: 'accessibility',
         priority: pageScanResult.priority,
         reports: pageScanResult.reports,
+        scanRunState: scanState,
     };
     reportGeneratorRequestProviderMock.setup((o) => o.writeRequest(It.isValue(reportGeneratorRequest))).verifiable();
 }
@@ -410,7 +412,7 @@ function setupProcessScanResult(useReportGeneratorWorkflow: boolean = false): vo
             .verifiable();
 
         if (useReportGeneratorWorkflow) {
-            setupReportGeneratorRequestProvider();
+            setupReportGeneratorRequestProvider(pageScanResult.run.state);
         } else {
             combinedScanResultProcessorMock
                 .setup((o) => o.generateCombinedScanResults(It.isValue(axeScanResults), It.isValue(pageScanResult)))

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.spec.ts
@@ -30,6 +30,10 @@ describe('E2EScanScenarioDefinitions', () => {
                 consolidatedId: `consolidated-id-base-test-release-version-consolidated-${fakeDate.getTime()}`,
             },
             {
+                scanNotificationUrl: 'base-url/scan-notify-api-endpoint',
+                consolidatedId: `consolidated-id-base-test-release-version-failed-${fakeDate.getTime()}`,
+            },
+            {
                 deepScan: true,
                 scanNotificationUrl: 'base-url/scan-notify-api-endpoint',
                 consolidatedId: `consolidated-id-base-test-release-version-deepScan-${fakeDate.getTime()}`,

--- a/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
+++ b/packages/web-workers/src/e2e-test-scenarios/e2e-scan-scenario-definitions.ts
@@ -43,6 +43,22 @@ export const E2EScanFactories: E2EScanScenarioDefinitionFactory[] = [
             },
         };
     },
+    // Failed consolidated scan with notification
+    (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
+        return {
+            readableName: 'FailedScan',
+            scanOptions: {
+                scanNotificationUrl: `${webApiConfig.baseUrl}${availabilityConfig.scanNotifyApiEndpoint}`,
+                consolidatedId: `${availabilityConfig.consolidatedIdBase}-${webApiConfig.releaseId}-failed-${Date.now()}`,
+            },
+            initialTestContextData: {
+                scanUrl: `${availabilityConfig.urlToScan}invalid-page-url`,
+            },
+            testGroups: {
+                postScanCompletionNotificationTests: ['ScanCompletionNotification'],
+            },
+        };
+    },
     // Deep scan
     (availabilityConfig: AvailabilityTestConfig, webApiConfig: WebApiConfig): E2EScanScenarioDefinition => {
         const baseUrl = availabilityConfig.urlToScan;


### PR DESCRIPTION
#### Details

Send a report generation request even in the case of failed scans

##### Motivation

This will fix a bug where, if the last scan in a crawl or report group fails, the scan completion notification is not sent.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
