### PR TITLE
Send notification if scan failed

### DIFF
--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -172,37 +172,45 @@ describe(Runner, () => {
         await runner.run();
     });
 
-    it('execute runner with page scanner exception', async () => {
-        const error = new Error('page scan processor error');
-        const errorMessage = System.serializeError(error);
-        pageScanResult.run = {
-            state: 'failed',
-            timestamp: dateNow.toJSON(),
-            error: errorMessage.substring(0, 2048),
-        };
-        loggerMock.setup((o) => o.logError(`The scanner failed to scan a page.`, { error: errorMessage })).verifiable();
+    it.each([true, false])(
+        'execute runner with page scanner exception with useReportGeneratorWorkflow=%s',
+        async (useReportGeneratorWorkflow) => {
+            pageScanResultDbDocument.websiteScanRefs[0].scanGroupId = useReportGeneratorWorkflow ? 'scanGroupId' : undefined;
+            const error = new Error('page scan processor error');
+            const errorMessage = System.serializeError(error);
+            pageScanResult.run = {
+                state: 'failed',
+                timestamp: dateNow.toJSON(),
+                error: errorMessage.substring(0, 2048),
+            };
+            loggerMock.setup((o) => o.logError(`The scanner failed to scan a page.`, { error: errorMessage })).verifiable();
 
-        setupScanMetadataConfig();
-        setupUpdateScanRunStateToRunning();
-        setupScanRunnerTelemetryManager(false);
-        setupPageScanProcessor(true, error);
-        setupUpdateScanResult();
-        setupScanNotificationProcessor();
-        await runner.run();
-    });
+            setupScanMetadataConfig();
+            setupUpdateScanRunStateToRunning();
+            setupScanRunnerTelemetryManager(false);
+            setupPageScanProcessor(true, error);
+            setupUpdateScanResult();
+            setupScanNotificationProcessor();
+            await runner.run();
+        },
+    );
 
-    it('handle scanner browser navigation error', async () => {
-        axeScanResults.error = 'browser navigation error';
+    it.each([true, false])(
+        'handle scanner browser navigation error with useReportGeneratorWorkflow=%s',
+        async (useReportGeneratorWorkflow: boolean) => {
+            pageScanResultDbDocument.websiteScanRefs[0].scanGroupId = useReportGeneratorWorkflow ? 'scanGroupId' : undefined;
+            axeScanResults.error = 'browser navigation error';
 
-        setupScanMetadataConfig();
-        setupUpdateScanRunStateToRunning();
-        setupScanRunnerTelemetryManager(true, false);
-        setupPageScanProcessor();
-        setupProcessScanResult();
-        setupUpdateScanResult();
-        setupScanNotificationProcessor();
-        await runner.run();
-    });
+            setupScanMetadataConfig();
+            setupUpdateScanRunStateToRunning();
+            setupScanRunnerTelemetryManager(true, false);
+            setupPageScanProcessor();
+            setupProcessScanResult();
+            setupUpdateScanResult();
+            setupScanNotificationProcessor();
+            await runner.run();
+        },
+    );
 
     it('handle scan result violations', async () => {
         axeScanResults.results = {

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -86,7 +86,7 @@ export class Runner {
 
         const websiteScanResult = await this.updateScanResult(runnerScanMetadata, pageScanResult);
 
-        if (this.isPageScanCompleted(pageScanResult)) {
+        if (this.isPageScanCompleted(pageScanResult) || pageScanResult.run.state === 'failed') {
             await this.scanNotificationProcessor.sendScanCompletionNotification(runnerScanMetadata, pageScanResult, websiteScanResult);
         }
 


### PR DESCRIPTION
#### Details

Send scan completion notification immediately if the scan failed (and the notification is applicable)

##### Motivation

Fixes a bug where, if the last scan in a consolidated report group fails when using the consolidated report workflow, the scan completion notification is never sent.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
