### PR TITLE
Fixed report workflow error trace

### DIFF
--- a/packages/azure-services/src/credentials/credentials-provider.spec.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.spec.ts
@@ -4,50 +4,56 @@
 import 'reflect-metadata';
 
 import { IMock, Mock, Times } from 'typemoq';
-import { ChainedTokenCredential, EnvironmentCredential } from '@azure/identity';
+import { EnvironmentCredential } from '@azure/identity';
 import { CredentialsProvider } from './credentials-provider';
-import { MSICredentialsProvider } from './msi-credential-provider';
+import { MSICredentialsProvider, AuthenticationMethod } from './msi-credential-provider';
 import { ManagedIdentityCredentialCache } from './managed-identity-credential-cache';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+const credentialsStub = 'test credentials' as any;
+
 describe(CredentialsProvider, () => {
     let testSubject: CredentialsProvider;
     let msiCredProviderMock: IMock<MSICredentialsProvider>;
-    const credentialsStub = 'test credentials' as any;
+    let managedIdentityCredentialCacheMock: IMock<ManagedIdentityCredentialCache>;
 
     beforeEach(() => {
         msiCredProviderMock = Mock.ofType(MSICredentialsProvider);
+        managedIdentityCredentialCacheMock = Mock.ofType(ManagedIdentityCredentialCache);
+        testSubject = new CredentialsProvider(
+            msiCredProviderMock.object,
+            managedIdentityCredentialCacheMock.object,
+            AuthenticationMethod.managedIdentity,
+        );
+    });
+
+    afterEach(() => {
+        msiCredProviderMock.verifyAll();
     });
 
     it('getCredentialForBatch gets batch credentials with MSI auth', async () => {
-        testSubject = new CredentialsProvider(msiCredProviderMock.object);
-
         msiCredProviderMock
             .setup(async (r) => r.getCredentials('https://batch.core.windows.net/'))
             .returns(async () => Promise.resolve(credentialsStub))
             .verifiable(Times.once());
 
         const actualCredentials = await testSubject.getCredentialsForBatch();
-
         expect(actualCredentials).toBe(credentialsStub);
-        msiCredProviderMock.verifyAll();
     });
 
-    it('getAzureCredential creates singleton credential', () => {
+    it('getAzureCredential creates ManagedIdentityCredentialCache instance', () => {
         const credential = testSubject.getAzureCredential();
-        //_sources:
-
-        expect(credential).toBeInstanceOf(ChainedTokenCredential);
-        expect(testSubject.getAzureCredential()).toBe(credential);
+        expect(credential).toBe(managedIdentityCredentialCacheMock.object);
     });
 
-    it('getAzureCredential creates credential with limited providers', () => {
-        const credential = testSubject.getAzureCredential() as any;
-
-        expect(credential._sources.length).toEqual(2);
-        // credential providers sequence should match
-        expect(credential._sources[0]).toBeInstanceOf(ManagedIdentityCredentialCache);
-        expect(credential._sources[1]).toBeInstanceOf(EnvironmentCredential);
+    it('getAzureCredential creates EnvironmentCredential instance', () => {
+        testSubject = new CredentialsProvider(
+            msiCredProviderMock.object,
+            managedIdentityCredentialCacheMock.object,
+            AuthenticationMethod.servicePrincipal,
+        );
+        const credential = testSubject.getAzureCredential();
+        expect(credential).toBeInstanceOf(EnvironmentCredential);
     });
 });

--- a/packages/azure-services/src/credentials/managed-identity-credential-cache.spec.ts
+++ b/packages/azure-services/src/credentials/managed-identity-credential-cache.spec.ts
@@ -47,7 +47,7 @@ describe(ManagedIdentityCredentialCache, () => {
             .returns(() => undefined)
             .verifiable();
         tokenCacheMock
-            .setup((o) => o.set(resourceUrl, accessToken, accessToken.expiresOnTimestamp - cacheCheckPeriodInSeconds * 1000 * 3))
+            .setup((o) => o.set(resourceUrl, accessToken, accessToken.expiresOnTimestamp / 1000 - cacheCheckPeriodInSeconds * 3))
             .returns(() => true)
             .verifiable();
         managedIdentityCredentialMock

--- a/packages/azure-services/src/credentials/managed-identity-credential-cache.ts
+++ b/packages/azure-services/src/credentials/managed-identity-credential-cache.ts
@@ -50,7 +50,8 @@ export class ManagedIdentityCredentialCache implements TokenCredential {
         this.tokenCache.set<AccessToken>(
             resourceUrl,
             accessToken,
-            accessToken.expiresOnTimestamp - ManagedIdentityCredentialCache.cacheCheckPeriodInSeconds * 1000 * 3,
+            // cache item TTL in seconds
+            accessToken.expiresOnTimestamp / 1000 - ManagedIdentityCredentialCache.cacheCheckPeriodInSeconds * 3,
         );
 
         return accessToken;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
         "pack": "npm-run-all --serial --npm-path npm 'create-drop-dir' 'pack-to-drop-dir'",
         "pack-to-drop-dir": "yarn pack --filename drop/cli.tgz",
         "create-drop-dir": "npx mkdirp drop",
-        "clean": "rimraf dist drop test-results",
+        "clean": "rimraf dist drop test-results ai_scan_cli_output",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
         "test": "jest --coverage --colors"

--- a/packages/common/src/system/system.spec.ts
+++ b/packages/common/src/system/system.spec.ts
@@ -7,7 +7,7 @@ import * as utils from 'util';
 import { serializeError as serializeErrorExt } from 'serialize-error';
 import { System } from './system';
 
-/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable @typescript-eslint/no-floating-promises, @typescript-eslint/no-explicit-any */
 
 describe('create instance if nil', () => {
     test.each([null, undefined])('creates instance when nil - %o', (testCase) => {
@@ -81,5 +81,51 @@ describe('serializeError()', () => {
         const error = new Error('Error message');
         const errorStr = System.serializeError(error);
         expect(errorStr).toEqual(utils.inspect(serializeErrorExt(error), false, null));
+    });
+
+    it('serialize HTTP response error object', () => {
+        const httpResponse = {
+            statusCode: 412,
+            request: {
+                url: 'request url',
+                method: 'PUT',
+                body: 'request body',
+            },
+            response: {
+                body: 'response body',
+            },
+        } as any;
+        const { request, ...httpResponseExpected } = httpResponse;
+        httpResponseExpected.request = {
+            url: 'request url',
+            method: 'PUT',
+        };
+
+        const errorStr = System.serializeError(httpResponse);
+        expect(errorStr).toEqual(utils.inspect(serializeErrorExt(System.normalizeHttpResponse(httpResponseExpected)), false, null));
+    });
+});
+
+describe('normalizeHttpResponse()', () => {
+    it('should normalize request object', () => {
+        const httpResponse = {
+            statusCode: 412,
+            request: {
+                url: 'request url',
+                method: 'PUT',
+                body: 'request body',
+            },
+            response: {
+                body: 'response body',
+            },
+        } as any;
+        const { request, ...httpResponseExpected } = httpResponse;
+        httpResponseExpected.request = {
+            url: 'request url',
+            method: 'PUT',
+        };
+
+        const actualResponse = System.normalizeHttpResponse(httpResponse);
+        expect(actualResponse).toEqual(httpResponseExpected);
     });
 });

--- a/packages/common/src/system/system.ts
+++ b/packages/common/src/system/system.ts
@@ -6,7 +6,7 @@ import * as utils from 'util';
 import { isNil } from 'lodash';
 import { serializeError as serializeErrorExt } from 'serialize-error';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 
 export namespace System {
     export function createInstanceIfNil<T>(instance: T, factory: () => T): T {
@@ -40,8 +40,25 @@ export namespace System {
         return crypto.randomBytes(bytes).toString('hex').substr(0, length);
     }
 
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     export function serializeError(error: any): string {
-        return utils.inspect(serializeErrorExt(error), false, null);
+        return utils.inspect(serializeErrorExt(normalizeHttpResponse(error)), false, null);
+    }
+
+    /**
+     * Normalizes request object from the HTTP response object. The request object will have the `url` and `method` properties only.
+     * @param responseObj The HTTP response object
+     */
+    export function normalizeHttpResponse(responseObj: any): any {
+        if (responseObj === undefined || responseObj.request === undefined) {
+            return responseObj;
+        }
+
+        const { request, ...responseCopy } = responseObj;
+        responseCopy.request = {
+            url: responseObj.request?.url,
+            method: responseObj.request?.method,
+        };
+
+        return responseCopy;
     }
 }

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "build": "tsc && rollup -c && echo",
         "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
-        "clean": "rimraf dist test-results",
+        "clean": "rimraf dist test-results ai_scan_cli_output",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
         "test": "jest --coverage --colors",

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -11,7 +11,6 @@ import {
     ReportGeneratorRequestProvider,
     ScanNotificationProcessor,
     RunnerScanMetadata,
-    CombinedScanResultProcessor,
 } from 'service-library';
 import {
     OnDemandPageScanReport,
@@ -40,7 +39,6 @@ export class Runner {
         @inject(PageScanProcessor) private readonly pageScanProcessor: PageScanProcessor,
         @inject(ReportWriter) protected readonly reportWriter: ReportWriter,
         @inject(ReportGenerator) private readonly reportGenerator: ReportGenerator,
-        @inject(CombinedScanResultProcessor) private readonly combinedScanResultProcessor: CombinedScanResultProcessor,
         @inject(ScanNotificationProcessor) protected readonly scanNotificationProcessor: ScanNotificationProcessor,
         @inject(ScanRunnerTelemetryManager) private readonly telemetryManager: ScanRunnerTelemetryManager,
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
@@ -103,15 +101,6 @@ export class Runner {
         const websiteScanRef = this.getWebsiteScanRefs(pageScanResult);
         if (this.isPageScanCompleted(pageScanResult)) {
             this.setRunResult(pageScanResult, 'completed');
-
-            // TODO remove below after transition phase
-            // The transition workflow is to support old report generation logic while
-            // new scan request documents will be created with websiteScanRef.scanGroupId metadata
-            if (websiteScanRef && websiteScanRef.scanGroupId === undefined) {
-                await this.combinedScanResultProcessor.generateCombinedScanResults(axeScanResults, pageScanResult);
-
-                return;
-            }
         } else {
             this.setRunResult(pageScanResult, 'report');
             await this.sendGenerateConsolidatedReportRequest(pageScanResult, websiteScanRef);
@@ -241,13 +230,9 @@ export class Runner {
     }
 
     /**
-     * The scan is completed if there is no combined report generated
-     * or combined report generated via old workflow
+     * The scan is completed if there is no combined report to generate
      */
     private isPageScanCompleted(pageScanResult: OnDemandPageScanResult): boolean {
-        const websiteScanRef = this.getWebsiteScanRefs(pageScanResult);
-
-        // TODO remove websiteScanRef.scanGroupId === undefined condition
-        return websiteScanRef === undefined || websiteScanRef.scanGroupId === undefined;
+        return this.getWebsiteScanRefs(pageScanResult) === undefined;
     }
 }


### PR DESCRIPTION
#### Details

Fixed trace data size when logging HTTP request failure to avoid batch stdout.txt overload.
Fixed AAD token cache TTL.
Removed old report generation workflow.
Fixed debug credential provided factory.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
