### PR TITLE
chore: remove obsolete Dependabot badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Licensed under the MIT License.
 
 [![Build Status](https://dev.azure.com/accessibility-insights/Accessibility%20Insights%20Service/_apis/build/status/Accessibility-Insights-Service%20CI?branchName=main)](https://dev.azure.com/accessibility-insights/Accessibility%20Insights%20Service/_build/latest?definitionId=28&branchName=main)
 [![codecov](https://codecov.io/gh/microsoft/accessibility-insights-service/branch/main/graph/badge.svg)](https://codecov.io/gh/microsoft/accessibility-insights-service)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=microsoft/accessibility-insights-service)](https://dependabot.com)
 
 Accessibility Insights Service is a service that can be used to scan websites for accessibility issues on a periodic basis. It is Typescript project with shell scripts for install and update scenarios.
 


### PR DESCRIPTION
#### Details

Dependabot's README badges broke when the old non-GitHub Dependabot migrated to GitHub. This PR removes the broken badge.

##### Motivation

Fixes broken link/image at top of README

##### Context

There isn't currently a replacement for the badge feature in the native GitHub Dependabot. https://github.com/dependabot/dependabot-core/issues/1912 tracks the request to add it, but hasn't seen activity in some time.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
