### PR TITLE
Fixed axe result blob deserialization

### DIFF
--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -9,7 +9,7 @@
         "messageVisibilityTimeoutInSeconds": 300
     },
     "scanConfig": {
-        "failedScanRetryIntervalInMinutes": 6,
+        "failedScanRetryIntervalInMinutes": 15,
         "maxFailedScanRetryCount": 1
     }
 }

--- a/packages/service-library/src/combined-report-provider/combined-axe-result-builder.spec.ts
+++ b/packages/service-library/src/combined-report-provider/combined-axe-result-builder.spec.ts
@@ -3,10 +3,10 @@
 
 import 'reflect-metadata';
 
-import axe, { AxeResults } from 'axe-core';
+import { AxeResults } from 'axe-core';
 import { AxeResultsReducer } from 'axe-result-converter';
 import { cloneDeep } from 'lodash';
-import { CombinedScanResults } from 'storage-documents';
+import { CombinedScanResults, PageScan } from 'storage-documents';
 import { IMock, It, Mock } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 import {
@@ -31,12 +31,27 @@ describe(CombinedAxeResultBuilder, () => {
     let combinedResultsBlobId: string;
     let blobReadETagStub: string;
     let combinedResultsBlobInfoStub: CombinedResultsBlob;
+    let pageScans: PageScan[];
 
     beforeEach(() => {
         loggerMock = Mock.ofType(MockableLogger);
         combinedScanResultsProviderMock = Mock.ofType<CombinedScanResultsProvider>();
         axeResultsReducerMock = Mock.ofType<AxeResultsReducer>();
 
+        pageScans = [
+            {
+                scanState: 'pass',
+            },
+            {
+                scanState: 'pass',
+            },
+            {
+                scanState: 'fail',
+            },
+            {
+                scanState: 'pending',
+            },
+        ] as PageScan[];
         axeResults = {
             url: 'url',
             timestamp: 'timestamp',
@@ -70,24 +85,16 @@ describe(CombinedAxeResultBuilder, () => {
     describe('Success', () => {
         test('generate combined scan results with no new violations', async () => {
             const expectedCombinedScanResults = cloneDeep(combinedScanResults);
-            expectedCombinedScanResults.urlCount.passed++;
-            expectedCombinedScanResults.urlCount.total++;
+            const failed = pageScans.filter((s) => s?.scanState === 'fail').length;
+            const passed = pageScans.filter((s) => s?.scanState === 'pass').length;
+            expectedCombinedScanResults.urlCount = {
+                total: passed + failed,
+                failed,
+                passed,
+            };
 
             setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {});
-            const combinedResults = await testSubject.mergeAxeResults(axeResults, combinedResultsBlobInfoStub);
-            expect(combinedResults).toEqual(expectedCombinedScanResults);
-        });
-
-        test('generate combined scan results with new violations', async () => {
-            axeResults.violations = [{} as axe.Result];
-
-            const expectedCombinedScanResults = cloneDeep(combinedScanResults);
-            expectedCombinedScanResults.urlCount.failed++;
-            expectedCombinedScanResults.urlCount.total++;
-
-            setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {});
-
-            const combinedResults = await testSubject.mergeAxeResults(axeResults, combinedResultsBlobInfoStub);
+            const combinedResults = await testSubject.mergeAxeResults(axeResults, combinedResultsBlobInfoStub, pageScans);
             expect(combinedResults).toEqual(expectedCombinedScanResults);
         });
     });
@@ -95,15 +102,18 @@ describe(CombinedAxeResultBuilder, () => {
     describe('Error', () => {
         test('throw for when writing blob fails', async () => {
             const expectedCombinedScanResults = cloneDeep(combinedScanResultsBlobRead.results);
-            expectedCombinedScanResults.urlCount.passed++;
-            expectedCombinedScanResults.urlCount.total++;
+            expectedCombinedScanResults.urlCount = {
+                total: 3,
+                failed: 1,
+                passed: 2,
+            };
 
             combinedScanResultsProviderMock.setup((m) => m.getEmptyResponse()).returns(() => combinedScanResultsBlobRead);
             setupBlobWrite(expectedCombinedScanResults, blobReadETagStub, combinedResultsBlobId, {
                 error: {} as any,
             });
 
-            await expect(testSubject.mergeAxeResults(axeResults, combinedResultsBlobInfoStub)).rejects.toThrowError(
+            await expect(testSubject.mergeAxeResults(axeResults, combinedResultsBlobInfoStub, pageScans)).rejects.toThrowError(
                 'Failed to write new combined axe scan results blob.',
             );
         });

--- a/packages/service-library/src/combined-report-provider/combined-axe-result-builder.ts
+++ b/packages/service-library/src/combined-report-provider/combined-axe-result-builder.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 import axe from 'axe-core';
-import { AxeResultsReducer } from 'axe-result-converter';
+import { AxeResultsReducer, UrlCount } from 'axe-result-converter';
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
-import { CombinedScanResults } from 'storage-documents';
+import { CombinedScanResults, PageScan } from 'storage-documents';
 import { CombinedScanResultsProvider } from '../data-providers/combined-scan-results-provider';
 import { CombinedResultsBlob } from './combined-results-blob-provider';
 
@@ -20,17 +20,13 @@ export class CombinedAxeResultBuilder {
     public async mergeAxeResults(
         axeScanResults: axe.AxeResults,
         combinedResultsBlobInfo: CombinedResultsBlob,
+        pageScans: PageScan[],
     ): Promise<CombinedScanResults> {
         const combinedResultsBlobId = combinedResultsBlobInfo.blobId;
         const blobReadResponse = combinedResultsBlobInfo.response;
         const combinedScanResults = blobReadResponse.results;
 
-        combinedScanResults.urlCount.total++;
-        if (axeScanResults.violations.length > 0) {
-            combinedScanResults.urlCount.failed++;
-        } else {
-            combinedScanResults.urlCount.passed++;
-        }
+        combinedScanResults.urlCount = this.getScannedUrlCount(pageScans);
 
         this.axeResultsReducer.reduce(combinedScanResults.axeResults, axeScanResults);
         const blobWriteResponse = await this.combinedScanResultsProvider.writeCombinedResults(
@@ -52,5 +48,24 @@ export class CombinedAxeResultBuilder {
         }
 
         return combinedScanResults;
+    }
+
+    private getScannedUrlCount(pageScans: PageScan[]): UrlCount {
+        if (pageScans === undefined) {
+            return {
+                total: 0,
+                failed: 0,
+                passed: 0,
+            };
+        }
+
+        const passed = pageScans.filter((s) => s?.scanState === 'pass').length;
+        const failed = pageScans.filter((s) => s?.scanState === 'fail').length;
+
+        return {
+            total: passed + failed,
+            failed,
+            passed,
+        };
     }
 }

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
@@ -43,7 +43,7 @@ export class CombinedScanResultProcessor {
 
     private async generateCombinedScanResultsImpl(axeScanResults: AxeScanResults, pageScanResult: OnDemandPageScanResult): Promise<void> {
         const websiteScanRef = this.getWebsiteScanRefs(pageScanResult);
-        const websiteScanResult = await this.websiteScanResultProvider.read(websiteScanRef.id);
+        const websiteScanResult = await this.websiteScanResultProvider.read(websiteScanRef.id, true);
         const combinedResultsBlob = await this.combinedResultsBlobProvider.getBlob(websiteScanResult.combinedResultsBlobId);
         const combinedResultsBlobId = combinedResultsBlob.blobId;
 
@@ -52,7 +52,11 @@ export class CombinedScanResultProcessor {
             websiteScanId: websiteScanRef.id,
         });
 
-        const combinedAxeResults = await this.combinedAxeResultBuilder.mergeAxeResults(axeScanResults.results, combinedResultsBlob);
+        const combinedAxeResults = await this.combinedAxeResultBuilder.mergeAxeResults(
+            axeScanResults.results,
+            combinedResultsBlob,
+            websiteScanResult.pageScans,
+        );
         const generatedReport = this.combinedReportGenerator.generate(
             combinedAxeResults,
             websiteScanResult,

--- a/packages/service-library/src/data-providers/page-scan-run-report-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-run-report-provider.spec.ts
@@ -9,7 +9,6 @@ import { IMock, Mock } from 'typemoq';
 import { BodyParser, System } from 'common';
 import { AxeScanResults } from 'scanner-global-library';
 import { AxeResults } from 'axe-core';
-import { AxeResultsList, AxeResult } from 'axe-result-converter';
 import { DataProvidersCommon } from './data-providers-common';
 import { PageScanRunReportProvider } from './page-scan-run-report-provider';
 
@@ -27,22 +26,16 @@ const blobFilePath = `${time.getUTCFullYear()}/${time.getUTCMonth() + 1}/${time.
 const readableStream = {
     readable: true,
 } as NodeJS.ReadableStream;
-const createAxeResult = (key: string, value: string) => {
-    const list = new AxeResultsList();
-    list.add(key, { description: value } as unknown as AxeResult);
-
-    return list;
-};
 const axeScanResults = {
     scannedUrl: 'scannedUrl',
     pageTitle: 'pageTitle',
     results: {
         url: 'url',
-        passes: createAxeResult('1', 'a'),
-        violations: createAxeResult('2', 'b'),
-        incomplete: createAxeResult('3', 'c'),
-        inapplicable: createAxeResult('4', 'd'),
-    } as unknown as AxeResults,
+        passes: [{ id: 'aria-allowed-attr', impact: null }],
+        violations: [{ id: 'frame-title', impact: 'serious' }],
+        incomplete: [{ id: 'color-contrast', impact: 'serious' }],
+        inapplicable: [{ id: 'area-alt', impact: null }],
+    } as AxeResults,
 } as AxeScanResults;
 const resultsString = JSON.stringify(axeScanResults);
 

--- a/packages/service-library/src/data-providers/page-scan-run-report-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-run-report-provider.ts
@@ -5,7 +5,6 @@ import { Readable } from 'stream';
 import { BlobContentDownloadResponse, BlobStorageClient } from 'azure-services';
 import { inject, injectable } from 'inversify';
 import { BodyParser, System } from 'common';
-import { AxeResultsList } from 'axe-result-converter';
 import { AxeScanResults } from 'scanner-global-library';
 import { DataProvidersCommon } from './data-providers-common';
 import { ReadErrorCode } from './combined-scan-results-provider';
@@ -58,13 +57,7 @@ export class PageScanRunReportProvider {
         }
 
         try {
-            const content = JSON.parse(contentString, (key, value) => {
-                if (key === 'violations' || key === 'passes' || key === 'incomplete' || key === 'inapplicable') {
-                    return new AxeResultsList(value);
-                }
-
-                return value;
-            });
+            const content = JSON.parse(contentString);
 
             return {
                 content,


### PR DESCRIPTION
#### Details

Fixed axe result blob deserialization. The axe scan results were incorrectly deserialized into non-array object.

##### Motivation

Fix consolidated  report stata data issue.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: Fixes #2080
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
