### PR TITLE
Renew AAD token before expiration time

### DIFF
--- a/packages/azure-services/src/credentials/credentials-provider.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.ts
@@ -22,7 +22,7 @@ export class CredentialsProvider {
     }
 
     public getAzureCredential(): TokenCredential {
-        if (this.authenticationMethod === AuthenticationMethod.managedIdentity) {
+        if (this.authenticationMethod === AuthenticationMethod.servicePrincipal) {
             return new EnvironmentCredential();
         } else {
             // must be object instance to reuse an internal cache

--- a/packages/azure-services/src/credentials/credentials-provider.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.ts
@@ -22,7 +22,7 @@ export class CredentialsProvider {
     }
 
     public getAzureCredential(): TokenCredential {
-        if (this.authenticationMethod === AuthenticationMethod.servicePrincipal) {
+        if (this.authenticationMethod === AuthenticationMethod.managedIdentity) {
             return new EnvironmentCredential();
         } else {
             // must be object instance to reuse an internal cache

--- a/packages/azure-services/src/credentials/managed-identity-credential-cache.spec.ts
+++ b/packages/azure-services/src/credentials/managed-identity-credential-cache.spec.ts
@@ -6,21 +6,29 @@ import 'reflect-metadata';
 import NodeCache from 'node-cache';
 import { IMock, Mock, Times } from 'typemoq';
 import { Mutex } from 'async-mutex';
-import { ManagedIdentityCredential } from '@azure/identity';
+import { ManagedIdentityCredential, AccessToken } from '@azure/identity';
+import * as MockDate from 'mockdate';
 import { ManagedIdentityCredentialCache } from './managed-identity-credential-cache';
 
 const scopes = 'https://vault.azure.net/default';
 const resourceUrl = 'vault.azure.net';
-const accessToken = { token: 'eyJ0e_3g', expiresOnTimestamp: 1633500000 };
 const accessTokenOptions = {};
 const cacheCheckPeriodInSeconds = 60;
+const tokenExpirationReductionMsec = 3600000;
+
+let tokenCacheMock: IMock<NodeCache>;
+let managedIdentityCredentialMock: IMock<ManagedIdentityCredential>;
+let azureManagedCredential: ManagedIdentityCredentialCache;
+let accessToken: AccessToken;
+let dateNow: Date;
 
 describe(ManagedIdentityCredentialCache, () => {
-    let tokenCacheMock: IMock<NodeCache>;
-    let managedIdentityCredentialMock: IMock<ManagedIdentityCredential>;
-    let azureManagedCredential: ManagedIdentityCredentialCache;
-
     beforeEach(() => {
+        dateNow = new Date();
+        MockDate.set(dateNow);
+
+        accessToken = { token: 'eyJ0e_3g', expiresOnTimestamp: dateNow.valueOf() + tokenExpirationReductionMsec + 60000 };
+
         tokenCacheMock = Mock.ofType<NodeCache>();
         managedIdentityCredentialMock = Mock.ofType<ManagedIdentityCredential>();
         azureManagedCredential = new ManagedIdentityCredentialCache(
@@ -37,14 +45,35 @@ describe(ManagedIdentityCredentialCache, () => {
     });
 
     afterEach(() => {
+        MockDate.reset();
         managedIdentityCredentialMock.verifyAll();
         tokenCacheMock.verifyAll();
     });
 
-    it('get token from a service', async () => {
+    it('get token from a service on cache miss', async () => {
         tokenCacheMock
             .setup((o) => o.get(resourceUrl))
             .returns(() => undefined)
+            .verifiable();
+        tokenCacheMock
+            .setup((o) => o.set(resourceUrl, accessToken, accessToken.expiresOnTimestamp / 1000 - cacheCheckPeriodInSeconds * 3))
+            .returns(() => true)
+            .verifiable();
+        managedIdentityCredentialMock
+            .setup((o) => o.getToken(scopes, accessTokenOptions))
+            .returns(() => Promise.resolve(accessToken))
+            .verifiable();
+
+        const actualAccessToken = await azureManagedCredential.getToken(scopes, accessTokenOptions);
+
+        expect(actualAccessToken).toEqual(accessToken);
+    });
+
+    it('get token from a service on token expiration', async () => {
+        accessToken.expiresOnTimestamp = dateNow.valueOf() + tokenExpirationReductionMsec;
+        tokenCacheMock
+            .setup((o) => o.get(resourceUrl))
+            .returns(() => accessToken)
             .verifiable();
         tokenCacheMock
             .setup((o) => o.set(resourceUrl, accessToken, accessToken.expiresOnTimestamp / 1000 - cacheCheckPeriodInSeconds * 3))


### PR DESCRIPTION
#### Details

Enforce renew of AAD token when expiration is due to avoid expired token reuse.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
