### PR TITLE
Performance optimization to support high number page under single scan request

### DIFF
--- a/packages/report-generator-runner/src/runner/runner.ts
+++ b/packages/report-generator-runner/src/runner/runner.ts
@@ -3,8 +3,8 @@
 
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
-import { OnDemandPageScanRunResultProvider, ReportGeneratorRequestProvider } from 'service-library';
-import { OnDemandPageScanResult, ReportGeneratorRequest } from 'storage-documents';
+import { OnDemandPageScanRunResultProvider, ReportGeneratorRequestProvider, OperationResult } from 'service-library';
+import { OnDemandPageScanResult, ReportGeneratorRequest, OnDemandPageScanRunState } from 'storage-documents';
 import { System } from 'common';
 import { isEmpty } from 'lodash';
 import { RunMetadataConfig } from '../run-metadata-config';
@@ -80,11 +80,6 @@ export class Runner {
 
     private async updateRequestStateToRunning(queuedRequests: QueuedRequests): Promise<void> {
         const requestsToUpdate = queuedRequests.requestsToProcess.map((queuedRequest) => {
-            this.logger.logInfo(`Updating report request run state to running.`, {
-                id: queuedRequest.request.id,
-                scanId: queuedRequest.request.scanId,
-            });
-
             return {
                 id: queuedRequest.request.id,
                 run: {
@@ -97,6 +92,7 @@ export class Runner {
         });
 
         const updatedRequestsResponse = await this.reportGeneratorRequestProvider.tryUpdateRequests(requestsToUpdate);
+        this.logOperationResult('running', updatedRequestsResponse);
 
         // remove failed update requests
         const updatedRequests = queuedRequests.requestsToProcess.filter((queuedRequest) =>
@@ -107,11 +103,6 @@ export class Runner {
 
     private async updateRequestStateToFailed(queuedRequests: QueuedRequest[]): Promise<void> {
         const requestsToUpdate = queuedRequests.map((queuedRequest) => {
-            this.logger.logInfo(`Updating report request run state to failed.`, {
-                id: queuedRequest.request.id,
-                scanId: queuedRequest.request.scanId,
-            });
-
             return {
                 id: queuedRequest.request.id,
                 run: {
@@ -122,7 +113,8 @@ export class Runner {
             } as Partial<ReportGeneratorRequest>;
         });
 
-        await this.reportGeneratorRequestProvider.tryUpdateRequests(requestsToUpdate);
+        const updatedRequestsResponse = await this.reportGeneratorRequestProvider.tryUpdateRequests(requestsToUpdate);
+        this.logOperationResult('failed', updatedRequestsResponse);
     }
 
     private async updateScanRunStatesToCompleted(queuedRequests: QueuedRequest[]): Promise<void> {
@@ -150,7 +142,7 @@ export class Runner {
     private async deleteRequests(queuedRequests: QueuedRequest[]): Promise<void> {
         await this.reportGeneratorRequestProvider.deleteRequests(
             queuedRequests.map((queuedRequest) => {
-                this.logger.logInfo(`Deleting report request from a queue.`, {
+                this.logger.logInfo(`Deleting report request from a report queue.`, {
                     id: queuedRequest.request.id,
                     scanId: queuedRequest.request.scanId,
                 });
@@ -158,5 +150,21 @@ export class Runner {
                 return queuedRequest.request.id;
             }),
         );
+    }
+
+    private logOperationResult(state: OnDemandPageScanRunState, operationResult: OperationResult<ReportGeneratorRequest>[]): void {
+        operationResult.map((response) => {
+            if (response.succeeded) {
+                this.logger.logInfo(`Updated report request run state to ${state}.`, {
+                    id: response.result.id,
+                    scanId: response.result.scanId,
+                });
+            } else {
+                this.logger.logError(`Failed to update report request run state to ${state}.`, {
+                    id: response.result.id,
+                    scanId: response.result.scanId,
+                });
+            }
+        });
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.ci.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ci.json
@@ -7,5 +7,9 @@
     },
     "availabilityTestConfig": {
         "environmentDefinition": "canary"
+    },
+    "crawlConfig": {
+        "deepScanDiscoveryLimit": 10,
+        "deepScanUpperLimit": 5000
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -6,7 +6,8 @@
         "environmentDefinition": "canary"
     },
     "queueConfig": {
-        "messageVisibilityTimeoutInSeconds": 300
+        "messageVisibilityTimeoutInSeconds": 300,
+        "maxQueueSize": 50
     },
     "scanConfig": {
         "failedScanRetryIntervalInMinutes": 15,

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -11,5 +11,9 @@
     "scanConfig": {
         "failedScanRetryIntervalInMinutes": 15,
         "maxFailedScanRetryCount": 1
+    },
+    "crawlConfig": {
+        "deepScanDiscoveryLimit": 10,
+        "deepScanUpperLimit": 5000
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -13,6 +13,6 @@
     },
     "crawlConfig": {
         "deepScanDiscoveryLimit": 100,
-        "deepScanUpperLimit": 3000
+        "deepScanUpperLimit": 5000
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.ppe.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.ppe.json
@@ -3,7 +3,7 @@
         "sendNotification": true
     },
     "queueConfig": {
-        "maxQueueSize": 40
+        "maxQueueSize": 100
     },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300

--- a/packages/resource-deployment/runtime-config/runtime-config.prod.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.prod.json
@@ -13,6 +13,6 @@
     },
     "crawlConfig": {
         "deepScanDiscoveryLimit": 100,
-        "deepScanUpperLimit": 3000
+        "deepScanUpperLimit": 5000
     }
 }

--- a/packages/resource-deployment/runtime-config/runtime-config.prod.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.prod.json
@@ -3,7 +3,7 @@
         "sendNotification": true
     },
     "queueConfig": {
-        "maxQueueSize": 40
+        "maxQueueSize": 100
     },
     "restApiConfig": {
         "scanRequestProcessingDelayInSeconds": 300

--- a/packages/resource-deployment/runtime-config/runtime-config.selftest.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.selftest.json
@@ -7,5 +7,9 @@
     },
     "availabilityTestConfig": {
         "environmentDefinition": "canary"
+    },
+    "crawlConfig": {
+        "deepScanDiscoveryLimit": 10,
+        "deepScanUpperLimit": 5000
     }
 }

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -6,28 +6,28 @@
             "value": "1"
         },
         "onDemandScanRequestPoolVmSize": {
-            "value": "standard_d1_v2"
+            "value": "standard_f8s_v2"
         },
         "onDemandScanRequestPoolTaskSlotsPerNode": {
-            "value": "4"
+            "value": "8"
         },
         "onDemandUrlScanPoolNodes": {
             "value": "1"
         },
         "onDemandUrlScanPoolVmSize": {
-            "value": "standard_d11_v2"
+            "value": "standard_f8s_v2"
         },
         "onDemandUrlScanPoolTaskSlotsPerNode": {
-            "value": "2"
+            "value": "8"
         },
         "privacyScanPoolNodes": {
             "value": "1"
         },
         "privacyScanPoolVmSize": {
-            "value": "standard_d11_v2"
+            "value": "standard_f8s_v2"
         },
         "privacyScanPoolTaskSlotsPerNode": {
-            "value": "2"
+            "value": "8"
         }
     }
 }

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "onDemandScanRequestPoolNodes": {
-            "value": "5"
+            "value": "1"
         },
         "onDemandScanRequestPoolVmSize": {
             "value": "standard_f8s_v2"
@@ -12,7 +12,7 @@
             "value": "8"
         },
         "onDemandUrlScanPoolNodes": {
-            "value": "5"
+            "value": "1"
         },
         "onDemandUrlScanPoolVmSize": {
             "value": "standard_f8s_v2"

--- a/packages/resource-deployment/templates/batch-account-dev.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-dev.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "onDemandScanRequestPoolNodes": {
-            "value": "1"
+            "value": "5"
         },
         "onDemandScanRequestPoolVmSize": {
             "value": "standard_f8s_v2"
@@ -12,7 +12,7 @@
             "value": "8"
         },
         "onDemandUrlScanPoolNodes": {
-            "value": "1"
+            "value": "5"
         },
         "onDemandUrlScanPoolVmSize": {
             "value": "standard_f8s_v2"

--- a/packages/resource-deployment/templates/batch-account-prod.parameters.json
+++ b/packages/resource-deployment/templates/batch-account-prod.parameters.json
@@ -6,28 +6,28 @@
             "value": "8"
         },
         "onDemandScanRequestPoolVmSize": {
-            "value": "standard_d11_v2"
+            "value": "standard_f8s_v2"
         },
         "onDemandScanRequestPoolTaskSlotsPerNode": {
-            "value": "4"
+            "value": "8"
         },
         "onDemandUrlScanPoolNodes": {
             "value": "8"
         },
         "onDemandUrlScanPoolVmSize": {
-            "value": "standard_d11_v2"
+            "value": "standard_f8s_v2"
         },
         "onDemandUrlScanPoolTaskSlotsPerNode": {
-            "value": "2"
+            "value": "8"
         },
         "privacyScanPoolNodes": {
             "value": "1"
         },
         "privacyScanPoolVmSize": {
-            "value": "standard_d11_v2"
+            "value": "standard_f8s_v2"
         },
         "privacyScanPoolTaskSlotsPerNode": {
-            "value": "2"
+            "value": "8"
         }
     }
 }

--- a/packages/resource-deployment/templates/batch-account.template.json
+++ b/packages/resource-deployment/templates/batch-account.template.json
@@ -6,7 +6,7 @@
             "type": "string",
             "defaultValue": "[concat('allybatch',toLower(uniqueString(resourceGroup().id)))]",
             "metadata": {
-                "description": "Batch Account Name"
+                "description": "Batch account name"
             }
         },
         "keyVault": {
@@ -66,14 +66,14 @@
             }
         },
         "onDemandScanRequestPoolVmSize": {
-            "defaultValue": "standard_d1_v2",
+            "defaultValue": "standard_f8s_v2",
             "type": "string",
             "metadata": {
                 "description": "VM size for on-demand-scan-request-pool pool"
             }
         },
         "onDemandScanRequestPoolTaskSlotsPerNode": {
-            "defaultValue": "2",
+            "defaultValue": "8",
             "type": "string",
             "metadata": {
                 "description": "Task slots per node for on-demand-scan-request-pool pool"
@@ -87,14 +87,14 @@
             }
         },
         "onDemandUrlScanPoolVmSize": {
-            "defaultValue": "standard_d11_v2",
+            "defaultValue": "standard_f8s_v2",
             "type": "string",
             "metadata": {
                 "description": "VM size for on-demand-url-scan-pool pool"
             }
         },
         "onDemandUrlScanPoolTaskSlotsPerNode": {
-            "defaultValue": "4",
+            "defaultValue": "8",
             "type": "string",
             "metadata": {
                 "description": "Task slots per node for on-demand-url-scan-pool pool"
@@ -108,14 +108,14 @@
             }
         },
         "privacyScanPoolVmSize": {
-            "defaultValue": "standard_d11_v2",
+            "defaultValue": "standard_f8s_v2",
             "type": "string",
             "metadata": {
                 "description": "VM size for privacy-scan-pool pool"
             }
         },
         "privacyScanPoolTaskSlotsPerNode": {
-            "defaultValue": "4",
+            "defaultValue": "8",
             "type": "string",
             "metadata": {
                 "description": "Task slots per node for privacy-scan-pool pool"

--- a/packages/resource-deployment/templates/report-generator-schedule.template.json
+++ b/packages/resource-deployment/templates/report-generator-schedule.template.json
@@ -1,7 +1,7 @@
 {
     "id": "report-generator-schedule",
     "schedule": {
-        "recurrenceInterval": "PT5M"
+        "recurrenceInterval": "PT1M"
     },
     "jobSpecification": {
         "priority": 0,

--- a/packages/resource-deployment/templates/report-generator-schedule.template.json
+++ b/packages/resource-deployment/templates/report-generator-schedule.template.json
@@ -1,7 +1,7 @@
 {
     "id": "report-generator-schedule",
     "schedule": {
-        "recurrenceInterval": "PT1M"
+        "recurrenceInterval": "PT5M"
     },
     "jobSpecification": {
         "priority": 0,

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.spec.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.spec.ts
@@ -7,7 +7,7 @@ import { IMock, Mock, It, Times } from 'typemoq';
 import { RetryHelper } from 'common';
 import { AxeScanResults } from 'scanner-global-library';
 import { AxeResults } from 'axe-core';
-import { OnDemandPageScanResult, WebsiteScanResult, CombinedScanResults, OnDemandPageScanReport, PageScan } from 'storage-documents';
+import { OnDemandPageScanResult, WebsiteScanResult, CombinedScanResults, OnDemandPageScanReport } from 'storage-documents';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 import { WebsiteScanResultProvider } from '../data-providers/website-scan-result-provider';
 import { GeneratedReport, ReportWriter } from '../data-providers/report-writer';
@@ -32,7 +32,6 @@ let combinedResultsBlob: CombinedResultsBlob;
 let combinedAxeResults: CombinedScanResults;
 let generatedReport: GeneratedReport;
 let pageScanReport: OnDemandPageScanReport;
-let pageScans: PageScan[];
 
 const websiteScanId = 'websiteScanId';
 
@@ -57,22 +56,9 @@ describe(CombinedScanResultProcessor, () => {
         combinedResultsBlob = {
             blobId: 'blobId',
         } as CombinedResultsBlob;
-        pageScans = [
-            {
-                scanState: 'pass',
-            },
-            {
-                scanState: 'pass',
-            },
-            {
-                scanState: 'fail',
-            },
-        ] as PageScan[];
         combinedAxeResults = {
             urlCount: {
-                total: 3,
-                passed: 2,
-                failed: 1,
+                total: 12,
             },
         } as CombinedScanResults;
         generatedReport = {
@@ -168,11 +154,9 @@ function setupFullPass(): void {
     websiteScanResult = {
         id: 'websiteScanResultId',
         combinedResultsBlobId: combinedResultsBlob.blobId,
-        pageScans,
     } as WebsiteScanResult;
     updatedWebsiteScanResults = {
-        id: websiteScanResult.id,
-        combinedResultsBlobId: combinedResultsBlob.blobId,
+        ...websiteScanResult,
         reports: [pageScanReport],
     };
 
@@ -181,7 +165,7 @@ function setupFullPass(): void {
         .returns(() => Promise.resolve(combinedResultsBlob))
         .verifiable();
     combinedAxeResultBuilderMock
-        .setup((o) => o.mergeAxeResults(axeScanResults.results, combinedResultsBlob, websiteScanResult.pageScans))
+        .setup((o) => o.mergeAxeResults(axeScanResults.results, combinedResultsBlob))
         .returns(() => Promise.resolve(combinedAxeResults))
         .verifiable();
     combinedReportGeneratorMock
@@ -197,7 +181,7 @@ function setupFullPass(): void {
 
 function setupWebsiteScanResultProviderMock(): void {
     websiteScanResultProviderMock
-        .setup((o) => o.read(websiteScanId, true))
+        .setup((o) => o.read(websiteScanId))
         .returns(() => Promise.resolve(websiteScanResult))
         .verifiable();
     websiteScanResultProviderMock.setup((o) => o.mergeOrCreate(pageScanResult.id, It.isValue(updatedWebsiteScanResults))).verifiable();

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
@@ -43,7 +43,7 @@ export class CombinedScanResultProcessor {
 
     private async generateCombinedScanResultsImpl(axeScanResults: AxeScanResults, pageScanResult: OnDemandPageScanResult): Promise<void> {
         const websiteScanRef = this.getWebsiteScanRefs(pageScanResult);
-        const websiteScanResult = await this.websiteScanResultProvider.read(websiteScanRef.id, true);
+        const websiteScanResult = await this.websiteScanResultProvider.read(websiteScanRef.id);
         const combinedResultsBlob = await this.combinedResultsBlobProvider.getBlob(websiteScanResult.combinedResultsBlobId);
         const combinedResultsBlobId = combinedResultsBlob.blobId;
 
@@ -52,11 +52,7 @@ export class CombinedScanResultProcessor {
             websiteScanId: websiteScanRef.id,
         });
 
-        const combinedAxeResults = await this.combinedAxeResultBuilder.mergeAxeResults(
-            axeScanResults.results,
-            combinedResultsBlob,
-            websiteScanResult.pageScans,
-        );
+        const combinedAxeResults = await this.combinedAxeResultBuilder.mergeAxeResults(axeScanResults.results, combinedResultsBlob);
         const generatedReport = this.combinedReportGenerator.generate(
             combinedAxeResults,
             websiteScanResult,

--- a/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
@@ -46,6 +46,13 @@ export class WebsiteScanResultAggregator {
         return this.mergePartDocuments([sourceDocument], targetDocument);
     }
 
+    /**
+     * Merge DB documents. The merge runs in a separate node process. Creating a separate process is a time consuming operation.
+     * Passing a high number of documents to merge at once will reduce process creation operations when processing in batches.
+     *
+     * @param documents DB documents to merge.
+     * @param baseDocument The base DB document to merge with DB documents.
+     */
     public async mergePartDocuments(
         documents: Partial<WebsiteScanResultPart>[],
         baseDocument?: Partial<WebsiteScanResultPart>,

--- a/packages/service-library/src/data-providers/website-scan-result-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-provider.spec.ts
@@ -240,11 +240,7 @@ describe(WebsiteScanResultProvider, () => {
             .verifiable();
 
         websiteScanResultAggregatorMock
-            .setup((o) => o.mergePartDocuments(It.isValue([partDocuments[0]]), {}))
-            .returns(() => Promise.resolve(partMergedDocuments[0]))
-            .verifiable();
-        websiteScanResultAggregatorMock
-            .setup((o) => o.mergePartDocuments(It.isValue([partDocuments[1]]), partMergedDocuments[0]))
+            .setup((o) => o.mergePartDocuments(It.isValue([partDocuments[0], partDocuments[1]]), {}))
             .returns(() => Promise.resolve(partMergedDocuments[1]))
             .verifiable();
 

--- a/packages/service-library/src/web-api/web-api-error-codes.ts
+++ b/packages/service-library/src/web-api/web-api-error-codes.ts
@@ -19,7 +19,9 @@ export declare type WebApiErrorCodeName =
     | 'MissingReleaseVersion'
     | 'InvalidScanNotifyUrl'
     | 'MissingSiteOrReportGroups'
-    | 'MissingRequiredDeepScanProperties';
+    | 'MissingRequiredDeepScanProperties'
+    | 'TooManyKnownPages'
+    | 'InvalidKnownPageURL';
 
 export interface WebApiErrorCode {
     statusCode: number;
@@ -159,6 +161,24 @@ export class WebApiErrorCodes {
             code: 'MissingRequiredDeepScanProperties',
             codeId: 4014,
             message: 'The request is missing either the site or report groups property, which are required when deepScan is true.',
+        },
+    };
+
+    public static tooManyKnownPages: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'TooManyKnownPages',
+            codeId: 4015,
+            message: 'The request contains too many known pages.',
+        },
+    };
+
+    public static invalidKnownPageURL: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'InvalidKnownPageURL',
+            codeId: 4016,
+            message: 'The know page URL is not valid.',
         },
     };
 


### PR DESCRIPTION
#### Details

- Increased limit to support 5000 pages for a single scan request.
- Switch to use larger batch of db documents when processing in parallel to eliminate node processes creation operations.
- Added client error codes to indicate validation error when too many know pages is sent in a request, and invalid URLs provided.
- Revert to use consolidated urls count from a previous consolidated blob result.
- Upgraded VM to SKU with higher CPU count

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
