### PR TITLE
Mark test passwords as placeholder for CredScan Compliance

### DIFF
--- a/packages/crawler/src/authenticator/authenticator-factory.spec.ts
+++ b/packages/crawler/src/authenticator/authenticator-factory.spec.ts
@@ -9,7 +9,7 @@ import { AzurePortalAuthentication } from './azure-portal-authenticator';
 
 describe(AuthenticatorFactory, () => {
     const testAccountName = 'testServiceAccount';
-    const testAccountPassword = 'test123';
+    const testAccountPassword = 'placeholder';
     let authenticatorFactory: AuthenticatorFactory;
 
     beforeEach(() => {

--- a/packages/crawler/src/authenticator/authenticator-factory.spec.ts
+++ b/packages/crawler/src/authenticator/authenticator-factory.spec.ts
@@ -9,7 +9,7 @@ import { AzurePortalAuthentication } from './azure-portal-authenticator';
 
 describe(AuthenticatorFactory, () => {
     const testAccountName = 'testServiceAccount';
-    const testAccountPassword = 'placeholder';
+    const testAccountPassword = 'Placeholder_test123';
     let authenticatorFactory: AuthenticatorFactory;
 
     beforeEach(() => {

--- a/packages/crawler/src/authenticator/azure-portal-authenticator.spec.ts
+++ b/packages/crawler/src/authenticator/azure-portal-authenticator.spec.ts
@@ -30,7 +30,7 @@ function setupPortalAuthenticationFlow(
 
 describe(AzurePortalAuthentication, () => {
     const accountName = 'testServiceAccount';
-    const accountPassword = 'placeholder';
+    const accountPassword = 'Placeholder_test123';
     let pageMock: IMock<Puppeteer.Page>;
     let keyboardMock: IMock<Puppeteer.Keyboard>;
     let testSubject: AzurePortalAuthentication;

--- a/packages/crawler/src/authenticator/azure-portal-authenticator.spec.ts
+++ b/packages/crawler/src/authenticator/azure-portal-authenticator.spec.ts
@@ -30,7 +30,7 @@ function setupPortalAuthenticationFlow(
 
 describe(AzurePortalAuthentication, () => {
     const accountName = 'testServiceAccount';
-    const accountPassword = 'test123';
+    const accountPassword = 'placeholder';
     let pageMock: IMock<Puppeteer.Page>;
     let keyboardMock: IMock<Puppeteer.Keyboard>;
     let testSubject: AzurePortalAuthentication;


### PR DESCRIPTION
#### Details

This appends the `Placeholder` prefix to test passwords to signal to CredScan that they are not real passwords.

##### Motivation

CredScan Compliance 


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [ n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
