### PR TITLE
Return pending run state for retrying failed scans

### DIFF
--- a/packages/privacy-scan-core/src/privacy-page-scanner.ts
+++ b/packages/privacy-scan-core/src/privacy-page-scanner.ts
@@ -63,7 +63,8 @@ export class PrivacyPageScanner {
 
         // Test sequentially so that cookie values don't interfere with each other
         for (const scenario of scenarios) {
-            results.push(await this.cookieCollector.getCookiesForScenario(page, scenario, reloadPageFunc));
+            const result = await this.cookieCollector.getCookiesForScenario(page, scenario, reloadPageFunc);
+            results.push(result);
         }
 
         return results;

--- a/packages/privacy-scan-runner/src/scanner/scan-feed-generator.ts
+++ b/packages/privacy-scan-runner/src/scanner/scan-feed-generator.ts
@@ -149,6 +149,6 @@ export class ScanFeedGenerator {
     private getUrlsToScan(websiteScanResult: WebsiteScanResult): string[] {
         const queuedUrls = websiteScanResult.pageScans.map((pageScan) => pageScan.url);
 
-        return pullAll([...websiteScanResult.knownPages], queuedUrls);
+        return pullAll([...(websiteScanResult?.knownPages ?? [])], queuedUrls);
     }
 }

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -341,10 +341,17 @@ describe(Page, () => {
             await expect(page.scanForPrivacy()).rejects.toThrow();
         });
 
-        it('Returns result with error if results contain an error in ConsentCollectionResults', async () => {
-            privacyResults.cookieCollectionConsentResults.push({
-                error: 'Error reloading page',
-            });
+        it('Returns result with error if privacy results contain an error', async () => {
+            privacyResults.cookieCollectionConsentResults.push(
+                ...[
+                    {
+                        error: 'Error reloading page 1',
+                    },
+                    {
+                        error: 'Error reloading page 2',
+                    },
+                ],
+            );
             puppeteerPageMock.setup((p) => p.url()).returns(() => url);
             simulatePageNavigation(puppeteerResponseMock.object);
             const expectedPrivacyScanResults = {
@@ -353,7 +360,7 @@ describe(Page, () => {
                     httpStatusCode: 200,
                 },
                 pageResponseCode: 200,
-                error: 'Failed to collect cookies for 1 test cases',
+                error: privacyResults.cookieCollectionConsentResults.find((r) => r.error !== undefined).error,
             } as PrivacyScanResult;
 
             const privacyScanResults = await page.scanForPrivacy();

--- a/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
+++ b/packages/service-library/src/data-providers/website-scan-result-aggregator.ts
@@ -80,7 +80,7 @@ export class WebsiteScanResultAggregator {
     private async mergePartDocumentsParallel(documents: Partial<WebsiteScanResultPart>[]): Promise<Partial<WebsiteScanResultPart>[]> {
         const partResults = await new Promise<Partial<WebsiteScanResultPart>[][]>((resolve, reject) => {
             const parts = System.chunkArray(documents, WebsiteScanResultAggregator.parallelBlockSize);
-            const parallel = new Parallel(parts, { evalPath: `${__dirname}/eval.js` });
+            const parallel = new Parallel(parts, { evalPath: `${this.getDirName()}/eval.js` });
 
             parallel
                 .map((part: Partial<WebsiteScanResultPart>[]) => {
@@ -103,6 +103,19 @@ export class WebsiteScanResultAggregator {
         });
 
         return partResults.map((p) => p[0]);
+    }
+
+    private getDirName(): string {
+        const isDebugEnabled = /--debug|--inspect/i.test(process.execArgv.join(' '));
+        if (isDebugEnabled === true) {
+            const buildDir = '/dist/';
+            if (__dirname.lastIndexOf(buildDir) > -1) {
+                // return build directory
+                return __dirname.substring(0, __dirname.lastIndexOf(buildDir) + buildDir.length - 1);
+            }
+        }
+
+        return __dirname;
     }
 
     private mergeArray(target: any, source: any, key: string, supportedKeys: string[]): any {

--- a/packages/web-api/src/controllers/base-scan-result-controller.ts
+++ b/packages/web-api/src/controllers/base-scan-result-controller.ts
@@ -62,7 +62,10 @@ export abstract class BaseScanResultController extends ApiController {
         );
     }
 
-    protected getScanResultResponse(pageScanResult: OnDemandPageScanResult, websiteScanResult: WebsiteScanResult): ScanResultResponse {
+    protected async getScanResultResponse(
+        pageScanResult: OnDemandPageScanResult,
+        websiteScanResult: WebsiteScanResult,
+    ): Promise<ScanResultResponse> {
         const segment = '/api/';
         const baseUrl = this.context.req.url.substring(0, this.context.req.url.indexOf(segment) + segment.length);
 

--- a/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
@@ -103,7 +103,7 @@ describe(BatchScanResultController, () => {
         scanResponseConverterMock = Mock.ofType<ScanResponseConverter>();
         scanResponseConverterMock
             .setup((o) => o.getScanResultResponse(baseUrl, apiVersion, scanFetchedResponse, websiteScanResult))
-            .returns(() => scanClientResponseForFetchedResponse);
+            .returns(() => Promise.resolve(scanClientResponseForFetchedResponse));
 
         websiteScanResultProviderMock = Mock.ofType<WebsiteScanResultProvider>();
         websiteScanResultProviderMock

--- a/packages/web-api/src/controllers/batch-scan-result-controller.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.ts
@@ -86,7 +86,8 @@ export class BatchScanResultController extends BaseScanResultController {
                     });
                 } else {
                     const websiteScanResult = await this.getWebsiteScanResult(pageScanResult);
-                    responses.push(this.getScanResultResponse(pageScanResult, websiteScanResult));
+                    const response = await this.getScanResultResponse(pageScanResult, websiteScanResult);
+                    responses.push(response);
                 }
             }),
         );

--- a/packages/web-api/src/controllers/scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.spec.ts
@@ -230,7 +230,7 @@ describe(ScanResultController, () => {
 
             scanResponseConverterMock
                 .setup((o) => o.getScanResultResponse(baseUrl, apiVersion, dbResponse, websiteScanResult))
-                .returns(() => scanClientResponseForDbResponse);
+                .returns(() => Promise.resolve(scanClientResponseForDbResponse));
 
             await scanResultController.handleRequest();
 

--- a/packages/web-api/src/controllers/scan-result-controller.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.ts
@@ -56,9 +56,10 @@ export class ScanResultController extends BaseScanResultController {
             }
         } else {
             const websiteScanResult = await this.getWebsiteScanResult(pageScanResult);
+            const body = await this.getScanResultResponse(pageScanResult, websiteScanResult);
             this.context.res = {
                 status: 200,
-                body: this.getScanResultResponse(pageScanResult, websiteScanResult),
+                body,
             };
             this.logger.logInfo('Scan result successfully fetched from a storage.');
         }


### PR DESCRIPTION
#### Details

Return pending run state for retrying failed scans to avoid false positive results.
Return an actual browser error to a client if any.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
