### PR TITLE
Convert to use fixed MSI token cache TTL

### DIFF
--- a/packages/azure-services/src/credentials/managed-identity-credential-cache.spec.ts
+++ b/packages/azure-services/src/credentials/managed-identity-credential-cache.spec.ts
@@ -6,21 +6,22 @@ import 'reflect-metadata';
 import NodeCache from 'node-cache';
 import { IMock, Mock, Times } from 'typemoq';
 import { Mutex } from 'async-mutex';
-import { ManagedIdentityCredential, AccessToken } from '@azure/identity';
+import { ManagedIdentityCredential } from '@azure/identity';
 import * as MockDate from 'mockdate';
 import { ExponentialRetryOptions } from 'common';
-import { ManagedIdentityCredentialCache } from './managed-identity-credential-cache';
+import moment from 'moment';
+import { cloneDeep } from 'lodash';
+import { ManagedIdentityCredentialCache, TokenCacheItem } from './managed-identity-credential-cache';
 
 const scopes = 'https://vault.azure.net/default';
 const resourceUrl = 'vault.azure.net';
 const accessTokenOptions = {};
-const tokenExpirationReductionMsec = 11100000;
-const getCacheTtl = (token: AccessToken): number => (token.expiresOnTimestamp - tokenExpirationReductionMsec) / 1000;
+const tokenValidForSec = 55 * 60;
 
 let tokenCacheMock: IMock<NodeCache>;
 let managedIdentityCredentialMock: IMock<ManagedIdentityCredential>;
 let azureManagedCredential: ManagedIdentityCredentialCache;
-let accessToken: AccessToken;
+let tokenCacheItem: TokenCacheItem;
 let dateNow: Date;
 let retryOptions: ExponentialRetryOptions;
 
@@ -29,7 +30,10 @@ describe(ManagedIdentityCredentialCache, () => {
         dateNow = new Date();
         MockDate.set(dateNow);
 
-        accessToken = { token: 'eyJ0e_3g', expiresOnTimestamp: dateNow.valueOf() + tokenExpirationReductionMsec + 60000 };
+        tokenCacheItem = {
+            accessToken: { token: 'eyJ0e_3g' },
+            expiresOn: moment.utc().valueOf() + tokenValidForSec * 1000,
+        } as TokenCacheItem;
         retryOptions = {
             delayFirstAttempt: false,
             numOfAttempts: 2,
@@ -58,52 +62,53 @@ describe(ManagedIdentityCredentialCache, () => {
             .returns(() => undefined)
             .verifiable();
         tokenCacheMock
-            .setup((o) => o.set(resourceUrl, accessToken, getCacheTtl(accessToken)))
+            .setup((o) => o.set(resourceUrl, tokenCacheItem, tokenValidForSec))
             .returns(() => true)
             .verifiable();
         managedIdentityCredentialMock
             .setup((o) => o.getToken(scopes, accessTokenOptions))
-            .returns(() => Promise.resolve(accessToken))
+            .returns(() => Promise.resolve(tokenCacheItem.accessToken))
             .verifiable();
 
         const actualAccessToken = await azureManagedCredential.getToken(scopes, accessTokenOptions);
 
-        expect(actualAccessToken).toEqual(accessToken);
+        expect(actualAccessToken).toEqual(tokenCacheItem.accessToken);
     });
 
     it('get token from a service on token expiration', async () => {
-        accessToken.expiresOnTimestamp = dateNow.valueOf() + tokenExpirationReductionMsec;
+        const currentTokenCacheItem = cloneDeep(tokenCacheItem);
+        currentTokenCacheItem.expiresOn = moment.utc().valueOf() - 1;
         tokenCacheMock
             .setup((o) => o.get(resourceUrl))
-            .returns(() => accessToken)
+            .returns(() => currentTokenCacheItem)
             .verifiable();
         tokenCacheMock
-            .setup((o) => o.set(resourceUrl, accessToken, getCacheTtl(accessToken)))
+            .setup((o) => o.set(resourceUrl, tokenCacheItem, tokenValidForSec))
             .returns(() => true)
             .verifiable();
         managedIdentityCredentialMock
             .setup((o) => o.getToken(scopes, accessTokenOptions))
-            .returns(() => Promise.resolve(accessToken))
+            .returns(() => Promise.resolve(tokenCacheItem.accessToken))
             .verifiable();
 
         const actualAccessToken = await azureManagedCredential.getToken(scopes, accessTokenOptions);
 
-        expect(actualAccessToken).toEqual(accessToken);
+        expect(actualAccessToken).toEqual(tokenCacheItem.accessToken);
     });
 
     it('get token from a cache', async () => {
         tokenCacheMock
             .setup((o) => o.get(resourceUrl))
-            .returns(() => accessToken)
+            .returns(() => tokenCacheItem)
             .verifiable();
         tokenCacheMock
-            .setup((o) => o.set(resourceUrl, accessToken, getCacheTtl(accessToken)))
+            .setup((o) => o.set(resourceUrl, tokenCacheItem, tokenValidForSec))
             .returns(() => true)
             .verifiable(Times.never());
 
         const actualAccessToken = await azureManagedCredential.getToken(scopes, accessTokenOptions);
 
-        expect(actualAccessToken).toEqual(accessToken);
+        expect(actualAccessToken).toEqual(tokenCacheItem.accessToken);
     });
 
     it('failed to get token from a service', async () => {
@@ -112,7 +117,7 @@ describe(ManagedIdentityCredentialCache, () => {
             .returns(() => undefined)
             .verifiable();
         tokenCacheMock
-            .setup((o) => o.set(resourceUrl, accessToken, getCacheTtl(accessToken)))
+            .setup((o) => o.set(resourceUrl, tokenCacheItem, tokenValidForSec))
             .returns(() => true)
             .verifiable(Times.never());
         managedIdentityCredentialMock


### PR DESCRIPTION
#### Details

Convert to use fixed MSI token cache TTL due to random rejection of cached token by AAD

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
