### PR TITLE
feat(ado-auth-part-2): auth stability improvements

### DIFF
--- a/packages/crawler/src/authenticator/azure-portal-authenticator.spec.ts
+++ b/packages/crawler/src/authenticator/azure-portal-authenticator.spec.ts
@@ -55,8 +55,8 @@ describe(AzurePortalAuthentication, () => {
     let consoleInfoMock: jest.SpyInstance;
     let testSubject: AzurePortalAuthentication;
     beforeEach(() => {
-        consoleErrorMock = jest.spyOn(global.console, 'error').mockImplementation(() => {});
-        consoleInfoMock = jest.spyOn(global.console, 'info').mockImplementation(() => {});
+        consoleErrorMock = jest.spyOn(global.console, 'error').mockImplementation();
+        consoleInfoMock = jest.spyOn(global.console, 'info').mockImplementation();
         keyboardMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Keyboard>());
         pageMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Page>());
         pageMock.setup((p) => p.keyboard).returns(() => keyboardMock.object);

--- a/packages/crawler/src/authenticator/azure-portal-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-portal-authenticator.ts
@@ -45,6 +45,7 @@ export class AzurePortalAuthentication implements AuthenticationMethod {
             return false;
         }
         console.info('Authentication succeeded.');
+
         return true;
     }
 }


### PR DESCRIPTION
#### Details

This adds the following stability improvements to the current auth browser automation:
- using `page.waitForNavigation()` in a `Promise.all` statement with the action that causes the navigation, as recommended in the puppeteer docs.
- adds an `authenticationSucceeded` check, and moves it to the top of the process. This was done because azure portal would unreliably finish navigating after auth before the auth check would retry. I couldn't track down exactly why this is happening but my hypothesis is that among the many auth redirects puppeteer would sometimes think it was done navigating when it wasn't. This checks before it goes through another auth attempt to ensure it truly didn't work.

Before these changes I was getting auth errors about 1 out of every 3 runs via the CLI. I have run this ~50 times without seeing an error yet.

##### Motivation

Feature Work

##### Context



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
