### PR TITLE
feat(ado-auth-part-2): add authType to Authenticator

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -137,6 +137,10 @@ function getScanArguments(): ScanArguments {
                 type: 'string',
                 describe: 'Use with --serviceAccountName to crawl pages requiring authentication.',
             },
+            authType: {
+                type: 'string',
+                describe: 'Use with --serviceAccountName and --serviceAccountPassword to specify the authentication type.',
+            },
         })
         .check((args) => {
             validateScanArguments(args as ScanArguments);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -131,11 +131,11 @@ function getScanArguments(): ScanArguments {
             },
             serviceAccountName: {
                 type: 'string',
-                describe: 'Use with --serviceAccountPassword to crawl pages requiring authentication.',
+                describe: 'Use with --serviceAccountPassword and --authType to crawl pages requiring authentication.',
             },
             serviceAccountPassword: {
                 type: 'string',
-                describe: 'Use with --serviceAccountName to crawl pages requiring authentication.',
+                describe: 'Use with --serviceAccountName and --authType to crawl pages requiring authentication.',
             },
             authType: {
                 type: 'string',

--- a/packages/cli/src/crawler/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.ts
@@ -45,6 +45,7 @@ export class CrawlerParametersBuilder {
             singleWorker: scanArguments.singleWorker,
             serviceAccountName: scanArguments.serviceAccountName,
             serviceAccountPassword: scanArguments.serviceAccountPassword,
+            authType: scanArguments.authType,
         };
     }
 

--- a/packages/cli/src/scan-arguments.ts
+++ b/packages/cli/src/scan-arguments.ts
@@ -25,4 +25,5 @@ export interface ScanArguments {
     singleWorker?: boolean;
     serviceAccountName?: string;
     serviceAccountPassword?: string;
+    authType?: string;
 }

--- a/packages/cli/src/validate-scan-arguments.ts
+++ b/packages/cli/src/validate-scan-arguments.ts
@@ -29,6 +29,10 @@ export function validateScanArguments(args: ScanArguments): void {
         throw new Error('Options --serviceAccountName, --serviceAccountPassword, and --authType are only supported with --crawl option.');
     }
 
+    validateAuthInputs(args);
+}
+
+function validateAuthInputs(args: ScanArguments): void {
     if (
         (!isEmpty(args.serviceAccountPassword) && (isEmpty(args.serviceAccountName) || isEmpty(args.authType))) ||
         (!isEmpty(args.serviceAccountName) && (isEmpty(args.serviceAccountPassword) || isEmpty(args.authType))) ||

--- a/packages/cli/src/validate-scan-arguments.ts
+++ b/packages/cli/src/validate-scan-arguments.ts
@@ -25,14 +25,14 @@ export function validateScanArguments(args: ScanArguments): void {
         throw new Error('Option --updateBaseline requires option --baselineFile.');
     }
 
-    if (!args.crawl && (!isEmpty(args.serviceAccountName) || !isEmpty(args.serviceAccountPassword))) {
-        throw new Error('Options --serviceAccountName and --serviceAccountPassword are only supported with --crawl option.');
+    if (!args.crawl && (!isEmpty(args.serviceAccountName) || !isEmpty(args.serviceAccountPassword) || !isEmpty(args.authType))) {
+        throw new Error('Options --serviceAccountName, --serviceAccountPassword, and --authType are only supported with --crawl option.');
     }
 
     if (
         (isEmpty(args.serviceAccountName) && !isEmpty(args.serviceAccountPassword)) ||
         (!isEmpty(args.serviceAccountName) && isEmpty(args.serviceAccountPassword))
     ) {
-        throw new Error('Both --serviceAccountName and --serviceAccountPassword must be provided to scan authenticated pages.');
+        throw new Error('--serviceAccountName, --serviceAccountPassword, and --authType all must be provided to scan authenticated pages.');
     }
 }

--- a/packages/cli/src/validate-scan-arguments.ts
+++ b/packages/cli/src/validate-scan-arguments.ts
@@ -30,8 +30,9 @@ export function validateScanArguments(args: ScanArguments): void {
     }
 
     if (
-        (isEmpty(args.serviceAccountName) && !isEmpty(args.serviceAccountPassword)) ||
-        (!isEmpty(args.serviceAccountName) && isEmpty(args.serviceAccountPassword))
+        (!isEmpty(args.serviceAccountPassword) && (isEmpty(args.serviceAccountName) || isEmpty(args.authType))) ||
+        (!isEmpty(args.serviceAccountName) && (isEmpty(args.serviceAccountPassword) || isEmpty(args.authType))) ||
+        (!isEmpty(args.authType) && (isEmpty(args.serviceAccountPassword) || isEmpty(args.serviceAccountName)))
     ) {
         throw new Error('--serviceAccountName, --serviceAccountPassword, and --authType all must be provided to scan authenticated pages.');
     }

--- a/packages/crawler/src/authenticator/authenticator-factory.spec.ts
+++ b/packages/crawler/src/authenticator/authenticator-factory.spec.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 
 import { Authenticator } from './authenticator';
 import { AuthenticatorFactory } from './authenticator-factory';
-import { AzurePortalAuthentication } from './azure-portal-authenticator';
+import { AzureActiveDirectoryAuthentication } from './azure-active-directory-authenticator';
 
 describe(AuthenticatorFactory, () => {
     const testAccountName = 'testServiceAccount';
@@ -16,9 +16,10 @@ describe(AuthenticatorFactory, () => {
         authenticatorFactory = new AuthenticatorFactory();
     });
 
-    it('createAADAuthenticator uses azure portal authentication with supplied credentials', async () => {
-        const testAuthenticationMethod = new AzurePortalAuthentication(testAccountName, testAccountPassword);
-        const authenticator = authenticatorFactory.createAADAuthenticator(testAccountName, testAccountPassword);
+    it('createAuthenticator uses AAD authentication with supplied credentials when authType is set to AAD', async () => {
+        const authType = 'AAD';
+        const testAuthenticationMethod = new AzureActiveDirectoryAuthentication(testAccountName, testAccountPassword);
+        const authenticator = authenticatorFactory.createAuthenticator(testAccountName, testAccountPassword, authType);
         expect(authenticator).toEqual(new Authenticator(testAuthenticationMethod));
     });
 });

--- a/packages/crawler/src/authenticator/authenticator-factory.ts
+++ b/packages/crawler/src/authenticator/authenticator-factory.ts
@@ -12,7 +12,7 @@ export class AuthenticatorFactory {
             case 'AAD':
                 return new Authenticator(new AzureActiveDirectoryAuthentication(accountName, accountPassword));
             default:
-                throw new Error(`Unknown auth type: ${authType}`);
+                throw new Error(`Unknown auth type: ${authType}, please provide a valid authType input.`);
         }
     }
 }

--- a/packages/crawler/src/authenticator/authenticator-factory.ts
+++ b/packages/crawler/src/authenticator/authenticator-factory.ts
@@ -3,11 +3,16 @@
 
 import { injectable } from 'inversify';
 import { Authenticator } from './authenticator';
-import { AzurePortalAuthentication } from './azure-portal-authenticator';
+import { AzureActiveDirectoryAuthentication } from './azure-active-directory-authenticator';
 
 @injectable()
 export class AuthenticatorFactory {
-    public createAADAuthenticator(accountName: string, accountPassword: string): Authenticator {
-        return new Authenticator(new AzurePortalAuthentication(accountName, accountPassword));
+    public createAuthenticator(accountName: string, accountPassword: string, authType: string): Authenticator {
+        switch (authType) {
+            case 'AAD':
+                return new Authenticator(new AzureActiveDirectoryAuthentication(accountName, accountPassword));
+            default:
+                throw new Error(`Unknown auth type: ${authType}`);
+        }
     }
 }

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.spec.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.spec.ts
@@ -4,9 +4,9 @@
 import { IMock, It, Mock, Times } from 'typemoq';
 import * as Puppeteer from 'puppeteer';
 import { getPromisableDynamicMock } from '../test-utilities/promisable-mock';
-import { AzurePortalAuthentication } from './azure-portal-authenticator';
+import { AzureActiveDirectoryAuthentication } from './azure-active-directory-authenticator';
 
-function setupPortalAuthenticationFlow(
+function setupAADAuthenticationFlow(
     pageMock: IMock<Puppeteer.Page>,
     keyboardMock: IMock<Puppeteer.Keyboard>,
     accountName: string,
@@ -46,21 +46,21 @@ function setupPortalAuthenticationFlow(
     }
 }
 
-describe(AzurePortalAuthentication, () => {
+describe(AzureActiveDirectoryAuthentication, () => {
     const accountName = 'testServiceAccount';
     const accountPassword = 'Placeholder_test123';
     let pageMock: IMock<Puppeteer.Page>;
     let keyboardMock: IMock<Puppeteer.Keyboard>;
     let consoleErrorMock: jest.SpyInstance;
     let consoleInfoMock: jest.SpyInstance;
-    let testSubject: AzurePortalAuthentication;
+    let testSubject: AzureActiveDirectoryAuthentication;
     beforeEach(() => {
         consoleErrorMock = jest.spyOn(global.console, 'error').mockImplementation();
         consoleInfoMock = jest.spyOn(global.console, 'info').mockImplementation();
         keyboardMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Keyboard>());
         pageMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Page>());
         pageMock.setup((p) => p.keyboard).returns(() => keyboardMock.object);
-        testSubject = new AzurePortalAuthentication(accountName, accountPassword);
+        testSubject = new AzureActiveDirectoryAuthentication(accountName, accountPassword);
     });
 
     afterEach(() => {
@@ -71,13 +71,13 @@ describe(AzurePortalAuthentication, () => {
     });
 
     it('follows portal.azure.com authentication flow', async () => {
-        setupPortalAuthenticationFlow(pageMock, keyboardMock, accountName, accountPassword);
+        setupAADAuthenticationFlow(pageMock, keyboardMock, accountName, accountPassword);
         await testSubject.authenticate(pageMock.object);
         expect(consoleInfoMock).toHaveBeenCalledWith('Authentication succeeded.');
     });
 
     it('retries four times if it detects authentication failed', async () => {
-        setupPortalAuthenticationFlow(pageMock, keyboardMock, accountName, accountPassword, false, 5);
+        setupAADAuthenticationFlow(pageMock, keyboardMock, accountName, accountPassword, false, 5);
         await testSubject.authenticate(pageMock.object);
         expect(consoleErrorMock).toHaveBeenCalledWith('Attempted authentication 5 times and ultimately failed.');
     });

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash';
 import * as Puppeteer from 'puppeteer';
 import { AuthenticationMethod } from './authentication-method';
 
-export class AzurePortalAuthentication implements AuthenticationMethod {
+export class AzureActiveDirectoryAuthentication implements AuthenticationMethod {
     constructor(private readonly accountName: string, private readonly accountPassword: string) {}
 
     public async authenticate(page: Puppeteer.Page, attemptNumber: number = 1): Promise<void> {

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
@@ -10,10 +10,10 @@ import { PageProcessor, PageProcessorBase } from '../page-processors/page-proces
 import { CrawlerRunOptions } from '../types/crawler-run-options';
 import { ApifyRequestQueueProvider } from '../types/ioc-types';
 import { AuthenticatorFactory } from '../authenticator/authenticator-factory';
+import { Authenticator } from '../authenticator/authenticator';
 import { CrawlerConfiguration } from './crawler-configuration';
 import { PuppeteerCrawlerEngine } from './puppeteer-crawler-engine';
 import { CrawlerFactory } from './crawler-factory';
-import { Authenticator } from '../authenticator/authenticator';
 
 /* eslint-disable
    @typescript-eslint/no-explicit-any,

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.spec.ts
@@ -10,10 +10,10 @@ import { PageProcessor, PageProcessorBase } from '../page-processors/page-proces
 import { CrawlerRunOptions } from '../types/crawler-run-options';
 import { ApifyRequestQueueProvider } from '../types/ioc-types';
 import { AuthenticatorFactory } from '../authenticator/authenticator-factory';
-import { Authenticator } from '../authenticator/authenticator';
 import { CrawlerConfiguration } from './crawler-configuration';
 import { PuppeteerCrawlerEngine } from './puppeteer-crawler-engine';
 import { CrawlerFactory } from './crawler-factory';
+import { Authenticator } from '../authenticator/authenticator';
 
 /* eslint-disable
    @typescript-eslint/no-explicit-any,
@@ -143,14 +143,16 @@ describe(PuppeteerCrawlerEngine, () => {
         await crawlerEngine.start(crawlerRunOptions);
     });
 
-    it('Run crawler while serviceAccountName and serviceAccountPassword are set', async () => {
+    it('Run crawler while serviceAccountName, serviceAccountPassword, and authType are set', async () => {
         const testAccountName = 'testAccount@microsoft.com';
         const testAccountPassword = 'testpassword';
+        const testAuthType = 'AAD';
         crawlerRunOptions.serviceAccountName = testAccountName;
         crawlerRunOptions.serviceAccountPassword = testAccountPassword;
+        crawlerRunOptions.authType = testAuthType;
 
         authenticatorFactoryMock
-            .setup((o) => o.createAADAuthenticator(testAccountName, testAccountPassword))
+            .setup((o) => o.createAuthenticator(testAccountName, testAccountPassword, testAuthType))
             .returns(() => authenticatorMock.object)
             .verifiable();
 

--- a/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
+++ b/packages/crawler/src/crawler/puppeteer-crawler-engine.ts
@@ -94,9 +94,10 @@ export class PuppeteerCrawlerEngine {
         }
 
         if (!isEmpty(crawlerRunOptions.serviceAccountName)) {
-            const authenticator = this.authenticatorFactory.createAADAuthenticator(
+            const authenticator = this.authenticatorFactory.createAuthenticator(
                 crawlerRunOptions.serviceAccountName,
                 crawlerRunOptions.serviceAccountPassword,
+                crawlerRunOptions.authType,
             );
 
             puppeteerCrawlerOptions.browserPoolOptions = {

--- a/packages/crawler/src/types/crawler-run-options.ts
+++ b/packages/crawler/src/types/crawler-run-options.ts
@@ -23,4 +23,5 @@ export interface CrawlerRunOptions {
     singleWorker?: boolean;
     serviceAccountName?: string;
     serviceAccountPassword?: string;
+    authType?: string;
 }


### PR DESCRIPTION
#### Details

This adds `authType` to the `Authenticator` in the `CLI` package. This allows us to specify which `authType` will be used in the `AuthenticatorFactory`. It also renames the `AzurePortalAuthenticator` to `AzureActiveDirectoryAuthenticator`, as it is a more accurate description of the purpose of the class.

##### Motivation

Feature work, this also allows the authType to be passed through from the ADO Extension.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran prechecking (`yarn precheckin`)
- [ ] Validated in an Azure resource group
