### PR TITLE
Reduce report generation concurrency

### DIFF
--- a/packages/report-generator-job-manager/src/worker/worker.ts
+++ b/packages/report-generator-job-manager/src/worker/worker.ts
@@ -68,7 +68,8 @@ export class Worker extends BatchTaskCreator {
         if (poolLoadSnapshot.tasksIncrementCountPerInterval > 0) {
             const reportMessages = await this.readReportMessages(poolLoadSnapshot.tasksIncrementCountPerInterval);
             if (reportMessages?.length > 0) {
-                messages = this.convertToScanMessages(reportMessages);
+                const newReportMessages = this.reduceReportMessages(reportMessages);
+                messages = this.convertToScanMessages(newReportMessages);
             }
         }
 
@@ -133,6 +134,14 @@ export class Worker extends BatchTaskCreator {
         } while (reportMessages.length < requestCount && continuationToken !== undefined);
 
         return reportMessages;
+    }
+
+    private reduceReportMessages(reportRequests: ScanReportGroup[]): ScanReportGroup[] {
+        if (this.activeScanMessages.length === 0 || reportRequests.length === 0) {
+            return reportRequests;
+        }
+
+        return reportRequests.filter((r) => !this.activeScanMessages.some((a) => a.scanId === r.scanGroupId));
     }
 
     private async writePoolLoadSnapshot(poolLoadSnapshot: PoolLoadSnapshot): Promise<void> {

--- a/packages/report-generator-runner/src/runner/request-selector.spec.ts
+++ b/packages/report-generator-runner/src/runner/request-selector.spec.ts
@@ -76,12 +76,6 @@ describe(RequestSelector, () => {
                 },
             },
             {
-                id: 'id4', // pending - process:pending
-                run: {
-                    state: 'pending',
-                },
-            },
-            {
                 id: 'id5', // abandon scan with retry - process:retry
                 run: {
                     state: 'running',
@@ -128,9 +122,8 @@ describe(RequestSelector, () => {
         const filteredRequests = {
             requestsToProcess: [
                 { request: queuedRequests[0], condition: 'pending' },
-                { request: queuedRequests[4], condition: 'pending' },
+                { request: queuedRequests[4], condition: 'retry' },
                 { request: queuedRequests[5], condition: 'retry' },
-                { request: queuedRequests[6], condition: 'retry' },
             ],
             requestsToDelete: [
                 { request: queuedRequests[1], condition: 'completed' },

--- a/packages/report-generator-runner/src/runner/request-selector.ts
+++ b/packages/report-generator-runner/src/runner/request-selector.ts
@@ -60,8 +60,6 @@ export class RequestSelector {
 
     private filterRequests(filteredRequests: QueuedRequests, queuedRequests: ReportGeneratorRequest[]): void {
         queuedRequests.map((queuedRequest) => {
-            // Supported run states: pending, running, completed, failed
-
             if (queuedRequest.run === undefined) {
                 filteredRequests.requestsToProcess.push({ request: queuedRequest, condition: 'pending' });
 
@@ -89,13 +87,6 @@ export class RequestSelector {
                 moment.utc(queuedRequest.run.timestamp).add(this.failedScanRetryIntervalInMinutes, 'minutes') <= moment.utc()
             ) {
                 filteredRequests.requestsToDelete.push({ request: queuedRequest, condition: 'failed' });
-
-                return;
-            }
-
-            // pending scan request
-            if (queuedRequest.run.state === 'pending') {
-                filteredRequests.requestsToProcess.push({ request: queuedRequest, condition: 'pending' });
 
                 return;
             }

--- a/packages/report-generator-runner/src/runner/runner.spec.ts
+++ b/packages/report-generator-runner/src/runner/runner.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, Mock, It } from 'typemoq';
 import { ReportGeneratorRequestProvider, OnDemandPageScanRunResultProvider, OperationResult } from 'service-library';
 import { GlobalLogger } from 'logger';
-import { ReportGeneratorRequest, OnDemandPageScanResult, OnDemandPageScanRunState } from 'storage-documents';
+import { ReportGeneratorRequest, OnDemandPageScanResult, ReportScanRunState } from 'storage-documents';
 import * as MockDate from 'mockdate';
 import { isEmpty, cloneDeep } from 'lodash';
 import { RunMetadataConfig } from '../run-metadata-config';
@@ -40,27 +40,21 @@ describe(Runner, () => {
                 id: 'id-1',
                 scanGroupId: 'scanGroupId-1',
                 reports: [{}],
-                run: {
-                    state: 'pending',
-                },
+                condition: 'pending',
             },
             {
                 id: 'id-2',
                 scanGroupId: 'scanGroupId-1',
                 reports: [{}],
-                run: {
-                    state: 'pending',
-                },
+                condition: 'pending',
             },
             {
                 id: 'id-3',
                 scanGroupId: 'scanGroupId-1',
                 reports: [{}],
-                run: {
-                    state: 'completed',
-                },
+                condition: 'completed',
             },
-        ] as ReportGeneratorRequest[];
+        ] as unknown as ReportGeneratorRequest[];
 
         runMetadataConfigMock = Mock.ofType<RunMetadataConfig>();
         reportGeneratorRequestProviderMock = Mock.ofType<ReportGeneratorRequestProvider>();
@@ -125,9 +119,7 @@ describe(Runner, () => {
                 id: 'id-1',
                 scanGroupId: 'scanGroupId-1',
                 reports: [{}],
-                run: {
-                    state: 'pending',
-                },
+                condition: 'pending',
             },
             {
                 id: 'id-3',
@@ -155,17 +147,13 @@ describe(Runner, () => {
                 id: 'id-1',
                 scanGroupId: 'scanGroupId-1',
                 reports: [{}],
-                run: {
-                    state: 'pending',
-                },
+                run: {},
             },
             {
                 id: 'id-3',
                 scanGroupId: 'scanGroupId-1',
                 reports: [{}],
-                run: {
-                    state: 'pending',
-                },
+                run: {},
             },
         ] as ReportGeneratorRequest[];
         const resultRequestsUpdateByReportProcessor = [
@@ -355,7 +343,7 @@ function setupReportProcessorMock(
         const projectedRequest = cloneDeep(request);
         const updatedRequest = updatedRequests.find((r) => r.request.id === projectedRequest.id);
         if (updatedRequest) {
-            projectedRequest.run.state = updatedRequest.condition as OnDemandPageScanRunState;
+            projectedRequest.run.state = updatedRequest.condition as ReportScanRunState;
         }
 
         return projectedRequest;

--- a/packages/service-library/src/batch/batch-task-creator.spec.ts
+++ b/packages/service-library/src/batch/batch-task-creator.spec.ts
@@ -84,13 +84,13 @@ class TestableBatchTaskCreator extends BatchTaskCreator {
         );
     }
 
-    public async deleteScanQueueMessagesForSucceededTasks(scanMessages: ScanMessage[]): Promise<void> {
+    public async deleteScanQueueMessagesForSucceededTasks(): Promise<void> {
         return this.invokeOverrides(
             EnableBaseWorkflow.deleteScanQueueMessagesForSucceededTasks,
             this.deleteScanQueueMessagesForSucceededTasksCallback,
-            async () => super.deleteScanQueueMessagesForSucceededTasks(scanMessages),
+            async () => super.deleteScanQueueMessagesForSucceededTasks(),
             undefined,
-            scanMessages,
+            this.activeScanMessages,
         );
     }
 
@@ -555,12 +555,12 @@ describe(BatchTaskCreator, () => {
             EnableBaseWorkflow.deleteScanQueueMessagesForSucceededTasks | EnableBaseWorkflow.deleteSucceededRequest;
         testSubject.activeScanMessages = queueMessagesGenerator.scanMessages;
 
-        await testSubject.deleteScanQueueMessagesForSucceededTasks(queueMessagesGenerator.scanMessages);
+        await testSubject.deleteScanQueueMessagesForSucceededTasks();
 
         expect(testSubject.activeScanMessages).toEqual(expectScanMessages);
 
         // the subsequent run should be no-op since active messages cache was cleaned up
-        await testSubject.deleteScanQueueMessagesForSucceededTasks(queueMessagesGenerator.scanMessages);
+        await testSubject.deleteScanQueueMessagesForSucceededTasks();
     });
 });
 

--- a/packages/service-library/src/batch/batch-task-creator.ts
+++ b/packages/service-library/src/batch/batch-task-creator.ts
@@ -189,12 +189,12 @@ export abstract class BatchTaskCreator {
     }
 
     protected async validateTasks(): Promise<void> {
-        await this.deleteScanQueueMessagesForSucceededTasks(this.activeScanMessages);
+        await this.deleteScanQueueMessagesForSucceededTasks();
         await this.handleFailedTasksImpl();
     }
 
-    protected async deleteScanQueueMessagesForSucceededTasks(scanMessages: ScanMessage[]): Promise<void> {
-        if (scanMessages.length === 0) {
+    protected async deleteScanQueueMessagesForSucceededTasks(): Promise<void> {
+        if (this.activeScanMessages.length === 0) {
             return;
         }
 

--- a/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
+++ b/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
@@ -61,8 +61,7 @@ export class ReportGeneratorRequestProvider {
     ): Promise<CosmosOperationResponse<ScanReportGroup[]>> {
         const query = {
             query: `SELECT TOP @itemCount COUNT(1) as scanCount, t.scanGroupId, t.targetReport FROM (
-                SELECT * FROM c WHERE c.itemType = @itemType AND
-                (NOT IS_DEFINED(c.run.state) OR c.run.state != "running" OR (c.run.state = "running" AND DateTimeToTimestamp(c.run.timestamp) < @availabilityTimestamp))
+                SELECT * FROM c WHERE c.itemType = @itemType AND (NOT IS_DEFINED(c.run.state) OR c.run.state != "running" OR (c.run.state = "running" AND DateTimeToTimestamp(c.run.timestamp) < @availabilityTimestamp))
                 ) t GROUP BY t.scanGroupId, t.targetReport`,
             parameters: [
                 {

--- a/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
+++ b/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
@@ -61,7 +61,8 @@ export class ReportGeneratorRequestProvider {
     ): Promise<CosmosOperationResponse<ScanReportGroup[]>> {
         const query = {
             query: `SELECT TOP @itemCount COUNT(1) as scanCount, t.scanGroupId, t.targetReport FROM (
-                SELECT * FROM c WHERE c.itemType = @itemType AND (NOT IS_DEFINED(c.run.state) OR c.run.state != "running" OR (c.run.state = "running" AND DateTimeToTimestamp(c.run.timestamp) < @availabilityTimestamp))
+                SELECT * FROM c WHERE c.itemType = @itemType AND
+                (NOT IS_DEFINED(c.run.state) OR c.run.state != "running" OR (c.run.state = "running" AND DateTimeToTimestamp(c.run.timestamp) < @availabilityTimestamp))
                 ) t GROUP BY t.scanGroupId, t.targetReport`,
             parameters: [
                 {

--- a/packages/storage-documents/src/report-generator-request.ts
+++ b/packages/storage-documents/src/report-generator-request.ts
@@ -6,6 +6,7 @@ import { StorageDocument } from './storage-document';
 import { ItemType } from './item-type';
 
 export declare type TargetReport = 'accessibility' | 'privacy';
+export declare type ReportScanRunState = 'running' | 'completed' | 'failed';
 
 export interface ReportGeneratorRequest extends StorageDocument {
     itemType: ItemType.reportGeneratorRequest;
@@ -17,5 +18,9 @@ export interface ReportGeneratorRequest extends StorageDocument {
     /**
      * Supported run states: pending, running, completed, failed
      */
-    run: OnDemandPageScanRunResult;
+    run: ReportScanRunResult;
+}
+
+export interface ReportScanRunResult extends Omit<OnDemandPageScanRunResult, 'state'> {
+    state: ReportScanRunState;
 }


### PR DESCRIPTION
#### Details

Reduce report generation concurrency. The large websites will have high contention when generating accessibility combined report on blob write operation. Converting report job manager to schedule single report batch per website.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
