### PR TITLE
Reset page state consent

### DIFF
--- a/packages/scanner-global-library/src/page-navigator.spec.ts
+++ b/packages/scanner-global-library/src/page-navigator.spec.ts
@@ -62,6 +62,48 @@ describe(PageNavigator, () => {
         expect(pageNavigator.pageConfigurator).toBe(pageConfiguratorMock.object);
     });
 
+    it('refresh page', async () => {
+        const response = {
+            status: () => 200,
+        } as unknown as HTTPResponse;
+
+        puppeteerPageMock
+            .setup(async (o) =>
+                o.reload({
+                    waitUntil: 'networkidle2',
+                    timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs,
+                }),
+            )
+            .returns(() => Promise.resolve(response))
+            .verifiable();
+
+        await pageNavigator.reload(puppeteerPageMock.object);
+    });
+
+    it('refresh page with error', async () => {
+        const error = new Error('navigation error');
+        const browserError = {
+            errorType: 'NavigationError',
+            message: 'navigation error',
+        } as BrowserError;
+
+        puppeteerPageMock
+            .setup(async (o) =>
+                o.reload({
+                    waitUntil: 'networkidle2',
+                    timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs,
+                }),
+            )
+            .returns(() => Promise.reject(error))
+            .verifiable();
+        pageResponseProcessorMock
+            .setup((o) => o.getNavigationError(error))
+            .returns(() => browserError)
+            .verifiable();
+
+        await pageNavigator.reload(puppeteerPageMock.object);
+    });
+
     it('reload with success', async () => {
         const response = {
             status: () => 200,

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -132,6 +132,20 @@ export class PageNavigator {
         };
     }
 
+    public async refresh(page: Puppeteer.Page): Promise<void> {
+        const navigationCondition = 'networkidle2';
+        try {
+            await page.reload({ waitUntil: navigationCondition, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs });
+        } catch (error) {
+            const browserError = this.pageResponseProcessor.getNavigationError(error as Error);
+            this.logger?.logError(`Page navigation error while refresh page.`, {
+                navigationCondition,
+                timeout: `${puppeteerTimeoutConfig.navigationTimeoutMsecs}`,
+                browserError: System.serializeError(browserError),
+            });
+        }
+    }
+
     private async tryWaitForNetworkIdle(page: Puppeteer.Page): Promise<Partial<PageNavigationTiming>> {
         let networkIdleTimeout = false;
         const timestamp = System.getTimestamp();


### PR DESCRIPTION
#### Details

Reset page state consent in a browser cache by re-submitting page to the web server without any cookies. The web server  overrides cookies consent state by persistent data within page html/script.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
