### PR TITLE
Terminate browser page script when it freezes

### DIFF
--- a/packages/scanner-global-library/src/page-client-lib.ts
+++ b/packages/scanner-global-library/src/page-client-lib.ts
@@ -6,12 +6,11 @@ import * as Puppeteer from 'puppeteer';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export async function scrollToBottom(page: Puppeteer.Page): Promise<boolean> {
-    await importGetScrollElementFunc(page);
+    await importFunctions(page);
 
     const scrollingComplete = await page.evaluate(async () => {
-        // @ts-ignore
         const scrollElement = getScrollElement();
-        scrollElement.element.scrollBy(0, document.documentElement.clientHeight);
+        await invokeWithTimeout(() => scrollElement.element.scrollBy(0, document.documentElement.clientHeight));
         const scrollingElement = scrollElement.type === 'window' ? scrollElement.element.document.scrollingElement : scrollElement.element;
 
         return (
@@ -24,56 +23,82 @@ export async function scrollToBottom(page: Puppeteer.Page): Promise<boolean> {
 }
 
 export async function scrollToTop(page: Puppeteer.Page): Promise<void> {
-    await importGetScrollElementFunc(page);
-    await page.evaluate(() => {
-        // @ts-ignore
+    await importFunctions(page);
+
+    await page.evaluate(async () => {
         const scrollElement = getScrollElement();
-        scrollElement.element.scrollTo(0, 0);
+        await invokeWithTimeout(() => scrollElement.element.scrollTo(0, 0));
         // Wait for browser to complete screen rendering
         document.body.getBoundingClientRect();
     });
 }
 
-async function importGetScrollElementFunc(page: Puppeteer.Page): Promise<void> {
-    function getScrollElement(): any {
-        function getDocumentScrollHeight(): any {
-            return Math.max(
-                document.body.scrollHeight,
-                document.body.clientHeight,
-                document.body.offsetHeight,
-                document.documentElement.scrollHeight,
-                document.documentElement.clientHeight,
-                document.documentElement.offsetHeight,
-            );
-        }
+async function invokeWithTimeout(op: any): Promise<any> {
+    const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
-        function hasVerticalScroll(e: any): any {
-            return e.offsetHeight < e.scrollHeight;
-        }
+    // call in separate thread to unblock if operation freezes
+    let completed = false;
+    setTimeout(() => {
+        op();
+        completed = true;
+    }, 0);
 
-        function getMaxScrollElement(elements: any): any {
-            let maxScrollHeight = 0;
-            let scrollElement;
-            elements.forEach((element: any) => {
-                if (element.scrollHeight > maxScrollHeight) {
-                    maxScrollHeight = element.scrollHeight;
-                    scrollElement = element;
-                }
-            });
-
-            return scrollElement;
-        }
-
-        const scrollElements = [].filter.call(document.querySelectorAll('*'), hasVerticalScroll);
-        const scrollElement = getMaxScrollElement(scrollElements);
-
-        return scrollElement?.scrollHeight > getDocumentScrollHeight()
-            ? { element: scrollElement, type: 'element' }
-            : { element: window, type: 'window' };
+    let totalDelay = 0;
+    const iterationDelay = 100;
+    while (!completed && totalDelay <= 1000) {
+        await delay(iterationDelay);
+        totalDelay = totalDelay + iterationDelay;
     }
 
+    if (!completed) {
+        throw new Error('Browser operation has timed out.');
+    }
+}
+
+function getScrollElement(): any {
+    function getDocumentScrollHeight(): any {
+        return Math.max(
+            document.body.scrollHeight,
+            document.body.clientHeight,
+            document.body.offsetHeight,
+            document.documentElement.scrollHeight,
+            document.documentElement.clientHeight,
+            document.documentElement.offsetHeight,
+        );
+    }
+
+    function hasVerticalScroll(e: any): any {
+        return e.offsetHeight < e.scrollHeight;
+    }
+
+    function getMaxScrollElement(elements: any): any {
+        let maxScrollHeight = 0;
+        let scrollElement;
+        elements.forEach((element: any) => {
+            if (element.scrollHeight > maxScrollHeight) {
+                maxScrollHeight = element.scrollHeight;
+                scrollElement = element;
+            }
+        });
+
+        return scrollElement;
+    }
+
+    const scrollElements = [].filter.call(document.querySelectorAll('*'), hasVerticalScroll);
+    const scrollElement = getMaxScrollElement(scrollElements);
+
+    return scrollElement?.scrollHeight > getDocumentScrollHeight()
+        ? { element: scrollElement, type: 'element' }
+        : { element: window, type: 'window' };
+}
+
+async function importFunctions(page: Puppeteer.Page): Promise<void> {
     const content = await page.content();
-    if (!content.includes('function getScrollElement(')) {
+    if (!content.includes('getScrollElement(')) {
         await page.addScriptTag({ content: `${getScrollElement}` });
+    }
+
+    if (!content.includes('invokeWithTimeout(')) {
+        await page.addScriptTag({ content: `${invokeWithTimeout}` });
     }
 }

--- a/packages/scanner-global-library/src/page-client-lib.ts
+++ b/packages/scanner-global-library/src/page-client-lib.ts
@@ -44,7 +44,7 @@ async function invokeWithTimeout(op: any): Promise<any> {
     }, 0);
 
     let totalDelay = 0;
-    const iterationDelay = 100;
+    const iterationDelay = 200;
     while (!completed && totalDelay <= 1000) {
         await delay(iterationDelay);
         totalDelay = totalDelay + iterationDelay;


### PR DESCRIPTION
#### Details

Terminate browser page script on timeout when it freezes. Browser freeze will block scan task if not terminated.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
