### PR TITLE
Reload page with local cache disabled on HTTP 304

### DIFF
--- a/packages/scanner-global-library/src/page-navigator.spec.ts
+++ b/packages/scanner-global-library/src/page-navigator.spec.ts
@@ -102,7 +102,7 @@ describe(PageNavigator, () => {
     });
 
     it('reload with success if received HTTP 304', async () => {
-        const maxRetryCount = 3;
+        const maxRetryCount = 2;
         const response = {
             status: () => 304,
         } as unknown as HTTPResponse;
@@ -178,6 +178,44 @@ describe(PageNavigator, () => {
 
         await pageNavigator.reload(puppeteerPageMock.object, onNavigationErrorMock);
         expect(onNavigationErrorMock).toHaveBeenCalledWith(browserError, error);
+    });
+
+    it('reload with navigation timeout', async () => {
+        const response = {
+            status: () => 200,
+        } as unknown as HTTPResponse;
+        const error = new Error('navigation timeout');
+        const browserError = {
+            errorType: 'UrlNavigationTimeout',
+            message: 'navigation timeout',
+        } as BrowserError;
+        puppeteerPageMock
+            .setup(async (o) =>
+                o.reload({
+                    waitUntil: 'networkidle2',
+                    timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs,
+                }),
+            )
+            .returns(() => Promise.reject(error))
+            .verifiable();
+        puppeteerPageMock
+            .setup(async (o) =>
+                o.reload({
+                    waitUntil: 'load',
+                    timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs,
+                }),
+            )
+            .returns(() => Promise.resolve(response))
+            .verifiable();
+        pageResponseProcessorMock
+            .setup((o) => o.getNavigationError(error))
+            .returns(() => browserError)
+            .verifiable();
+        const onNavigationErrorMock = jest.fn();
+        onNavigationErrorMock.mockImplementation((browserErr, err) => Promise.resolve());
+
+        await pageNavigator.reload(puppeteerPageMock.object, onNavigationErrorMock);
+        expect(onNavigationErrorMock).not.toHaveBeenCalledWith(browserError, error);
     });
 
     it('reload with network idle wait error', async () => {

--- a/packages/scanner-global-library/src/page-navigator.spec.ts
+++ b/packages/scanner-global-library/src/page-navigator.spec.ts
@@ -102,7 +102,7 @@ describe(PageNavigator, () => {
     });
 
     it('reload with success if received HTTP 304', async () => {
-        const maxRetryCount = 4;
+        const maxRetryCount = 3;
         const response = {
             status: () => 304,
         } as unknown as HTTPResponse;

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -206,7 +206,7 @@ export class PageNavigator {
         page: Puppeteer.Page,
         navigationCondition: Puppeteer.PuppeteerLifeCycleEvent,
     ): Promise<Puppeteer.HTTPResponse> {
-        const maxRetryCount = 3;
+        const maxRetryCount = 2;
 
         let count = 0;
         let opResult;

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -105,10 +105,6 @@ export class Page {
      * parameter `hardReload === true` will restart browser instance and delete browser storage, settings, etc. but use browser disk cache
      */
     public async reload(options?: { hardReload: boolean }): Promise<void> {
-        if (isEmpty(this.lastNavigationResponse)) {
-            throw new Error('Page should be loaded first before reload.');
-        }
-
         this.requestUrl = this.url;
 
         if (options?.hardReload === true) {

--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -50,7 +50,7 @@ export class WebDriver {
         this.addStealthPlugin();
 
         if (options.clearDiskCache === true) {
-            this.fs.rmSync(this.diskCacheDir, { recursive: true, force: true });
+            this.clearDiskCache();
         }
 
         const launchOptions = this.createLaunchOptions();
@@ -76,6 +76,10 @@ export class WebDriver {
 
             this.logger?.logInfo('Chromium browser instance stopped.');
         }
+    }
+
+    public clearDiskCache(): void {
+        this.fs.rmSync(this.diskCacheDir, { recursive: true, force: true });
     }
 
     private async closeBrowser(): Promise<void> {


### PR DESCRIPTION
#### Details

Fallback on browser with local cache removed when reload with cache fails with HTTP 304
Added page navigation fallback on timeout for reload page operation

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
