### PR TITLE
Allow HTTP 304 on page reload when timed out

### DIFF
--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -67,7 +67,8 @@ export class PageNavigator {
             });
 
             timestamp = System.getTimestamp();
-            navigationResult = await this.navigateToUrl(url, page, goto2NavigationCondition, options);
+            // allow page cached version on page reload to mitigate HTTP 304 response status code
+            navigationResult = await this.navigateToUrl(url, page, goto2NavigationCondition, { ...options, allowCachedVersion: true });
             goto2Elapsed = System.getElapsedTime(timestamp);
             if (navigationResult.browserError) {
                 this.logger?.logError('Page navigation error on a second attempt.', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3879,9 +3879,9 @@ __metadata:
   linkType: hard
 
 "@xmldom/xmldom@npm:^0.7.0":
-  version: 0.7.4
-  resolution: "@xmldom/xmldom@npm:0.7.4"
-  checksum: f807a921fe2c1b4244bb0c79ac6b61f06c8a71c5108017aa022060aa0ffb0c832aa7a704288a9c66888991bf701da8c9148c0775e66b0b3efe8d884153c5729d
+  version: 0.8.3
+  resolution: "@xmldom/xmldom@npm:0.8.3"
+  checksum: 087303060fc794f0ec8c0e9031362c1ae56eb1cf06b291cc178602462c072fb9f84657a430ae9c8c1b4c0d33549259e89ed14ebc86ca1a696f253bdd7f0dffcf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

Allow HTTP 304 on page reload when initial page load is timed out

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
