### PR TITLE
Update authentication to throw errors and catch account name errors

### DIFF
--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.spec.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.spec.ts
@@ -12,36 +12,35 @@ function setupAADAuthenticationFlow(
     accountName: string,
     accountPassword: string,
     success: boolean = true,
-    times: number = 1,
 ): void {
-    keyboardMock.setup((k) => k.press('Enter')).verifiable(Times.exactly(2 * times));
-    pageMock.setup((p) => p.goto('https://portal.azure.com')).verifiable(Times.exactly(times));
-    pageMock.setup((p) => p.waitForSelector(It.isAnyString())).verifiable(Times.exactly(2 * times));
-    pageMock.setup((p) => p.type(It.isAnyString(), accountName)).verifiable(Times.exactly(times));
-    pageMock.setup((p) => p.type(It.isAnyString(), accountPassword)).verifiable(Times.exactly(times));
-    pageMock.setup((p) => p.click('#FormsAuthentication')).verifiable(Times.exactly(times));
-    pageMock.setup((p) => p.waitForNavigation({ waitUntil: 'networkidle0' })).verifiable(Times.exactly(times));
+    keyboardMock.setup((k) => k.press('Enter')).verifiable(Times.exactly(2));
+    pageMock.setup((p) => p.goto('https://portal.azure.com')).verifiable(Times.exactly(1));
+    pageMock.setup((p) => p.waitForSelector(It.isAnyString())).verifiable(Times.exactly(2));
+    pageMock.setup((p) => p.type(It.isAnyString(), accountName)).verifiable(Times.exactly(1));
+    pageMock.setup((p) => p.type(It.isAnyString(), accountPassword)).verifiable(Times.exactly(1));
+    pageMock.setup((p) => p.click('#FormsAuthentication')).verifiable(Times.exactly(1));
+    pageMock.setup((p) => p.waitForNavigation({ waitUntil: 'networkidle0' })).verifiable(Times.exactly(1));
     pageMock.setup((p) => p.$eval('#errorText', It.isAny())).returns(() => Promise.resolve(success ? '' : 'this is an error'));
     pageMock
         .setup((p) => p.url())
         .returns(() => 'https://login.microsoftonline.com')
-        .verifiable(Times.exactly(2 * times));
+        .verifiable(Times.exactly(2));
 
     if (success) {
         pageMock
             .setup((p) => p.url())
             .returns(() => 'https://ms.portal.azure.com')
-            .verifiable(Times.exactly(2 * times));
+            .verifiable(Times.exactly(2));
     } else {
         // If authentication fails we must setup a sequence of calls to the page.url() method
         // equaling the number of times it will be called. This is because in a successful scenario
         // the page.url() method will be called twice with different values each time. With multiple
         // setups you must have a setup for each time it is called, as detailed here: https://github.com/florinn/typemoq#record-and-replay
-        for (let i = 0; i < times * 2; i++) {
+        for (let i = 0; i < 2; i++) {
             pageMock
                 .setup((p) => p.url())
                 .returns(() => 'https://login.microsoftonline.com')
-                .verifiable(Times.exactly(2 * times));
+                .verifiable(Times.exactly(2));
         }
     }
 }
@@ -51,11 +50,9 @@ describe(AzureActiveDirectoryAuthentication, () => {
     const accountPassword = 'Placeholder_test123';
     let pageMock: IMock<Puppeteer.Page>;
     let keyboardMock: IMock<Puppeteer.Keyboard>;
-    let consoleErrorMock: jest.SpyInstance;
     let consoleInfoMock: jest.SpyInstance;
     let testSubject: AzureActiveDirectoryAuthentication;
     beforeEach(() => {
-        consoleErrorMock = jest.spyOn(global.console, 'error').mockImplementation();
         consoleInfoMock = jest.spyOn(global.console, 'info').mockImplementation();
         keyboardMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Keyboard>());
         pageMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Page>());
@@ -66,7 +63,6 @@ describe(AzureActiveDirectoryAuthentication, () => {
     afterEach(() => {
         pageMock.verifyAll();
         keyboardMock.verifyAll();
-        consoleErrorMock.mockRestore();
         consoleInfoMock.mockRestore();
     });
 
@@ -76,10 +72,15 @@ describe(AzureActiveDirectoryAuthentication, () => {
         expect(consoleInfoMock).toHaveBeenCalledWith('Authentication succeeded.');
     });
 
-    it('retries four times if it detects authentication failed', async () => {
-        setupAADAuthenticationFlow(pageMock, keyboardMock, accountName, accountPassword, false, 5);
-        await testSubject.authenticate(pageMock.object);
-        expect(consoleErrorMock).toHaveBeenCalledWith('Attempted authentication 5 times and ultimately failed.');
+    it('throw error if authentication failed', async () => {
+        setupAADAuthenticationFlow(pageMock, keyboardMock, accountName, accountPassword, false);
+        expect.assertions(1);
+        const expectedErrorMessage = new Error('Authentication failed with error: this is an error');
+        try {
+            await testSubject.authenticate(pageMock.object);
+        } catch (error) {
+            expect(error).toEqual(expectedErrorMessage);
+        }
     });
 
     it('throws error if account name is invalid', async () => {

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -17,7 +17,12 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
 
         await page.waitForSelector('input[name="loginfmt"]');
         await page.type('input[name="loginfmt"]', this.accountName);
-        await Promise.all([page.waitForNavigation(), page.keyboard.press('Enter')]);
+        try {
+            await Promise.all([page.waitForNavigation(), page.keyboard.press('Enter')]);
+        } catch (error) {
+            const errorText: string = await page.$eval('#usernameError', (el) => el.textContent).catch(() => '');
+            throw new Error(isEmpty(errorText) ? error : `Authentication failed with error: ${errorText}`);
+        }
         await page.waitForSelector('#FormsAuthentication');
         await page.click('#FormsAuthentication');
         await page.type('input[type="password"]', this.accountPassword);

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -8,7 +8,7 @@ import { AuthenticationMethod } from './authentication-method';
 export class AzureActiveDirectoryAuthentication implements AuthenticationMethod {
     constructor(private readonly accountName: string, private readonly accountPassword: string) {}
 
-    public async authenticate(page: Puppeteer.Page, attemptNumber: number = 1): Promise<void> {
+    public async authenticate(page: Puppeteer.Page): Promise<void> {
         await page.goto('https://portal.azure.com');
 
         if (this.authenticationSucceeded(page)) {
@@ -28,19 +28,8 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
         await page.type('input[type="password"]', this.accountPassword);
         await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), await page.keyboard.press('Enter')]);
         if (!this.authenticationSucceeded(page)) {
-            if (attemptNumber > 4) {
-                console.error(`Attempted authentication ${attemptNumber} times and ultimately failed.`);
-
-                return;
-            }
-
             const errorText: string = await page.$eval('#errorText', (el) => el.textContent).catch(() => '');
-            if (!isEmpty(errorText)) {
-                console.error(`Authentication failed with error: ${errorText}`);
-            }
-            await this.authenticate(page, attemptNumber + 1);
-
-            return;
+            throw new Error(`Authentication failed${isEmpty(errorText) ? '' : ` with error: ${errorText}`}`);
         }
     }
 


### PR DESCRIPTION
#### Details

This pull request will make improvements to authentication errors:

- throw errors in the Azure active directory flow to stop the scanner from continuing. Previously, if unable to authenticate, the scanner would log the error and continue to scan the login page; resulting in a false positive.
- add a try/catch statement when entering the account name and throw a specific error from the login page. Previously, if a pipeline entered an invalid account name, it would return a timeout error.
- remove attempts. Now that auth will throw errors, the `handleRequestFunction` will retry up to 3 times and removes the need for auth to kick off additional attempts.

##### Motivation

Improve user experience when authenticating.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
