### PR TITLE
Added page indirect redirection handler

### DIFF
--- a/packages/azure-services/src/azure-batch/batch-task-config-generator.spec.ts
+++ b/packages/azure-services/src/azure-batch/batch-task-config-generator.spec.ts
@@ -68,7 +68,7 @@ describe(BatchTaskConfigGenerator, () => {
         const environmentSettings = getEnvironmentSettings(taskArgsString);
         const actualContainerRunOptions = testSubject.getContainerRunOptions(taskArgsString, environmentSettings);
         expect(actualContainerRunOptions).toEqual(
-            '--init --rm --workdir /app -e APPINSIGHTS_INSTRUMENTATIONKEY -e KEY_VAULT_URL -e TASK_ARGUMENTS -e arg1=arg1Value -e arg2=arg2Value -e arg3=arg3Value --addon option',
+            '--init --rm --shm-size=2gb --workdir /app -e APPINSIGHTS_INSTRUMENTATIONKEY -e KEY_VAULT_URL -e TASK_ARGUMENTS -e arg1=arg1Value -e arg2=arg2Value -e arg3=arg3Value --addon option',
         );
     });
 
@@ -79,7 +79,7 @@ describe(BatchTaskConfigGenerator, () => {
         const environmentSettings = getEnvironmentSettings(taskArgsString);
         const actualContainerRunOptions = testSubject.getContainerRunOptions(taskArgsString, environmentSettings);
         expect(actualContainerRunOptions).toEqual(
-            '--init --rm --workdir /app -e APPINSIGHTS_INSTRUMENTATIONKEY -e KEY_VAULT_URL -e TASK_ARGUMENTS -e url=https://localhost/support%20page/ --addon option',
+            '--init --rm --shm-size=2gb --workdir /app -e APPINSIGHTS_INSTRUMENTATIONKEY -e KEY_VAULT_URL -e TASK_ARGUMENTS -e url=https://localhost/support%20page/ --addon option',
         );
     });
 
@@ -110,7 +110,7 @@ describe(BatchTaskConfigGenerator, () => {
             containerSettings: {
                 imageName: 'allyContainerRegistry.azurecr.io/imageNameValue',
                 containerRunOptions:
-                    '--init --rm --workdir /app -e APPINSIGHTS_INSTRUMENTATIONKEY -e KEY_VAULT_URL -e TASK_ARGUMENTS -e arg1=arg1Value -e arg2=arg2Value -e arg3=arg3Value --addon option',
+                    '--init --rm --shm-size=2gb --workdir /app -e APPINSIGHTS_INSTRUMENTATIONKEY -e KEY_VAULT_URL -e TASK_ARGUMENTS -e arg1=arg1Value -e arg2=arg2Value -e arg3=arg3Value --addon option',
             },
             constraints: {
                 maxWallClockTime: `PT${taskRuntimeConfig.taskTimeoutInMinutes}M`,

--- a/packages/azure-services/src/azure-batch/batch-task-config-generator.ts
+++ b/packages/azure-services/src/azure-batch/batch-task-config-generator.ts
@@ -43,7 +43,8 @@ export class BatchTaskConfigGenerator {
     // The --rm container option removes the container after the task finishes
     // The --workdir container option defines task working directory
     // The --init arg to reap zombie processes
-    private readonly containerRunOptions = '--init --rm --workdir /app';
+    // The --shm-size increases shared memory allocated to a container
+    private readonly containerRunOptions = '--init --rm --shm-size=2gb --workdir /app';
 
     public constructor(
         @inject(BatchTaskPropertyProvider) protected readonly batchTaskPropertyProvider: BatchTaskPropertyProvider,

--- a/packages/scanner-global-library/src/page-navigator.spec.ts
+++ b/packages/scanner-global-library/src/page-navigator.spec.ts
@@ -505,13 +505,39 @@ describe(PageNavigator, () => {
             puppeteerPageMock
                 .setup((o) => o.on(It.isAny(), It.isAny()))
                 .callback(async (eventName, eventHandler) => {
-                    if (['request', 'requestfinished'].includes(eventName)) {
-                        await Promise.all(onEventRequests.map(async (request) => eventHandler(request)));
+                    if (['request', 'response'].includes(eventName)) {
+                        await Promise.all(
+                            onEventRequests.map(async (request) => {
+                                if (eventName === 'response') {
+                                    return eventHandler(request.response());
+                                } else {
+                                    return eventHandler(request);
+                                }
+                            }),
+                        );
                     }
                 })
                 .returns(() => {
                     return {} as Puppeteer.EventEmitter;
                 });
+            puppeteerPageMock
+                .setup((o) => o.removeListener('request', It.isAny()))
+                .returns(() => {
+                    return {} as Puppeteer.EventEmitter;
+                })
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.removeListener('response', It.isAny()))
+                .returns(() => {
+                    return {} as Puppeteer.EventEmitter;
+                })
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.removeListener('requestfailed', It.isAny()))
+                .returns(() => {
+                    return {} as Puppeteer.EventEmitter;
+                })
+                .verifiable();
 
             const opResponse = await pageNavigator.handleIndirectPageRedirection(
                 navigationOperation,

--- a/packages/scanner-global-library/src/page-navigator.spec.ts
+++ b/packages/scanner-global-library/src/page-navigator.spec.ts
@@ -8,12 +8,11 @@ import * as Puppeteer from 'puppeteer';
 import { GlobalLogger } from 'logger';
 import { cloneDeep } from 'lodash';
 import { PageResponseProcessor } from './page-response-processor';
-import { PageNavigator, PageOperationResult, NavigationOperation } from './page-navigator';
-// import { BrowserError } from './browser-error';
+import { PageNavigator, PageOperationResult, NavigationOperation, NavigationResponse } from './page-navigator';
 import { PageNavigationHooks } from './page-navigation-hooks';
-// import { PageConfigurator } from './page-configurator';
-import { puppeteerTimeoutConfig } from './page-timeout-config';
+import { puppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
 import { MockableLogger } from './test-utilities/mockable-logger';
+import { BrowserError } from './browser-error';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
 
@@ -38,13 +37,25 @@ class PageNavigatorStub extends PageNavigator {
     ): Promise<PageOperationResult> {
         return super.handleIndirectPageRedirection(navigationOperation, pageOperationResult, page);
     }
+
+    public async invokePageNavigationOperation(navigationOperation: NavigationOperation): Promise<PageOperationResult> {
+        return super.invokePageNavigationOperation(navigationOperation);
+    }
+
+    public async waitForNetworkIdle(page: Puppeteer.Page): Promise<Partial<PageNavigationTiming>> {
+        return super.waitForNetworkIdle(page);
+    }
+
+    public async navigatePage(navigationOperation: NavigationOperation, page: Puppeteer.Page): Promise<PageOperationResult> {
+        return super.navigatePage(navigationOperation, page);
+    }
 }
 
 const url = 'url';
 
 let pageNavigator: PageNavigatorStub;
 let pageResponseProcessorMock: IMock<PageResponseProcessor>;
-let navigationHooksMock: IMock<PageNavigationHooks>;
+let pageNavigationHooksMock: IMock<PageNavigationHooks>;
 let puppeteerPageMock: IMock<Puppeteer.Page>;
 let loggerMock: IMock<MockableLogger>;
 let timingCount: number;
@@ -57,7 +68,7 @@ let response: Puppeteer.HTTPResponse;
 describe(PageNavigator, () => {
     beforeEach(() => {
         pageResponseProcessorMock = Mock.ofType<PageResponseProcessor>();
-        navigationHooksMock = Mock.ofType<PageNavigationHooks>();
+        pageNavigationHooksMock = Mock.ofType<PageNavigationHooks>();
         puppeteerPageMock = Mock.ofType<Puppeteer.Page>();
         loggerMock = Mock.ofType(MockableLogger);
         pageOperationResult = {} as PageOperationResult;
@@ -81,14 +92,335 @@ describe(PageNavigator, () => {
             .returns(() => {
                 return puppeteerFrame;
             });
-        pageNavigator = new PageNavigatorStub(pageResponseProcessorMock.object, navigationHooksMock.object, loggerMock.object);
+        pageNavigator = new PageNavigatorStub(pageResponseProcessorMock.object, pageNavigationHooksMock.object, loggerMock.object);
     });
 
     afterEach(() => {
         pageResponseProcessorMock.verifyAll();
-        navigationHooksMock.verifyAll();
+        pageNavigationHooksMock.verifyAll();
         puppeteerPageMock.verifyAll();
         loggerMock.verifyAll();
+    });
+
+    describe('reload', () => {
+        it('simple reload', async () => {
+            pageOperationResult.response = {
+                status: () => 200,
+            } as Puppeteer.HTTPResponse;
+            const waitForNetworkIdleTiming = {
+                networkIdle: 10000,
+                networkIdleTimeout: true,
+            } as PageNavigationTiming;
+            const postNavigationTiming = {
+                render: 5000,
+                scroll: 2000,
+            } as PageNavigationTiming;
+            pageNavigationHooksMock
+                .setup((o) => o.postNavigation(puppeteerPageMock.object, pageOperationResult.response, It.isAny()))
+                .returns(() => Promise.resolve(postNavigationTiming))
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.reload({ waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }))
+                .returns(() => Promise.resolve(response))
+                .verifiable();
+            const navigatePageFn = jest.fn().mockImplementation(async (op) => {
+                await op();
+
+                return Promise.resolve(pageOperationResult);
+            });
+            pageNavigator.navigatePage = navigatePageFn;
+            const waitForNetworkIdleFn = jest.fn().mockImplementation(() => Promise.resolve(waitForNetworkIdleTiming));
+            pageNavigator.waitForNetworkIdle = waitForNetworkIdleFn;
+
+            const actualNavigationResponse = await pageNavigator.reload(puppeteerPageMock.object, undefined);
+
+            const expectedNavigationResponse = {
+                httpResponse: pageOperationResult.response,
+                pageNavigationTiming: {
+                    networkIdle: 10000,
+                    networkIdleTimeout: true,
+                    render: 5000,
+                    scroll: 2000,
+                },
+            } as NavigationResponse;
+            expect(navigatePageFn).toBeCalledWith(expect.any(Function), puppeteerPageMock.object);
+            expect(waitForNetworkIdleFn).toBeCalledWith(puppeteerPageMock.object);
+            expect(actualNavigationResponse).toEqual(expectedNavigationResponse);
+        });
+
+        it('reload with error', async () => {
+            pageOperationResult = {
+                response: undefined,
+                error: new Error(),
+                browserError: {} as BrowserError,
+            };
+            const navigatePageFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.navigatePage = navigatePageFn;
+            const onNavigationErrorFn = jest.fn().mockImplementation(async () => Promise.resolve());
+
+            const actualNavigationResponse = await pageNavigator.reload(puppeteerPageMock.object, onNavigationErrorFn);
+
+            expect(navigatePageFn).toBeCalledWith(expect.any(Function), puppeteerPageMock.object);
+            expect(onNavigationErrorFn).toHaveBeenCalledWith(pageOperationResult.browserError, pageOperationResult.error);
+            expect(actualNavigationResponse).toEqual(undefined);
+        });
+    });
+
+    describe('navigate', () => {
+        it('simple navigation', async () => {
+            pageOperationResult.response = {
+                status: () => 200,
+            } as Puppeteer.HTTPResponse;
+            const waitForNetworkIdleTiming = {
+                networkIdle: 10000,
+                networkIdleTimeout: true,
+            } as PageNavigationTiming;
+            const postNavigationTiming = {
+                render: 5000,
+                scroll: 2000,
+            } as PageNavigationTiming;
+            pageNavigationHooksMock
+                .setup((o) => o.preNavigation(puppeteerPageMock.object))
+                .returns(() => Promise.resolve())
+                .verifiable();
+            pageNavigationHooksMock
+                .setup((o) => o.postNavigation(puppeteerPageMock.object, pageOperationResult.response, It.isAny()))
+                .returns(() => Promise.resolve(postNavigationTiming))
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }))
+                .returns(() => Promise.resolve(response))
+                .verifiable();
+            const navigatePageFn = jest.fn().mockImplementation(async (op) => {
+                await op();
+
+                return Promise.resolve(pageOperationResult);
+            });
+            pageNavigator.navigatePage = navigatePageFn;
+            const waitForNetworkIdleFn = jest.fn().mockImplementation(() => Promise.resolve(waitForNetworkIdleTiming));
+            pageNavigator.waitForNetworkIdle = waitForNetworkIdleFn;
+
+            const actualNavigationResponse = await pageNavigator.navigate(url, puppeteerPageMock.object, undefined);
+
+            const expectedNavigationResponse = {
+                httpResponse: pageOperationResult.response,
+                pageNavigationTiming: {
+                    networkIdle: 10000,
+                    networkIdleTimeout: true,
+                    render: 5000,
+                    scroll: 2000,
+                },
+            } as NavigationResponse;
+            expect(navigatePageFn).toBeCalledWith(expect.any(Function), puppeteerPageMock.object);
+            expect(waitForNetworkIdleFn).toBeCalledWith(puppeteerPageMock.object);
+            expect(actualNavigationResponse).toEqual(expectedNavigationResponse);
+        });
+
+        it('navigation with error', async () => {
+            pageOperationResult = {
+                response: undefined,
+                error: new Error(),
+                browserError: {} as BrowserError,
+            };
+            pageNavigationHooksMock
+                .setup((o) => o.preNavigation(puppeteerPageMock.object))
+                .returns(() => Promise.resolve())
+                .verifiable();
+            const navigatePageFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.navigatePage = navigatePageFn;
+            const onNavigationErrorFn = jest.fn().mockImplementation(async () => Promise.resolve());
+
+            const actualNavigationResponse = await pageNavigator.navigate(url, puppeteerPageMock.object, onNavigationErrorFn);
+
+            expect(navigatePageFn).toBeCalledWith(expect.any(Function), puppeteerPageMock.object);
+            expect(onNavigationErrorFn).toHaveBeenCalledWith(pageOperationResult.browserError, pageOperationResult.error);
+            expect(actualNavigationResponse).toEqual(undefined);
+        });
+    });
+
+    describe('navigatePage', () => {
+        it('simple navigation', async () => {
+            navigationOperation = async (waitUntil = 'networkidle2') => {
+                return puppeteerPageMock.object.goto(url, { waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs });
+            };
+
+            const invokePageNavigationOperationFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.invokePageNavigationOperation = invokePageNavigationOperationFn;
+            const handleIndirectPageRedirectionFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.handleIndirectPageRedirection = handleIndirectPageRedirectionFn;
+            const handleCachedResponseFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.handleCachedResponse = handleCachedResponseFn;
+
+            const opResponse = await pageNavigator.navigatePage(navigationOperation, puppeteerPageMock.object);
+
+            expect(invokePageNavigationOperationFn).toBeCalledWith(navigationOperation);
+            expect(handleIndirectPageRedirectionFn).toBeCalledWith(navigationOperation, pageOperationResult, puppeteerPageMock.object);
+            expect(handleCachedResponseFn).toBeCalledWith(pageOperationResult, puppeteerPageMock.object);
+            expect(opResponse).toEqual(pageOperationResult);
+        });
+
+        it('navigation with redirection failure', async () => {
+            navigationOperation = async (waitUntil = 'networkidle2') => {
+                return puppeteerPageMock.object.goto(url, { waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs });
+            };
+            const pageOperationResultError = {
+                ...cloneDeep(pageOperationResult),
+                error: new Error('handleIndirectPageRedirection'),
+            };
+
+            const invokePageNavigationOperationFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.invokePageNavigationOperation = invokePageNavigationOperationFn;
+            const handleIndirectPageRedirectionFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResultError));
+            pageNavigator.handleIndirectPageRedirection = handleIndirectPageRedirectionFn;
+            const handleCachedResponseFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.handleCachedResponse = handleCachedResponseFn;
+
+            const opResponse = await pageNavigator.navigatePage(navigationOperation, puppeteerPageMock.object);
+
+            expect(invokePageNavigationOperationFn).toBeCalledWith(navigationOperation);
+            expect(handleIndirectPageRedirectionFn).toBeCalledWith(navigationOperation, pageOperationResult, puppeteerPageMock.object);
+            expect(handleCachedResponseFn).not.toBeCalled();
+            expect(opResponse).toEqual(pageOperationResultError);
+        });
+
+        it('navigation with cache reload failure', async () => {
+            navigationOperation = async (waitUntil = 'networkidle2') => {
+                return puppeteerPageMock.object.goto(url, { waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs });
+            };
+            const pageOperationResultError = {
+                ...cloneDeep(pageOperationResult),
+                error: new Error('handleCachedResponse'),
+            };
+
+            const invokePageNavigationOperationFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.invokePageNavigationOperation = invokePageNavigationOperationFn;
+            const handleIndirectPageRedirectionFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResult));
+            pageNavigator.handleIndirectPageRedirection = handleIndirectPageRedirectionFn;
+            const handleCachedResponseFn = jest.fn().mockImplementation(() => Promise.resolve(pageOperationResultError));
+            pageNavigator.handleCachedResponse = handleCachedResponseFn;
+
+            const opResponse = await pageNavigator.navigatePage(navigationOperation, puppeteerPageMock.object);
+
+            expect(invokePageNavigationOperationFn).toBeCalledWith(navigationOperation);
+            expect(handleIndirectPageRedirectionFn).toBeCalledWith(navigationOperation, pageOperationResult, puppeteerPageMock.object);
+            expect(handleCachedResponseFn).toBeCalledWith(pageOperationResult, puppeteerPageMock.object);
+            expect(opResponse).toEqual(pageOperationResultError);
+        });
+    });
+
+    describe('waitForNetworkIdle', () => {
+        it('wait without timeout', async () => {
+            puppeteerPageMock
+                .setup((o) => o.waitForNavigation({ waitUntil: 'networkidle0', timeout: puppeteerTimeoutConfig.networkIdleTimeoutMsec }))
+                .returns(() => Promise.resolve(response))
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.evaluate(It.isAny()))
+                .returns(() => Promise.resolve())
+                .verifiable();
+
+            const actualNavigationTiming = await pageNavigator.waitForNetworkIdle(puppeteerPageMock.object);
+            const expectedNavigationTiming = {
+                networkIdle: 10000,
+                networkIdleTimeout: false,
+            } as PageNavigationTiming;
+            expect(expectedNavigationTiming).toEqual(actualNavigationTiming);
+        });
+
+        it('wait with timeout', async () => {
+            const timeoutError = new Error('Navigation timeout');
+            puppeteerPageMock
+                .setup((o) => o.waitForNavigation({ waitUntil: 'networkidle0', timeout: puppeteerTimeoutConfig.networkIdleTimeoutMsec }))
+                .returns(() => Promise.reject(timeoutError))
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.evaluate(It.isAny()))
+                .returns(() => Promise.resolve())
+                .verifiable();
+
+            const actualNavigationTiming = await pageNavigator.waitForNetworkIdle(puppeteerPageMock.object);
+            const expectedNavigationTiming = {
+                networkIdle: 10000,
+                networkIdleTimeout: true,
+            } as PageNavigationTiming;
+            expect(expectedNavigationTiming).toEqual(actualNavigationTiming);
+        });
+    });
+
+    describe('invokePageNavigationOperation', () => {
+        it('invoke without fallback to `load` wait condition', async () => {
+            navigationOperation = async (waitUntil = 'networkidle2') => {
+                return puppeteerPageMock.object.goto(url, { waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs });
+            };
+            puppeteerPageMock
+                .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }))
+                .returns(() => Promise.resolve(response))
+                .verifiable();
+
+            const opResponse = await pageNavigator.invokePageNavigationOperation(navigationOperation);
+            expect(opResponse.response).toEqual(response);
+        });
+
+        it('invoke with fallback to `load` wait condition', async () => {
+            const timeoutError = new Error('Navigation timeout');
+            navigationOperation = async (waitUntil = 'networkidle2') => {
+                return puppeteerPageMock.object.goto(url, { waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs });
+            };
+            puppeteerPageMock
+                .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }))
+                .returns(() => Promise.reject(timeoutError))
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.goto(url, { waitUntil: 'load', timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }))
+                .returns(() => Promise.resolve(response))
+                .verifiable();
+            pageResponseProcessorMock
+                .setup((o) => o.getNavigationError(timeoutError))
+                .returns(() => {
+                    return { errorType: 'UrlNavigationTimeout' } as BrowserError;
+                })
+                .verifiable();
+
+            const opResponse = await pageNavigator.invokePageNavigationOperation(navigationOperation);
+            expect(opResponse.response).toEqual(response);
+        });
+    });
+
+    describe('handleCachedResponse', () => {
+        it('skip handler if status code is not HTTP 304', async () => {
+            pageOperationResult.response = {
+                status: () => 200,
+            } as Puppeteer.HTTPResponse;
+
+            const opResponse = await pageNavigator.handleCachedResponse(pageOperationResult, puppeteerPageMock.object);
+            expect(opResponse).toEqual(pageOperationResult);
+        });
+
+        it('handle page HTTP 304', async () => {
+            pageOperationResult.response = {
+                status: () => 304,
+            } as Puppeteer.HTTPResponse;
+            const okResponse = {
+                status: () => 200,
+            } as Puppeteer.HTTPResponse;
+            puppeteerPageMock
+                .setup((o) => o.goto(`file:///${__dirname}/blank-page.html`))
+                .returns(() => Promise.resolve(response))
+                .verifiable();
+            puppeteerPageMock
+                .setup((o) => o.goBack({ waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }))
+                .returns(() => Promise.resolve(okResponse))
+                .verifiable();
+
+            const opResponse = await pageNavigator.handleCachedResponse(pageOperationResult, puppeteerPageMock.object);
+            const navigationTiming = {
+                goto1: 10000,
+                goto1Timeout: false,
+                goto2: 0,
+            } as PageNavigationTiming;
+            expect(opResponse.navigationTiming).toEqual(navigationTiming);
+            expect(opResponse.response).toEqual(okResponse);
+        });
     });
 
     describe('handleIndirectPageRedirection', () => {
@@ -107,6 +439,7 @@ describe(PageNavigator, () => {
                 return undefined;
             };
             pageOperationResult.response = {} as Puppeteer.HTTPResponse;
+
             const opResponse = await pageNavigator.handleIndirectPageRedirection(
                 navigationOperation,
                 pageOperationResult,
@@ -134,6 +467,7 @@ describe(PageNavigator, () => {
             const onEventRequests = [
                 {
                     ...cloneDeep(onEventRequest),
+
                     url: () => 'Url-1-OK',
                     response: () => {
                         return { url: () => 'Url-1-OK' } as Puppeteer.HTTPResponse;
@@ -141,16 +475,16 @@ describe(PageNavigator, () => {
                 } as Puppeteer.HTTPRequest,
                 {
                     ...cloneDeep(onEventRequest),
+                    _requestId: '2',
                     url: () => 'Url-2-OK',
                     response: () => {
                         return { url: () => 'Url-2-OK' } as Puppeteer.HTTPResponse;
                     },
                 } as Puppeteer.HTTPRequest,
             ];
-            navigationOperation = (waitUntil = 'networkidle2') => {
+            navigationOperation = async (waitUntil = 'networkidle2') => {
                 return puppeteerPageMock.object.goto(url, { waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs });
             };
-            const pageEventHandlers: { eventName: string; eventHandler(request: Puppeteer.HTTPRequest): Promise<void> }[] = [];
             puppeteerPageMock
                 .setup((o) =>
                     o.goto(url, {
@@ -170,7 +504,11 @@ describe(PageNavigator, () => {
                 .verifiable();
             puppeteerPageMock
                 .setup((o) => o.on(It.isAny(), It.isAny()))
-                .callback((eventName, eventHandler) => pageEventHandlers.push({ eventName, eventHandler }))
+                .callback(async (eventName, eventHandler) => {
+                    if (['request', 'requestfinished'].includes(eventName)) {
+                        await Promise.all(onEventRequests.map(async (request) => eventHandler(request)));
+                    }
+                })
                 .returns(() => {
                     return {} as Puppeteer.EventEmitter;
                 });
@@ -181,12 +519,7 @@ describe(PageNavigator, () => {
                 puppeteerPageMock.object,
             );
 
-            for (const request of onEventRequests) {
-                await pageEventHandlers.find((h) => h.eventName === 'request').eventHandler(request);
-                await pageEventHandlers.find((h) => h.eventName === 'requestfinished').eventHandler(request);
-            }
-
-            expect(opResponse).toEqual(onEventRequests[1].response());
+            expect(opResponse.response.url()).toEqual(onEventRequests[1].response().url());
         });
     });
 });

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -5,6 +5,7 @@ import * as Puppeteer from 'puppeteer';
 import { injectable, inject, optional } from 'inversify';
 import { System } from 'common';
 import { GlobalLogger } from 'logger';
+import { isNil } from 'lodash';
 import { PageResponseProcessor } from './page-response-processor';
 import { BrowserError } from './browser-error';
 import { PageNavigationHooks } from './page-navigation-hooks';
@@ -222,7 +223,7 @@ export class PageNavigator {
     ): Promise<PageOperationResult> {
         const requests: { url: string; opResult?: PageOperationResult }[] = [];
 
-        if (pageOperationResult.response !== undefined || pageOperationResult.error !== undefined) {
+        if (!isNil(pageOperationResult.response) || !isNil(pageOperationResult.error)) {
             return pageOperationResult;
         }
 

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -114,7 +114,7 @@ export class PageNavigator {
         };
     }
 
-    private async navigatePage(navigationOperation: NavigationOperation, page: Puppeteer.Page): Promise<PageOperationResult> {
+    protected async navigatePage(navigationOperation: NavigationOperation, page: Puppeteer.Page): Promise<PageOperationResult> {
         const getErrorResult = (result: PageOperationResult): PageOperationResult => {
             this.logger?.logError(`Page navigation error.`, {
                 error: System.serializeError(result.error),
@@ -142,7 +142,7 @@ export class PageNavigator {
         return opResult;
     }
 
-    private async invokePageNavigationOperation(navigationOperation: NavigationOperation): Promise<PageOperationResult> {
+    protected async invokePageNavigationOperation(navigationOperation: NavigationOperation): Promise<PageOperationResult> {
         let opTimeout = false;
 
         let timestamp = System.getTimestamp();
@@ -279,7 +279,7 @@ export class PageNavigator {
      * This mitigates cases when page needs load pending frame/content.
      * Will not throw if page still has network activity.
      */
-    private async waitForNetworkIdle(page: Puppeteer.Page): Promise<Partial<PageNavigationTiming>> {
+    protected async waitForNetworkIdle(page: Puppeteer.Page): Promise<Partial<PageNavigationTiming>> {
         let networkIdleTimeout = false;
         const timestamp = System.getTimestamp();
         try {

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -3,7 +3,6 @@
 
 import * as Puppeteer from 'puppeteer';
 import { injectable, inject, optional } from 'inversify';
-import { isNil } from 'lodash';
 import { System } from 'common';
 import { GlobalLogger } from 'logger';
 import { PageResponseProcessor } from './page-response-processor';
@@ -11,7 +10,6 @@ import { BrowserError } from './browser-error';
 import { PageNavigationHooks } from './page-navigation-hooks';
 import { PageConfigurator } from './page-configurator';
 import { puppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
-import { PageConfigurationOptions } from './page';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -22,8 +20,19 @@ export interface NavigationResponse {
     pageNavigationTiming: PageNavigationTiming;
 }
 
+export interface PageOperationResult {
+    response: Puppeteer.HTTPResponse;
+    browserError?: BrowserError;
+    error?: unknown;
+    navigationTiming?: PageNavigationTiming;
+}
+
+export declare type NavigationOperation = (navigationCondition?: Puppeteer.PuppeteerLifeCycleEvent) => Promise<Puppeteer.HTTPResponse>;
+
 @injectable()
 export class PageNavigator {
+    private readonly navigationCondition = 'networkidle2'; // use of networkidle0 will break websites scanning
+
     constructor(
         @inject(PageResponseProcessor) public readonly pageResponseProcessor: PageResponseProcessor,
         @inject(PageNavigationHooks) public readonly pageNavigationHooks: PageNavigationHooks,
@@ -37,67 +46,34 @@ export class PageNavigator {
     public async navigate(
         url: string,
         page: Puppeteer.Page,
-        options?: PageConfigurationOptions,
         onNavigationError: (browserError: BrowserError, error?: unknown) => Promise<void> = () => Promise.resolve(),
     ): Promise<NavigationResponse> {
-        const goto1NavigationCondition = 'networkidle2'; // switching to networkidle0 will break some websites scanning
-        const goto2NavigationCondition = 'load';
-
         await this.pageNavigationHooks.preNavigation(page);
 
-        let goto1Timeout = false;
-        let timestamp = System.getTimestamp();
-        let navigationResult = await this.navigateToUrl(url, page, goto1NavigationCondition, options);
-        const goto1Elapsed = System.getElapsedTime(timestamp);
+        const opResult = await this.navigatePage(
+            (waitUntil = this.navigationCondition) => page.goto(url, { waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }),
+            page,
+        );
 
-        let goto2Elapsed = 0;
-        if (navigationResult.browserError?.errorType === 'UrlNavigationTimeout') {
-            // Fallback to load partial page resources on navigation timeout.
-            // This will help in cases when page has streaming video controls.
-            //
-            // The 'load' event is fired when the whole page has loaded, including all dependent resources such as stylesheets and images.
-            // However any dynamic contents may not be available if it is loaded after window.onload() event.
-            // Since we reuse page instance from the first navigation attempt some contents could be already loaded and available
-            // that will mitigate dynamic content rendering issue above.
-            goto1Timeout = true;
-            this.logger?.logWarn('Page navigation error on a first attempt.', {
-                navigationCondition: goto1NavigationCondition,
+        if (opResult.browserError) {
+            this.logger?.logError('Page navigation error.', {
                 timeout: `${puppeteerTimeoutConfig.navigationTimeoutMsecs}`,
-                browserError: System.serializeError(navigationResult.browserError),
+                browserError: System.serializeError(opResult.browserError),
             });
 
-            timestamp = System.getTimestamp();
-            // allow page cached version on page reload to mitigate HTTP 304 response status code
-            navigationResult = await this.navigateToUrl(url, page, goto2NavigationCondition, { ...options, allowCachedVersion: true });
-            goto2Elapsed = System.getElapsedTime(timestamp);
-            if (navigationResult.browserError) {
-                this.logger?.logError('Page navigation error on a second attempt.', {
-                    navigationCondition: goto2NavigationCondition,
-                    timeout: `${puppeteerTimeoutConfig.navigationTimeoutMsecs}`,
-                    browserError: System.serializeError(navigationResult.browserError),
-                });
-            }
-        }
-
-        if (!isNil(navigationResult.browserError)) {
-            await onNavigationError(navigationResult.browserError, navigationResult.error);
+            await onNavigationError(opResult.browserError, opResult.error);
 
             return undefined;
         }
 
-        // Try to wait for the page network idle state to support pages that have network activity
-        // past networkidle2 wait condition. This will let page load pending frame/content.
-        // Pages with constant network activity still succeed this operation.
-        const networkIdlePageTiming = await this.tryWaitForNetworkIdle(page);
+        const networkIdlePageTiming = await this.waitForNetworkIdle(page);
 
-        const postNavigationPageTiming = await this.pageNavigationHooks.postNavigation(page, navigationResult.response, onNavigationError);
+        const postNavigationPageTiming = await this.pageNavigationHooks.postNavigation(page, opResult.response, onNavigationError);
 
         return {
-            httpResponse: navigationResult.response,
+            httpResponse: opResult.response,
             pageNavigationTiming: {
-                goto1: goto1Elapsed,
-                goto1Timeout,
-                goto2: goto2Elapsed,
+                ...opResult.navigationTiming,
                 ...networkIdlePageTiming,
                 ...postNavigationPageTiming,
             } as PageNavigationTiming,
@@ -108,32 +84,202 @@ export class PageNavigator {
         page: Puppeteer.Page,
         onNavigationError: (browserError: BrowserError, error?: unknown) => Promise<void> = () => Promise.resolve(),
     ): Promise<NavigationResponse> {
-        const timestamp = System.getTimestamp();
-        const navigationResult = await this.reloadPage(page);
-        const reloadElapsed = System.getElapsedTime(timestamp);
-        if (!isNil(navigationResult.browserError)) {
-            await onNavigationError(navigationResult.browserError, navigationResult.error);
+        const opResult = await this.navigatePage(
+            (waitUntil = this.navigationCondition) => page.reload({ waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }),
+            page,
+        );
+
+        if (opResult.browserError) {
+            this.logger?.logError('Page navigation error while reload page.', {
+                timeout: `${puppeteerTimeoutConfig.navigationTimeoutMsecs}`,
+                browserError: System.serializeError(opResult.browserError),
+            });
+
+            await onNavigationError(opResult.browserError, opResult.error);
 
             return undefined;
         }
 
-        const networkIdlePageTiming = await this.tryWaitForNetworkIdle(page);
+        const networkIdlePageTiming = await this.waitForNetworkIdle(page);
 
-        const postNavigationPageTiming = await this.pageNavigationHooks.postNavigation(page, navigationResult.response, onNavigationError);
+        const postNavigationPageTiming = await this.pageNavigationHooks.postNavigation(page, opResult.response, onNavigationError);
 
         return {
-            httpResponse: navigationResult.response,
+            httpResponse: opResult.response,
             pageNavigationTiming: {
-                goto1: reloadElapsed,
-                goto1Timeout: false,
-                goto2: 0,
+                ...opResult.navigationTiming,
                 ...networkIdlePageTiming,
                 ...postNavigationPageTiming,
             } as PageNavigationTiming,
         };
     }
 
-    private async tryWaitForNetworkIdle(page: Puppeteer.Page): Promise<Partial<PageNavigationTiming>> {
+    private async navigatePage(navigationOperation: NavigationOperation, page: Puppeteer.Page): Promise<PageOperationResult> {
+        const getErrorResult = (result: PageOperationResult): PageOperationResult => {
+            this.logger?.logError(`Page navigation error.`, {
+                error: System.serializeError(result.error),
+                browserError: System.serializeError(result.browserError),
+            });
+
+            return {
+                ...result,
+                response: undefined,
+            };
+        };
+
+        let opResult = await this.invokePageNavigationOperation(navigationOperation);
+
+        opResult = await this.handleIndirectPageRedirection(navigationOperation, opResult, page);
+        if (opResult.error) {
+            return getErrorResult(opResult);
+        }
+
+        opResult = await this.handleCachedResponse(opResult, page);
+        if (opResult.error) {
+            return getErrorResult(opResult);
+        }
+
+        return opResult;
+    }
+
+    private async invokePageNavigationOperation(navigationOperation: NavigationOperation): Promise<PageOperationResult> {
+        let opTimeout = false;
+
+        let timestamp = System.getTimestamp();
+        let opResult = await this.invokePageOperation(navigationOperation);
+        const op1Elapsed = System.getElapsedTime(timestamp);
+
+        let op2Elapsed = 0;
+        if (opResult.browserError?.errorType === 'UrlNavigationTimeout') {
+            // Fallback to load partial page resources on navigation timeout.
+            // This mitigates cases when page has active network connections,
+            // for example streaming video controls.
+            opTimeout = true;
+
+            timestamp = System.getTimestamp();
+            opResult = await this.invokePageOperation(() => navigationOperation('load'));
+            op2Elapsed = System.getElapsedTime(timestamp);
+        }
+
+        opResult.navigationTiming = {
+            goto1: op1Elapsed,
+            goto1Timeout: opTimeout,
+            goto2: op2Elapsed,
+        } as PageNavigationTiming;
+
+        return opResult;
+    }
+
+    private async invokePageOperation(pageOperation: () => Promise<Puppeteer.HTTPResponse>): Promise<PageOperationResult> {
+        try {
+            const response = await pageOperation();
+
+            return { response };
+        } catch (error) {
+            const browserError = this.pageResponseProcessor.getNavigationError(error as Error);
+
+            return { response: undefined, browserError, error };
+        }
+    }
+
+    /**
+     * Reloads page if server returns HTTP 304 (Not Modified) when browser uses disk cache.
+     */
+    protected async handleCachedResponse(pageOperationResult: PageOperationResult, page: Puppeteer.Page): Promise<PageOperationResult> {
+        const maxRetryCount = 2;
+
+        if (pageOperationResult.response?.status() !== 304) {
+            return pageOperationResult;
+        }
+
+        let count = 0;
+        let opResult;
+        do {
+            count++;
+            await page.goto(`file:///${__dirname}/blank-page.html`);
+            await System.wait(500);
+
+            opResult = await this.invokePageNavigationOperation((waitUntil = this.navigationCondition) =>
+                page.goBack({ waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }),
+            );
+        } while (count < maxRetryCount && opResult.response?.status() === 304 && opResult.error === undefined);
+
+        this.logger.logWarn('Reload page on HTTP 304 (Not Modified) web server response.', { retryCount: `${count}` });
+
+        return opResult;
+    }
+
+    /**
+     * This function handles case when page has indirect redirection.
+     * For example, page has a script with window.location set to a new URL.
+     * Puppeteer will fail the initial URL navigation and return empty response object.
+     * The function waits for all navigational requests to complete and return response
+     * for the last navigational request.
+     */
+    protected async handleIndirectPageRedirection(
+        navigationOperation: NavigationOperation,
+        pageOperationResult: PageOperationResult,
+        page: Puppeteer.Page,
+    ): Promise<PageOperationResult> {
+        const requests: { url: string; opResult?: PageOperationResult }[] = [];
+
+        if (pageOperationResult.response || pageOperationResult.error) {
+            return pageOperationResult;
+        }
+
+        await page.setRequestInterception(true);
+        page.on('request', async (request) => {
+            // handle only main frame navigational requests
+            const isNavigationRequest = request.isNavigationRequest() && request.frame() === page.mainFrame();
+            if (isNavigationRequest) {
+                requests.push({
+                    url: request.url(),
+                });
+            }
+
+            await request.continue();
+        });
+        page.on('requestfinished', async (request) => {
+            const pendingRequest = requests.find((r) => r.url === request.url());
+            if (pendingRequest !== undefined) {
+                pendingRequest.opResult = { response: request.response() };
+            }
+        });
+        page.on('requestfailed', async (request) => {
+            const pendingRequest = requests.find((r) => r.url === request.url());
+            if (pendingRequest !== undefined) {
+                const error = new Error(request.failure()?.errorText);
+                pendingRequest.opResult = {
+                    response: undefined,
+                    error,
+                    browserError: this.pageResponseProcessor.getNavigationError(error),
+                };
+            }
+        });
+
+        await this.invokePageNavigationOperation(navigationOperation);
+
+        const timestamp = System.getTimestamp();
+        let noPendingRequests = false;
+        do {
+            await System.wait(3000);
+            noPendingRequests = requests.every((r) => r.opResult.response || r.opResult.error);
+        } while (!noPendingRequests && System.getElapsedTime(timestamp) < puppeteerTimeoutConfig.navigationTimeoutMsecs);
+
+        await page.setRequestInterception(false);
+        this.logger.logWarn(`Indirect page redirection handled.`, {
+            redirectChain: JSON.stringify(requests.map((r) => r.url)),
+        });
+
+        return requests.at(-1)?.opResult;
+    }
+
+    /**
+     * Waits for page network activity to reach idle state.
+     * This mitigates cases when page needs load pending frame/content.
+     * Will not throw if page still has network activity.
+     */
+    private async waitForNetworkIdle(page: Puppeteer.Page): Promise<Partial<PageNavigationTiming>> {
         let networkIdleTimeout = false;
         const timestamp = System.getTimestamp();
         try {
@@ -151,109 +297,5 @@ export class PageNavigator {
         const networkIdleElapsed = System.getElapsedTime(timestamp);
 
         return { networkIdle: networkIdleElapsed, networkIdleTimeout };
-    }
-
-    private async reloadPage(
-        page: Puppeteer.Page,
-    ): Promise<{ response: Puppeteer.HTTPResponse; browserError?: BrowserError; error?: unknown }> {
-        const navigationCondition = 'networkidle2';
-        const opResult = await this.invokePageNavigationOperation((waitUntil = navigationCondition) =>
-            page.reload({ waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }),
-        );
-
-        if (isNil(opResult.error) && opResult.response.status() === 304) {
-            opResult.response = await this.reloadCachedVersion(page, navigationCondition);
-        }
-
-        if (!isNil(opResult.error)) {
-            this.logger?.logError(`Page navigation error while reload page.`, {
-                browserError: System.serializeError(opResult.browserError),
-            });
-
-            return { response: undefined, browserError: opResult.browserError, error: opResult.error };
-        }
-
-        return { response: opResult.response };
-    }
-
-    private async navigateToUrl(
-        url: string,
-        page: Puppeteer.Page,
-        navigationCondition: Puppeteer.PuppeteerLifeCycleEvent,
-        options?: PageConfigurationOptions,
-    ): Promise<{ response: Puppeteer.HTTPResponse; browserError?: BrowserError; error?: unknown }> {
-        let response: Puppeteer.HTTPResponse;
-        let browserError: BrowserError;
-        try {
-            response = await page.goto(url, {
-                waitUntil: navigationCondition,
-                timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs,
-            });
-
-            if (response.status() === 304 && options?.allowCachedVersion) {
-                response = await this.reloadCachedVersion(page, navigationCondition);
-            }
-
-            return { response };
-        } catch (error) {
-            browserError = this.pageResponseProcessor.getNavigationError(error as Error);
-
-            return { response, browserError, error };
-        }
-    }
-
-    // Reload page if website returns HTTP 304 (Not Modified) when browser use disk cache
-    private async reloadCachedVersion(
-        page: Puppeteer.Page,
-        navigationCondition: Puppeteer.PuppeteerLifeCycleEvent,
-    ): Promise<Puppeteer.HTTPResponse> {
-        const maxRetryCount = 2;
-
-        let count = 0;
-        let opResult;
-        do {
-            count++;
-            await page.goto(`file:///${__dirname}/blank-page.html`);
-            await System.wait(500);
-
-            opResult = await this.invokePageNavigationOperation(
-                (waitUntil = navigationCondition) => page.goBack({ waitUntil, timeout: puppeteerTimeoutConfig.navigationTimeoutMsecs }),
-                true, // throw if page navigation fails
-            );
-        } while (count < maxRetryCount && opResult.response.status() === 304);
-
-        this.logger.logWarn('Reloaded page on HTTP 304 (Not Modified) website response.', { retryCount: `${count}` });
-
-        return opResult.response;
-    }
-
-    private async invokePageNavigationOperation(
-        navigationOperation: (navigationCondition?: Puppeteer.PuppeteerLifeCycleEvent) => Promise<Puppeteer.HTTPResponse>,
-        throwOnError: boolean = false,
-    ): Promise<{ response: Puppeteer.HTTPResponse; browserError?: BrowserError; error?: unknown }> {
-        let opResult = await this.invokePageOperation(navigationOperation);
-        if (opResult?.browserError?.errorType === 'UrlNavigationTimeout') {
-            opResult = await this.invokePageOperation(() => navigationOperation('load'));
-        }
-
-        if (throwOnError === true && !isNil(opResult.error)) {
-            throw opResult.error;
-        }
-
-        return opResult;
-    }
-
-    private async invokePageOperation(
-        navigationOperation: () => Promise<Puppeteer.HTTPResponse>,
-    ): Promise<{ response: Puppeteer.HTTPResponse; browserError?: BrowserError; error?: unknown }> {
-        try {
-            const response = await navigationOperation();
-
-            return { response };
-        } catch (error) {
-            const browserError = this.pageResponseProcessor.getNavigationError(error as Error);
-
-            return { response: undefined, browserError, error };
-        }
     }
 }

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -209,7 +209,7 @@ describe(Page, () => {
         });
 
         it('scan throws error if navigateToUrl was not called first', async () => {
-            pageNavigatorMock.setup(async (o) => o.navigate(It.isAny(), It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+            pageNavigatorMock.setup(async (o) => o.navigate(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
 
             await expect(page.scanForA11yIssues(url)).rejects.toThrow();
         });
@@ -222,7 +222,7 @@ describe(Page, () => {
 
         it('navigates to page and saves response', async () => {
             pageNavigatorMock
-                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, undefined, It.isAny()))
+                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, It.isAny()))
                 .returns(() => Promise.resolve(navigationResponse))
                 .verifiable();
 
@@ -239,7 +239,7 @@ describe(Page, () => {
 
         it('navigates to page with allowCachedVersion option', async () => {
             pageNavigatorMock
-                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, { allowCachedVersion: true }, It.isAny()))
+                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, It.isAny()))
                 .returns(() => Promise.resolve(navigationResponse))
                 .verifiable();
 
@@ -255,7 +255,7 @@ describe(Page, () => {
                 .setup((o) => o.logError('Page navigation error', { browserError: System.serializeError(browserError) }))
                 .verifiable();
             pageNavigatorMock
-                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, undefined, It.isAny()))
+                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, It.isAny()))
                 .callback(async (u, p, o, fn) => {
                     await fn(browserError, error);
                 })
@@ -270,7 +270,7 @@ describe(Page, () => {
         it('set extra HTTP headers on navigate', async () => {
             process.env.X_FORWARDED_FOR_HTTP_HEADER = '1.1.1.1';
             pageNavigatorMock
-                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, undefined, It.isAny()))
+                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, It.isAny()))
                 .returns(() => Promise.resolve(navigationResponse))
                 .verifiable();
             puppeteerPageMock
@@ -346,7 +346,7 @@ describe(Page, () => {
                 .verifiable();
             // navigate url
             pageNavigatorMock
-                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, { allowCachedVersion: true }, It.isAny()))
+                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, It.isAny()))
                 .returns(() => Promise.resolve(navigationResponse))
                 .verifiable();
             // reload page

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -237,17 +237,6 @@ describe(Page, () => {
             expect(page.lastNavigationResponse).toEqual(puppeteerResponseMock.object);
         });
 
-        it('navigates to page with allowCachedVersion option', async () => {
-            pageNavigatorMock
-                .setup(async (o) => o.navigate(url, puppeteerPageMock.object, It.isAny()))
-                .returns(() => Promise.resolve(navigationResponse))
-                .verifiable();
-
-            await page.navigateToUrl(url, { allowCachedVersion: true });
-
-            expect(page.lastNavigationResponse).toEqual(puppeteerResponseMock.object);
-        });
-
         it('handles browser error on navigate', async () => {
             const error = new Error('navigation error');
             const browserError = { errorType: 'SslError', statusCode: 500 } as BrowserError;
@@ -256,7 +245,7 @@ describe(Page, () => {
                 .verifiable();
             pageNavigatorMock
                 .setup(async (o) => o.navigate(url, puppeteerPageMock.object, It.isAny()))
-                .callback(async (u, p, o, fn) => {
+                .callback(async (u, p, fn) => {
                     await fn(browserError, error);
                 })
                 .returns(() => Promise.resolve(undefined))

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -88,7 +88,7 @@ export class Page {
 
         await this.setExtraHTTPHeaders();
 
-        const navigationResponse = await this.pageNavigator.navigate(url, this.page, options, async (browserError) => {
+        const navigationResponse = await this.pageNavigator.navigate(url, this.page, async (browserError) => {
             this.logger?.logError('Page navigation error', { browserError: System.serializeError(browserError) });
             this.lastBrowserError = browserError;
         });

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -23,10 +23,6 @@ export interface BrowserStartOptions {
     clearBrowserCache?: boolean;
 }
 
-export interface PageConfigurationOptions {
-    allowCachedVersion?: boolean;
-}
-
 export interface Viewport {
     width: number;
     height: number;
@@ -82,7 +78,7 @@ export class Page {
         this.page = await this.browser.newPage();
     }
 
-    public async navigateToUrl(url: string, options?: PageConfigurationOptions): Promise<void> {
+    public async navigateToUrl(url: string): Promise<void> {
         this.requestUrl = url;
         this.lastBrowserError = undefined;
 
@@ -186,7 +182,7 @@ export class Page {
     private async hardReload(): Promise<void> {
         await this.close();
         await this.create({ ...this.lastBrowserStartOptions, clearBrowserCache: false });
-        await this.navigateToUrl(this.requestUrl, { allowCachedVersion: true });
+        await this.navigateToUrl(this.requestUrl);
     }
 
     private async softReload(): Promise<void> {


### PR DESCRIPTION
#### Details

Added page indirect redirection handler to support case when page was redirected by a script. The indirect redirection may result empty puppeteer response result and fail scan.
Refactored PageNavigator() to unify page load workflow for navigate and reload scenarios.
Increased shared memory allocated to a runner container.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
