### PR TITLE
chore: fix cbuild on windows by reverting obsolete npm-path workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "clean": "yarn packages run clean && rimraf dist test-results",
         "build": "yarn packages --topological-dev run build",
         "cbuild": "yarn packages --topological-dev run cbuild",
-        "dbuild": "yarn install && npm-run-all --serial --npm-path npm syncpack:fix build",
+        "dbuild": "yarn install && npm-run-all --serial syncpack:fix build",
         "pack": "yarn packages --topological-dev run pack",
         "test": "npx jest",
         "test:nc": "npx jest --collectCoverage=false --maxWorkers=4",

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "scripts": {
         "build": "tsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -4,7 +4,7 @@
     "description": "Common package for CRUD operation with your azure storage",
     "scripts": {
         "build": "tsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,8 +4,8 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
-        "pack": "npm-run-all --serial --npm-path npm 'create-drop-dir' 'pack-to-drop-dir'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
+        "pack": "npm-run-all --serial 'create-drop-dir' 'pack-to-drop-dir'",
         "pack-to-drop-dir": "yarn pack --filename drop/cli.tgz",
         "create-drop-dir": "npx mkdirp drop",
         "clean": "rimraf dist drop test-results ai_scan_cli_output",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "tsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "tsc && rollup -c && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results ai_scan_cli_output",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/e2e-test-site/package.json
+++ b/packages/e2e-test-site/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "cpy \"./site-content\" \"./dist\" && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results"
     },
     "author": "Microsoft",

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -4,14 +4,14 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js --config-name e2e-web-apis \"$@\"",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
         "test": "jest --coverage --colors",
         "watch": "tsc --w",
         "start:host": "func start",
-        "start": "npm-run-all --parallel --npm-path npm 'start:host' 'watch'"
+        "start": "npm-run-all --parallel 'start:host' 'watch'"
     },
     "repository": {
         "type": "git",

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "tsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "scripts": {
         "build": "tsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/parallel-workers/package.json
+++ b/packages/parallel-workers/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/privacy-scan-core/package.json
+++ b/packages/privacy-scan-core/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "scripts": {
         "build": "tsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/privacy-scan-job-manager/package.json
+++ b/packages/privacy-scan-job-manager/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/privacy-scan-runner/package.json
+++ b/packages/privacy-scan-runner/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/report-generator-job-manager/package.json
+++ b/packages/report-generator-job-manager/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/report-generator-runner/package.json
+++ b/packages/report-generator-runner/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/resource-deployment/package.json
+++ b/packages/resource-deployment/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "cpy \"./templates\" \"./dist\" && cpy \"./scripts\" \"./dist\" && cpy \"./runtime-config\" \"./dist\" && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results"
     },
     "author": "Microsoft",

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "scripts": {
         "build": "tsc && cpy \"./blank-page.html\" \"./dist\" && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "tsc && echo && cpy \"../parallel-workers/dist/*.js\" \"./dist\"",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/storage-documents/package.json
+++ b/packages/storage-documents/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "ttsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/web-api-client/package.json
+++ b/packages/web-api-client/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "tsc && echo",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -4,7 +4,7 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\" && node ../../create-docker-image-package-json.js",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -4,14 +4,14 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js --config-name web-api \"$@\"",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
         "test": "jest --coverage --colors",
         "watch": "tsc --w",
         "start:host": "func start",
-        "start": "npm-run-all --parallel --npm-path npm 'start:host' 'watch'"
+        "start": "npm-run-all --parallel 'start:host' 'watch'"
     },
     "repository": {
         "type": "git",

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -4,14 +4,14 @@
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js --config-name web-workers \"$@\"",
-        "cbuild": "npm-run-all --serial --npm-path npm 'clean' 'build'",
+        "cbuild": "npm-run-all --serial 'clean' 'build'",
         "clean": "rimraf dist test-results",
         "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
         "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
         "test": "jest --coverage --colors",
         "watch": "tsc --w",
         "start:host": "func start",
-        "start": "npm-run-all --parallel --npm-path npm 'start:host' 'watch'"
+        "start": "npm-run-all --parallel 'start:host' 'watch'"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
#### Details

This PR reverts a Lerna workaround @pownkel added in #2009 which became obsolete with our removal of Lerna in #2210. The workaround was breaking the ability to run `yarn cbuild` on Windows machines - this PR restores that capability.

##### Motivation

The upgrade to yarn 3 in #2210 accidentally broke all run scripts which transitively refer to a `npm-run-all` command in non-WSL Windows developer environments. Notably, this breaks `yarn cbuild` from the root of the repo.

This manifested as a failing `yarn cbuild` command with output like this:

<details>
<summary>full example output snippet</summary>
```
➤ YN0000: [parallel-workers]: Process started
➤ YN0000: [scanner-global-library]: Process started
➤ YN0000: [parallel-workers]:
➤ YN0000: [parallel-workers]: > parallel-workers@1.0.0 clean
➤ YN0000: [parallel-workers]: > rimraf dist test-results
➤ YN0000: [parallel-workers]:
➤ YN0000: [parallel-workers]:
➤ YN0000: [parallel-workers]: > parallel-workers@1.0.0 build
➤ YN0000: [parallel-workers]: > webpack --config ./webpack.config.js "$@"
➤ YN0000: [parallel-workers]:
➤ YN0000: [parallel-workers]: Building for version : dev
➤ YN0000: [parallel-workers]: [webpack-cli] Failed to load 'C:\repos\accessibility-insights-service\packages\parallel-workers\$@' config
➤ YN0000: [parallel-workers]: [webpack-cli] Error: Cannot find module 'C:\repos\accessibility-insights-service\packages\parallel-workers\$@'
➤ YN0000: [parallel-workers]: Require stack:
➤ YN0000: [parallel-workers]: - C:\repos\accessibility-insights-service\node_modules\webpack-cli\lib\webpack-cli.js
➤ YN0000: [parallel-workers]: - C:\repos\accessibility-insights-service\node_modules\webpack-cli\lib\bootstrap.js
➤ YN0000: [parallel-workers]: - C:\repos\accessibility-insights-service\node_modules\webpack-cli\bin\cli.js
➤ YN0000: [parallel-workers]: - C:\repos\accessibility-insights-service\node_modules\webpack\bin\webpack.js
➤ YN0000: [parallel-workers]:     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:985:15)
➤ YN0000: [parallel-workers]:     at Function.Module._load (node:internal/modules/cjs/loader:833:27)
➤ YN0000: [parallel-workers]:     at Module.require (node:internal/modules/cjs/loader:1057:19)
➤ YN0000: [parallel-workers]:     at require (node:internal/modules/cjs/helpers:103:18)
➤ YN0000: [parallel-workers]:     at WebpackCLI.tryRequireThenImport (C:\repos\accessibility-insights-service\node_modules\webpack-cli\lib\webpack-cli.js:244:16)
➤ YN0000: [parallel-workers]:     at loadConfigByPath (C:\repos\accessibility-insights-service\node_modules\webpack-cli\lib\webpack-cli.js:1712:30)
➤ YN0000: [parallel-workers]:     at C:\repos\accessibility-insights-service\node_modules\webpack-cli\lib\webpack-cli.js:1767:11
➤ YN0000: [parallel-workers]:     at Array.map (<anonymous>)
➤ YN0000: [parallel-workers]:     at WebpackCLI.loadConfig (C:\repos\accessibility-insights-service\node_modules\webpack-cli\lib\webpack-cli.js:1766:24)
➤ YN0000: [parallel-workers]:     at WebpackCLI.createCompiler (C:\repos\accessibility-insights-service\node_modules\webpack-cli\lib\webpack-cli.js:2187:29) {
➤ YN0000: [parallel-workers]:   code: 'MODULE_NOT_FOUND',
➤ YN0000: [parallel-workers]:   requireStack: [
➤ YN0000: [parallel-workers]:     'C:\\repos\\accessibility-insights-service\\node_modules\\webpack-cli\\lib\\webpack-cli.js',
➤ YN0000: [parallel-workers]:     'C:\\repos\\accessibility-insights-service\\node_modules\\webpack-cli\\lib\\bootstrap.js',
➤ YN0000: [parallel-workers]:     'C:\\repos\\accessibility-insights-service\\node_modules\\webpack-cli\\bin\\cli.js',
➤ YN0000: [parallel-workers]:     'C:\\repos\\accessibility-insights-service\\node_modules\\webpack\\bin\\webpack.js'
➤ YN0000: [parallel-workers]:   ]
➤ YN0000: [parallel-workers]: }
➤ YN0000: [parallel-workers]: npm ERR! Lifecycle script `build` failed with error:
➤ YN0000: [parallel-workers]: npm ERR! Error: command failed
➤ YN0000: [parallel-workers]: npm ERR!   in workspace: parallel-workers@1.0.0
➤ YN0000: [parallel-workers]: npm ERR!   at location: C:\repos\accessibility-insights-service\packages\parallel-workers
➤ YN0000: [parallel-workers]: ERROR: "build" exited with 1.
➤ YN0000: [parallel-workers]: Process exited (exit code 1), completed in 2s 607ms
```
</details>

The operative line is `[webpack-cli] Failed to load 'C:\repos\accessibility-insights-service\packages\parallel-workers\$@' config` - the webpack command was receiving a literal `$@`, instead of the intended behavior of the package's `build` run-script receiving "the rest" of its args as pass-through args.

In general, as of v2, yarn bundles its own minimal shell that is intended to be able to interpret bash-like variables like the `\"#@\"` used by this build script. However, #2009 included a workaround for a lerna issue which involved adding `--npm-path npm` to every use of `npm-run-all` in the repo, which causes `npm` to interpret sub-commands instead of `yarn`, bypassing this behavior and instead using host-specific shell intepretation, which is why we see an issue on Windows but not Linux. This is commonly used in `cbuild` run-scripts to run `clean` and `build` in serial.

Since we no longer use Lerna as of #2210, the workaround is no longer necessary. This PR removes the workaround. I verified that this is sufficient for `yarn cbuild` and `yarn precheckin` to work on a Windows machine from both the `/packages/parallel-workers` directory and the root directory (where the workaround was previously required).

##### Context

See #2009, #2210

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
