### PR TITLE
Make authentication throw custom error if `#FormsAuthentication` timesout

### DIFF
--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -23,8 +23,17 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
             const errorText: string = await page.$eval('#usernameError', (el) => el.textContent).catch(() => '');
             throw new Error(isEmpty(errorText) ? error : `Authentication failed with error: ${errorText}`);
         }
-        await page.waitForSelector('#FormsAuthentication');
+
+        try {
+            await page.waitForSelector('#FormsAuthentication');
+        } catch (error) {
+            throw new Error(
+                `Authentication failed. Authentication requires a non-people service account https://aka.ms/AI-action-auth. ${error}`,
+            );
+        }
+
         await page.click('#FormsAuthentication');
+
         await page.type('input[type="password"]', this.accountPassword);
         await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), await page.keyboard.press('Enter')]);
         if (!this.authenticationSucceeded(page)) {

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -33,7 +33,6 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
         }
 
         await page.click('#FormsAuthentication');
-
         await page.type('input[type="password"]', this.accountPassword);
         await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), await page.keyboard.press('Enter')]);
         if (!this.authenticationSucceeded(page)) {


### PR DESCRIPTION
#### Details

Adding on to the work in #2270, this pull request will add a try/catch around `#FormsAuthentication` to improve error handling. Before, when authentication uses a non-people service account, a timeout error will be reported back to the user.

##### Motivation

Improve error handling in authentication.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
