### PR TITLE
Set website page scan state on delete

### DIFF
--- a/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.spec.ts
+++ b/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.spec.ts
@@ -143,7 +143,7 @@ describe(PrivacyReportReducer, () => {
                 seedUri: url,
                 navigationalUri,
                 httpStatusCode: partialScanResult.pageResponseCode,
-                reason: 'error="Page reload error"',
+                reason: '"Page reload error"',
                 bannerDetected: partialScanResult.results.bannerDetected,
                 bannerDetectionXpathExpression: partialScanResult.results.bannerDetectionXpathExpression,
             };
@@ -180,7 +180,7 @@ describe(PrivacyReportReducer, () => {
                 seedUri: url,
                 navigationalUri: undefined,
                 httpStatusCode: 404,
-                reason: 'error="Browser error"',
+                reason: '"Browser error"',
                 bannerDetected: undefined,
                 bannerDetectionXpathExpression: undefined,
             };
@@ -259,7 +259,7 @@ describe(PrivacyReportReducer, () => {
                     seedUri: url,
                     navigationalUri,
                     httpStatusCode: partialScanResult.pageResponseCode,
-                    reason: 'error="Page reload error"',
+                    reason: '"Page reload error"',
                     bannerDetected: partialScanResult.results.bannerDetected,
                     bannerDetectionXpathExpression: partialScanResult.results.bannerDetectionXpathExpression,
                 };
@@ -298,7 +298,7 @@ describe(PrivacyReportReducer, () => {
                     seedUri: url,
                     navigationalUri: undefined,
                     httpStatusCode: 404,
-                    reason: 'error="Browser error"',
+                    reason: '"Browser error"',
                 };
 
                 const expectedReport: PrivacyScanCombinedReport = {
@@ -361,7 +361,7 @@ describe(PrivacyReportReducer, () => {
                 seedUri: url,
                 navigationalUri: undefined,
                 httpStatusCode: 404,
-                reason: 'error="Browser error"',
+                reason: '"Browser error"',
             };
 
             const expectedReport: PrivacyScanCombinedReport = {

--- a/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.ts
+++ b/packages/privacy-scan-runner/src/combined-report/privacy-report-reducer.ts
@@ -59,7 +59,7 @@ export class PrivacyReportReducer {
             seedUri: url,
             navigationalUri: privacyScanResult.results?.navigationalUri,
             httpStatusCode: privacyScanResult.pageResponseCode,
-            reason: `error=${JSON.stringify(privacyScanResult.error)}`,
+            reason: JSON.stringify(privacyScanResult.error),
             bannerDetected: privacyScanResult.results?.bannerDetected,
             bannerDetectionXpathExpression: privacyScanResult.results?.bannerDetectionXpathExpression,
         });


### PR DESCRIPTION
#### Details

Set website page scan state on delete to correctly reflect in combined scan result API response.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
