### PR TITLE
Fallback to legacy mode on axe-core/puppeteer scan error

### DIFF
--- a/packages/scanner-global-library/src/factories/axe-puppeteer-factory.spec.ts
+++ b/packages/scanner-global-library/src/factories/axe-puppeteer-factory.spec.ts
@@ -53,4 +53,11 @@ describe('AxePuppeteerFactory', () => {
         expect(axePuppeteer).toBeInstanceOf(AxePuppeteer);
         expect((axePuppeteer as any).config).toStrictEqual(axeConfiguration);
     });
+
+    it('create axe puppeteer instance, legacyMode is true', async () => {
+        const axePuppeteer = await testSubject.createAxePuppeteer(page.object, '', true);
+        expect(axePuppeteer).toBeDefined();
+        expect(axePuppeteer).toBeInstanceOf(AxePuppeteer);
+        expect((axePuppeteer as any).config).toStrictEqual(axeConfiguration);
+    });
 });

--- a/packages/scanner-global-library/src/factories/axe-puppeteer-factory.ts
+++ b/packages/scanner-global-library/src/factories/axe-puppeteer-factory.ts
@@ -18,12 +18,13 @@ export class AxePuppeteerFactory {
         private readonly fileSystemObj: typeof fs = fs,
     ) {}
 
-    public async createAxePuppeteer(page: Puppeteer.Page, contentSourcePath?: string): Promise<AxePuppeteer> {
+    public async createAxePuppeteer(page: Puppeteer.Page, contentSourcePath?: string, legacyMode: boolean = false): Promise<AxePuppeteer> {
         const axeSource = await this.getAxeSource(contentSourcePath);
 
         return new AxePuppeteer(page, axeSource)
             .configure(this.axeConfiguration)
-            .disableRules(this.ruleExclusion.accessibilityRuleExclusionList);
+            .disableRules(this.ruleExclusion.accessibilityRuleExclusionList)
+            .setLegacyMode(legacyMode);
     }
 
     private async getAxeSource(contentSourcePath?: string): Promise<string> {

--- a/packages/scanner-global-library/src/page-configurator.ts
+++ b/packages/scanner-global-library/src/page-configurator.ts
@@ -3,6 +3,7 @@
 
 import { injectable } from 'inversify';
 import * as Puppeteer from 'puppeteer';
+import { windowSize } from './puppeteer-options';
 
 @injectable()
 export class PageConfigurator {
@@ -13,7 +14,14 @@ export class PageConfigurator {
 
     private async enablePageResizing(page: Puppeteer.Page): Promise<void> {
         // enable page resizing to match to browser viewport
-        const client = await page.target().createCDPSession();
-        await client.send('Emulation.clearDeviceMetricsOverride');
+        const headless = process.env.HEADLESS === 'false' ? false : true;
+        if (headless) {
+            const session = await page.target().createCDPSession();
+            const { windowId } = await session.send('Browser.getWindowForTarget');
+            await session.send('Browser.setWindowBounds', { windowId, bounds: { width: windowSize.width, height: windowSize.height } });
+            await session.detach();
+        } else {
+            await page.setViewport({ width: 1920, height: 1080 });
+        }
     }
 }

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -119,11 +119,15 @@ describe(Page, () => {
         });
 
         it('handles error thrown by scan engine', async () => {
-            const scanError = new Error('Test error');
+            const scanError = { name: 'Error', message: 'error message' } as Error;
             const expectedResult = { error: `Axe core engine error. ${System.serializeError(scanError)}`, scannedUrl: url };
 
             puppeteerPageMock.setup((p) => p.url()).returns(() => url);
             setupAxePuppeteerFactoryMock();
+            axePuppeteerFactoryMock
+                .setup((o) => o.createAxePuppeteer(puppeteerPageMock.object, It.isAny(), true))
+                .returns(() => Promise.resolve(axePuppeteerMock.object))
+                .verifiable();
             axePuppeteerMock.reset();
             axePuppeteerMock = getPromisableDynamicMock(axePuppeteerMock);
             axePuppeteerMock.setup((ap) => ap.analyze()).throws(scanError);

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -5,8 +5,9 @@ import { System } from 'common';
 import { inject, injectable, optional } from 'inversify';
 import { GlobalLogger } from 'logger';
 import * as Puppeteer from 'puppeteer';
-import axe from 'axe-core';
+import axe, { AxeResults } from 'axe-core';
 import { isNil, isNumber, isEmpty } from 'lodash';
+import { AxePuppeteer } from '@axe-core/puppeteer';
 import { AxeScanResults } from './axe-scan-results';
 import { AxePuppeteerFactory } from './factories/axe-puppeteer-factory';
 import { WebDriver } from './web-driver';
@@ -257,19 +258,21 @@ export class Page {
     }
 
     private async scanPageForIssues(contentSourcePath?: string): Promise<AxeScanResults> {
-        const axePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.page, contentSourcePath);
-        let axeResults: axe.AxeResults;
-        try {
-            axeResults = await axePuppeteer.analyze();
-        } catch (error) {
-            this.logger?.logError('Axe core engine error', { browserError: System.serializeError(error), url: this.page.url() });
+        let axePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.page, contentSourcePath);
+        let result = await this.runAxeAnalyze(axePuppeteer);
+        if (result.error) {
+            // Fallback to axe puppeteer legacy mode
+            axePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.page, contentSourcePath, true);
+            result = await this.runAxeAnalyze(axePuppeteer);
+        }
 
-            return { error: `Axe core engine error. ${System.serializeError(error)}`, scannedUrl: this.page.url() };
+        if (result.error) {
+            return { error: `Axe core engine error. ${System.serializeError(result.error)}`, scannedUrl: this.page.url() };
         }
 
         const browserResolution = await this.getBrowserResolution();
         const scanResults: AxeScanResults = {
-            results: axeResults,
+            results: result.axeResult,
             pageTitle: await this.page.title(),
             browserSpec: await this.browser.version(),
             pageResponseCode: this.lastNavigationResponse.status(),
@@ -280,12 +283,25 @@ export class Page {
         if (
             this.lastNavigationResponse.request()?.redirectChain()?.length > 0 ||
             // Should compare encoded Urls
-            (this.requestUrl !== undefined && encodeURI(this.requestUrl) !== axeResults.url)
+            (this.requestUrl !== undefined && encodeURI(this.requestUrl) !== result.axeResult.url)
         ) {
-            this.logger?.logWarn(`Scanning performed on redirected page`, { redirectedUrl: axeResults.url });
-            scanResults.scannedUrl = axeResults.url;
+            this.logger?.logWarn(`Scanning performed on redirected page`, { redirectedUrl: result.axeResult.url });
+            scanResults.scannedUrl = result.axeResult.url;
         }
 
         return scanResults;
+    }
+
+    private async runAxeAnalyze(axePuppeteer: AxePuppeteer): Promise<{ axeResult?: AxeResults; error?: Error }> {
+        let result: axe.AxeResults;
+        try {
+            result = await axePuppeteer.analyze();
+        } catch (error) {
+            this.logger?.logError('Axe core engine error.', { error: System.serializeError(error), url: this.page.url() });
+
+            return { error };
+        }
+
+        return { axeResult: result };
     }
 }

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -259,20 +259,20 @@ export class Page {
 
     private async scanPageForIssues(contentSourcePath?: string): Promise<AxeScanResults> {
         let axePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.page, contentSourcePath);
-        let result = await this.runAxeAnalyze(axePuppeteer);
-        if (result.error) {
+        let axeRunResult = await this.runAxeAnalyze(axePuppeteer);
+        if (axeRunResult.error) {
             // Fallback to axe puppeteer legacy mode
             axePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(this.page, contentSourcePath, true);
-            result = await this.runAxeAnalyze(axePuppeteer);
+            axeRunResult = await this.runAxeAnalyze(axePuppeteer);
         }
 
-        if (result.error) {
-            return { error: `Axe core engine error. ${System.serializeError(result.error)}`, scannedUrl: this.page.url() };
+        if (axeRunResult.error) {
+            return { error: `Axe core engine error. ${System.serializeError(axeRunResult.error)}`, scannedUrl: this.page.url() };
         }
 
         const browserResolution = await this.getBrowserResolution();
         const scanResults: AxeScanResults = {
-            results: result.axeResult,
+            results: axeRunResult.axeResults,
             pageTitle: await this.page.title(),
             browserSpec: await this.browser.version(),
             pageResponseCode: this.lastNavigationResponse.status(),
@@ -283,16 +283,16 @@ export class Page {
         if (
             this.lastNavigationResponse.request()?.redirectChain()?.length > 0 ||
             // Should compare encoded Urls
-            (this.requestUrl !== undefined && encodeURI(this.requestUrl) !== result.axeResult.url)
+            (this.requestUrl !== undefined && encodeURI(this.requestUrl) !== axeRunResult.axeResults.url)
         ) {
-            this.logger?.logWarn(`Scanning performed on redirected page`, { redirectedUrl: result.axeResult.url });
-            scanResults.scannedUrl = result.axeResult.url;
+            this.logger?.logWarn(`Scanning performed on redirected page`, { redirectedUrl: axeRunResult.axeResults.url });
+            scanResults.scannedUrl = axeRunResult.axeResults.url;
         }
 
         return scanResults;
     }
 
-    private async runAxeAnalyze(axePuppeteer: AxePuppeteer): Promise<{ axeResult?: AxeResults; error?: Error }> {
+    private async runAxeAnalyze(axePuppeteer: AxePuppeteer): Promise<{ axeResults?: AxeResults; error?: Error }> {
         let result: axe.AxeResults;
         try {
             result = await axePuppeteer.analyze();
@@ -302,6 +302,6 @@ export class Page {
             return { error };
         }
 
-        return { axeResult: result };
+        return { axeResults: result };
     }
 }


### PR DESCRIPTION
#### Details

Fallback to legacy mode on axe-core/puppeteer scan error.
Fixed browser viewport mode.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
