### PR TITLE
fix: add process exit to end of cli execution

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,10 +18,14 @@ import { validateScanArguments } from './validate-scan-arguments';
     const scanArguments = getScanArguments();
     const cliEntryPoint = new CliEntryPoint(setupCliContainer());
     await cliEntryPoint.runScan(scanArguments);
-})().catch((error) => {
-    console.log('Exception occurred while running the tool: ', System.serializeError(error));
-    process.exitCode = 1;
-});
+})()
+    .catch((error) => {
+        console.log('Exception occurred while running the tool: ', System.serializeError(error));
+        process.exitCode = 1;
+    })
+    .finally(() => {
+        process.exit();
+    });
 
 function getScanArguments(): ScanArguments {
     const defaultOutputDir = 'ai_scan_cli_output';


### PR DESCRIPTION
#### Details

This adds a `process.exit()` call at the end of the CLI execution to fix a bug where the CLI seems to hang after everything has completed.

This also bumps the scan package version number in preparation for re-release.

##### Motivation

Fixes bug found during ADO Extension release validation

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
