### PR TITLE
fix: Update auth flow to handle KMSI page

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -36,10 +36,7 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
         await page.type('input[type="password"]', this.accountPassword);
         await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.keyboard.press('Enter')]);
 
-        const kmsiPageShown = await page.$eval('#idBtn_Back', () => true).catch(() => false);
-        if (kmsiPageShown) {
-            await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.click('#idBtn_Back')]);
-        }
+        await this.handleKmsiPageIfShown(page);
 
         if (!this.authenticationSucceeded(page)) {
             const errorText: string = await page.$eval('#errorText', (el) => el.textContent).catch(() => '');
@@ -55,5 +52,16 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
         console.info('Authentication succeeded.');
 
         return true;
+    }
+
+    private async handleKmsiPageIfShown(page: Puppeteer.Page): Promise<void> {
+        try {
+            //check for KMSI page, handle if shown
+            await page.waitForSelector('#idBtn_Back', { timeout: 5000 });
+            await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.click('#idBtn_Back')]);
+            console.info('KMSI page handled.');
+        } catch (error) {
+            console.info('KMSI page not shown.');
+        }
     }
 }

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -34,7 +34,13 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
 
         await page.click('#FormsAuthentication');
         await page.type('input[type="password"]', this.accountPassword);
-        await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), await page.keyboard.press('Enter')]);
+        await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.keyboard.press('Enter')]);
+
+        const kmsiPageShown = await page.$eval('#idBtn_Back', () => true).catch(() => false);
+        if (kmsiPageShown) {
+            await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.click('#idBtn_Back')]);
+        }
+
         if (!this.authenticationSucceeded(page)) {
             const errorText: string = await page.$eval('#errorText', (el) => el.textContent).catch(() => '');
             throw new Error(`Authentication failed${isEmpty(errorText) ? '' : ` with error: ${errorText}`}`);

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -56,7 +56,6 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
 
     private async handleKmsiPageIfShown(page: Puppeteer.Page): Promise<void> {
         try {
-            //check for KMSI page, handle if shown
             await page.waitForSelector('#idBtn_Back', { timeout: 5000 });
             await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.click('#idBtn_Back')]);
             console.info('KMSI page handled.');


### PR DESCRIPTION
#### Details

This adds a check for the KMSI (Keep Me Signed In) page that shows up conditionally based on a machine learning algorithm that detects high risk logins. It also bumps the scan package version in preparation for release.

More information on the KMSI page can be found here: https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/customize-branding#learn-about-the-stay-signed-in-prompt

##### Motivation

Fix for auth

##### Context

My initial implementation did not use the try/catch block, but instead was performing a `page.$eval` and looking for the selector. I changed it to a `waitForSelector` with a 5000ms timeout to ensure that we aren't missing the dialog due to a possible race condition where the page doesn't fully render before the `page.$eval` executes.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
