### PR TITLE
Ensure that the most precise error information is included in a scan run result

### DIFF
--- a/packages/privacy-scan-runner/src/runner/runner.spec.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.spec.ts
@@ -246,10 +246,10 @@ function setupProcessScanResult(): void {
         if ((privacyScanResults.error as BrowserError)?.errorType === 'BannerXPathNotDetected') {
             runState = pageScanResult.run?.retryCount >= maxFailedScanRetryCount ? 'completed' : 'failed';
         }
-        const scanError = privacyScanResults.error as ScanError;
-        if (isEmpty(scanError.errorType)) {
-            scanError.errorType = 'InternalError';
-        }
+        const scanError: ScanError = {
+            errorType: 'InternalError'
+            ...privacyScanResults.error,
+        };
         pageScanResult.run = {
             state: runState,
             timestamp: dateNow.toJSON(),

--- a/packages/privacy-scan-runner/src/runner/runner.spec.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.spec.ts
@@ -13,7 +13,6 @@ import {
 } from 'service-library';
 import { GlobalLogger } from 'logger';
 import * as MockDate from 'mockdate';
-import { isEmpty } from 'lodash';
 import {
     OnDemandPageScanResult,
     OnDemandPageScanReport,
@@ -247,7 +246,7 @@ function setupProcessScanResult(): void {
             runState = pageScanResult.run?.retryCount >= maxFailedScanRetryCount ? 'completed' : 'failed';
         }
         const scanError: ScanError = {
-            errorType: 'InternalError'
+            errorType: 'InternalError',
             ...privacyScanResults.error,
         };
         pageScanResult.run = {

--- a/packages/privacy-scan-runner/src/runner/runner.spec.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.spec.ts
@@ -13,6 +13,7 @@ import {
 } from 'service-library';
 import { GlobalLogger } from 'logger';
 import * as MockDate from 'mockdate';
+import { isEmpty } from 'lodash';
 import {
     OnDemandPageScanResult,
     OnDemandPageScanReport,
@@ -20,6 +21,7 @@ import {
     PrivacyPageScanReport,
     OnDemandPageScanRunState,
     OnDemandPageScanRunResult,
+    ScanError,
 } from 'storage-documents';
 import { PrivacyScanResult, BrowserError } from 'scanner-global-library';
 import { System, ServiceConfiguration, ScanRunTimeConfig, GuidGenerator } from 'common';
@@ -244,10 +246,14 @@ function setupProcessScanResult(): void {
         if ((privacyScanResults.error as BrowserError)?.errorType === 'BannerXPathNotDetected') {
             runState = pageScanResult.run?.retryCount >= maxFailedScanRetryCount ? 'completed' : 'failed';
         }
+        const scanError = privacyScanResults.error as ScanError;
+        if (isEmpty(scanError.errorType)) {
+            scanError.errorType = 'InternalError';
+        }
         pageScanResult.run = {
             state: runState,
             timestamp: dateNow.toJSON(),
-            error: System.serializeError(privacyScanResults.error),
+            error: scanError,
         };
         pageScanResult.scanResult = {
             state: 'fail',

--- a/packages/privacy-scan-runner/src/runner/runner.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.ts
@@ -118,7 +118,7 @@ export class Runner {
             state: 'fail',
         };
 
-        this.setRunResult(pageScanResult, runState, System.serializeError(privacyScanResult.error));
+        this.setRunResult(pageScanResult, runState, this.convertToScanError(privacyScanResult.error));
         this.logger.logError('Browser has failed to scan a webpage.', { error: System.serializeError(privacyScanResult.error) });
         this.telemetryManager.trackBrowserScanFailed();
     }
@@ -184,6 +184,17 @@ export class Runner {
         }
 
         return !isEmpty(reports) ? this.reportWriter.writeBatch(reports) : undefined;
+    }
+
+    private convertToScanError(error: Error | BrowserError): ScanError {
+        let scanError = null;
+        if (typeof error === typeof Error) {
+            scanError = { errorType: 'InternalError' } as ScanError;
+        } else {
+            scanError = error as ScanError;
+        }
+
+        return scanError;
     }
 
     private setRunResult(pageScanResult: OnDemandPageScanResult, state: OnDemandPageScanRunState, error?: string | ScanError): void {

--- a/packages/privacy-scan-runner/src/runner/runner.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.ts
@@ -187,10 +187,10 @@ export class Runner {
     }
 
     private convertToScanError(error: Error | BrowserError): ScanError {
-        const scanError = error as ScanError;
-        if (isEmpty(scanError.errorType)) {
-            scanError.errorType = 'InternalError';
-        }
+        const scanError: ScanError = {
+            errorType: 'InternalError',
+            ...error,
+        };
 
         return scanError;
     }

--- a/packages/privacy-scan-runner/src/runner/runner.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.ts
@@ -187,11 +187,9 @@ export class Runner {
     }
 
     private convertToScanError(error: Error | BrowserError): ScanError {
-        let scanError = null;
-        if (typeof error === typeof Error) {
-            scanError = { errorType: 'InternalError' } as ScanError;
-        } else {
-            scanError = error as ScanError;
+        const scanError = error as ScanError;
+        if (isEmpty(scanError.errorType)) {
+            scanError.errorType = 'InternalError';
         }
 
         return scanError;


### PR DESCRIPTION
#### Details
A previous change serialized a BrowserError to string before passing it into Runner.setRunResult. This had the unintended side effect of resulting in all BrowserErrors being reported as InternalError, instead of being mapped to the corresponding ScanRunErrorCode.

This change explicitly converts Error and BrowserError objects into ScanError objects before passing them to setRunResult. This works because both BrowserError and ScanError objects have an errorType member and the BrowserErrorTypes and ScanErrorTypes align. Error has no overlap with ScanError so it is mapped to InternalError - which is what the conversion handling would ultimately do with a string anyway.

For reference see also ScanResponseConverter.createFailedScanResponse and ScanErrorConverter.getScanRunErrorCode; this is the code path whereby a string | ScanError is converted into a ScanRunError for inclusion in a ScanResultResponse.

##### Motivation
Addresses internal bug 2007185 written against WCP.

##### Context
This was working before by a lucky loophole. We were passing a variable of type string | BrowserError into a type of string | ScanError. The string types on both sides allowed it to pass compile but then sneak through a BrowserError at runtime, which happened to be assignable and consumable as a ScanError.

I don't love this solution but it does make the luck and assumptions explicit, and it is narrowly scoped. Any change to the actual types defined for OnDemandPageScanResult or ScanResultResponse would have had a much wider ripple effect including the potential to affect a11y as well.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
