### PR TITLE
Revert CosmosDB nuget version

### DIFF
--- a/packages/web-workers/.vscode/tasks.json
+++ b/packages/web-workers/.vscode/tasks.json
@@ -41,7 +41,10 @@
         {
             "type": "shell",
             "label": "restore-dotnet-packages",
-            "command": "dotnet restore"
+            "command": "dotnet restore",
+            "options": {
+                "cwd": "${workspaceRoot}/dist"
+            }
         }
     ]
 }

--- a/packages/web-workers/extensions.csproj
+++ b/packages/web-workers/extensions.csproj
@@ -9,7 +9,7 @@ Licensed under the MIT License.
         <DefaultItemExcludes>**</DefaultItemExcludes>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.0.0" />
+        <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.8.1" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
     </ItemGroup>


### PR DESCRIPTION
#### Details

Revert CosmosDB nuget version after dependabot update as it currently breaks CosmosDB trigger functionality.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
