### PR TITLE
Fix xcopy path syntax for the Windows command.

### DIFF
--- a/packages/cli/.vscode/tasks.json
+++ b/packages/cli/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "label": "run",
             "dependsOn": "tsc",
             "windows": {
-                "command": "xcopy ./../crawler/dist/browser-imports.js ./dist /y"
+                "command": "xcopy .\\..\\crawler\\dist\\browser-imports.js .\\dist /y"
             },
             "osx": {
                 "command": "cp ./../crawler/dist/browser-imports.js ./dist"


### PR DESCRIPTION
#### Details

The xcopy path syntax for the Windows command in the run task was incorrect - used single forward slashes. The correct syntax is double backslashes.

##### Motivation

Allows the copy step to execute successfully when launching for debug in VSCode. This is not production-facing.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
