### PR TITLE
Quick and dirty fix for unhandled exception when running ai-scan --url

### DIFF
--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -232,7 +232,7 @@ export class Page {
                 timing[key] = `${this.pageNavigationTiming[key]}`;
             });
 
-            this.logger.logInfo(`Total page ${operation} time ${totalNavigationElapsed}, msec`, {
+            this.logger?.logInfo(`Total page ${operation} time ${totalNavigationElapsed}, msec`, {
                 total: totalNavigationElapsed.toString(),
                 ...timing,
             });


### PR DESCRIPTION
#### Details

Add null check to log statement.

##### Motivation

The logger is undefined when running the ai-scan CLI tool in --url mode (not crawling). This caused the tool to crash with an unhandled exception every time it was run. We probably did not detect this earlier because most consumers use the --crawl mode. However, "ai-scan --url <myurl>" is the first command example given in the readme, so it is a good idea to fix this.

##### Context

A nicer way to fix this would be to initialize a logger with a console client in ai-scan, but this is a more involved fix. For the immediate need this gets the job done. The existing code has the logger as optional and null checks throughout, so this scenario was probably imagined and just this statement omitted the null check unintentionally.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
