### PR TITLE
Add secret names for scan-behind-auth service account credentials.

### DIFF
--- a/packages/azure-services/src/key-vault/secret-names.ts
+++ b/packages/azure-services/src/key-vault/secret-names.ts
@@ -9,4 +9,6 @@ export const secretNames = {
     restApiSpSecret: 'restApiSpSecret',
     authorityUrl: 'authorityUrl',
     appInsightsApiKey: 'appInsightsApiKey',
+    scanBehindAuthUsername: 'scanBehindAuthUsername',
+    scanBehindAuthPassword: 'scanBehindAuthPassword',
 };

--- a/packages/azure-services/src/key-vault/secret-names.ts
+++ b/packages/azure-services/src/key-vault/secret-names.ts
@@ -10,5 +10,5 @@ export const secretNames = {
     authorityUrl: 'authorityUrl',
     appInsightsApiKey: 'appInsightsApiKey',
     scanBehindAuthUsername: 'scanBehindAuthUsername',
-    scanBehindAuthPassword: 'scanBehindAuthPassword',
+    azureServicePrincipalAuthClientPassword: 'scanBehindAuthPassword',
 };

--- a/packages/azure-services/src/key-vault/secret-names.ts
+++ b/packages/azure-services/src/key-vault/secret-names.ts
@@ -9,6 +9,6 @@ export const secretNames = {
     restApiSpSecret: 'restApiSpSecret',
     authorityUrl: 'authorityUrl',
     appInsightsApiKey: 'appInsightsApiKey',
-    scanBehindAuthUsername: 'scanBehindAuthUsername',
+    azureServicePrincipalAuthClientName: 'scanBehindAuthUsername',
     azureServicePrincipalAuthClientPassword: 'scanBehindAuthPassword',
 };


### PR DESCRIPTION
#### Details

Add values to secretNames for scanBehindAuthUsername and scanBehindAuthPassword. These correspond to the names of secrets in the service key vault. The secret value for scanBehindAuthUsername is expected to be the alias of a valid account to be used when scanning sites that require authentication. The secret value for scanBehindAuthPassword is the corresponding password for the account.

The secrets are configured manually on the key vault at or after creation time; since the key vault persists through redeployments this is not expected to add a maintenance burden.

##### Motivation

Allow the service to securely retrieve account credentials for authenticating sites at runtime.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
