### PR TITLE
feat(axe-core-4.6): Update to axe-core 4.6.3, enabling link-in-text-block, meta-viewport, and "Related paths" in reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "@npmcli/git": ">=2.1.0",
         "ansi-regex": "5.0.1",
         "async": ">=3.2.2",
-        "axe-core": "4.4.1",
+        "axe-core": "4.6.3",
         "glob-parent": ">=5.1.2",
         "json-schema": ">=0.4.0",
         "minimist": ">=1.2.6",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "tar": ">=6.1.9"
     },
     "dependencies": {
-        "accessibility-insights-report": "4.4.1"
+        "accessibility-insights-report": "4.6.3"
     },
     "packageManager": "yarn@3.2.2"
 }

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "accessibility-insights-report": "4.4.1",
-        "axe-core": "4.4.1",
+        "axe-core": "4.6.3",
         "common": "workspace:*",
         "inversify": "^6.0.1",
         "lodash": "^4.17.21",

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -34,7 +34,7 @@
         "typescript": "^4.9.4"
     },
     "dependencies": {
-        "accessibility-insights-report": "4.4.1",
+        "accessibility-insights-report": "4.6.3",
         "axe-core": "4.6.3",
         "common": "workspace:*",
         "inversify": "^6.0.1",

--- a/packages/axe-result-converter/src/__snapshots__/combined-report-data-converter.spec.ts.snap
+++ b/packages/axe-result-converter/src/__snapshots__/combined-report-data-converter.spec.ts.snap
@@ -18,6 +18,14 @@ Object {
                     "data": "check-data-node-31",
                     "id": "check-id-node-31",
                     "message": "check-message-node-31",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-31",
+                        "target": Array [
+                          "check-related-nodes-target-node-31",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-31",
@@ -47,6 +55,14 @@ Object {
                     "data": "check-data-node-32",
                     "id": "check-id-node-32",
                     "message": "check-message-node-32",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-32",
+                        "target": Array [
+                          "check-related-nodes-target-node-32",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-32",
@@ -75,6 +91,14 @@ Object {
                     "data": "check-data-node-33",
                     "id": "check-id-node-33",
                     "message": "check-message-node-33",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-33",
+                        "target": Array [
+                          "check-related-nodes-target-node-33",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-33",
@@ -107,6 +131,14 @@ Object {
                     "data": "check-data-node-12",
                     "id": "check-id-node-12",
                     "message": "check-message-node-12",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-12",
+                        "target": Array [
+                          "check-related-nodes-target-node-12",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-12",
@@ -135,6 +167,14 @@ Object {
                     "data": "check-data-node-22",
                     "id": "check-id-node-22",
                     "message": "check-message-node-22",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-22",
+                        "target": Array [
+                          "check-related-nodes-target-node-22",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-22",
@@ -167,6 +207,14 @@ Object {
                     "data": "check-data-node-41",
                     "id": "check-id-node-41",
                     "message": "check-message-node-41",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-41",
+                        "target": Array [
+                          "check-related-nodes-target-node-41",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-41",
@@ -206,6 +254,14 @@ Object {
                     "data": "check-data-node-11",
                     "id": "check-id-node-11",
                     "message": "check-message-node-11",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-11",
+                        "target": Array [
+                          "check-related-nodes-target-node-11",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-11",
@@ -301,6 +357,14 @@ Object {
                     "data": "check-data-node-1",
                     "id": "check-id-node-1",
                     "message": "check-message-node-1",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-1",
+                        "target": Array [
+                          "check-related-nodes-target-node-1",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-1",
@@ -330,6 +394,14 @@ Object {
                     "data": "check-data-node-2",
                     "id": "check-id-node-2",
                     "message": "check-message-node-2",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-2",
+                        "target": Array [
+                          "check-related-nodes-target-node-2",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-2",
@@ -358,6 +430,14 @@ Object {
                     "data": "check-data-node-3",
                     "id": "check-id-node-3",
                     "message": "check-message-node-3",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-3",
+                        "target": Array [
+                          "check-related-nodes-target-node-3",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-3",
@@ -386,6 +466,14 @@ Object {
                     "data": "check-data-node-4",
                     "id": "check-id-node-4",
                     "message": "check-message-node-4",
+                    "relatedNodes": Array [
+                      Object {
+                        "html": "check-related-nodes-html-node-4",
+                        "target": Array [
+                          "check-related-nodes-target-node-4",
+                        ],
+                      },
+                    ],
                   },
                 ],
                 "failureSummary": "failureSummary-node-4",

--- a/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
+++ b/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
@@ -33,6 +33,10 @@ const getAccumulatedNode = (nodeId: string) => {
                 id: `check-id-${nodeId}`,
                 data: `check-data-${nodeId}`,
                 message: `check-message-${nodeId}`,
+                relatedNodes: [{
+                    target: [`check-related-nodes-target-${nodeId}`],
+                    html: `check-related-nodes-html-${nodeId}`
+                }]
             },
         ],
         all: [],

--- a/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
+++ b/packages/axe-result-converter/src/combined-report-data-converter.spec.ts
@@ -33,10 +33,12 @@ const getAccumulatedNode = (nodeId: string) => {
                 id: `check-id-${nodeId}`,
                 data: `check-data-${nodeId}`,
                 message: `check-message-${nodeId}`,
-                relatedNodes: [{
-                    target: [`check-related-nodes-target-${nodeId}`],
-                    html: `check-related-nodes-html-${nodeId}`
-                }]
+                relatedNodes: [
+                    {
+                        target: [`check-related-nodes-target-${nodeId}`],
+                        html: `check-related-nodes-html-${nodeId}`,
+                    },
+                ],
             },
         ],
         all: [],

--- a/packages/axe-result-converter/src/combined-report-data-converter.ts
+++ b/packages/axe-result-converter/src/combined-report-data-converter.ts
@@ -136,6 +136,7 @@ export class CombinedReportDataConverter {
                     id: nodeCheckResult?.id,
                     message: nodeCheckResult?.message,
                     data: nodeCheckResult?.data,
+                    relatedNodes: nodeCheckResult?.relatedNodes,
                 });
             }
         }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
         "ajv": "^8.11.2",
         "apify": "^2.3.2",
         "applicationinsights": "^2.3.1",
-        "axe-core": "4.4.1",
+        "axe-core": "4.6.3",
         "browser-pool": "^3.1.4",
         "cli-spinner": "^0.2.10",
         "convict": "^6.2.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
         "@axe-core/puppeteer": "^4.5.0",
         "@medv/finder": "^2.1.0",
         "@sindresorhus/fnv1a": "^2.0.1",
-        "accessibility-insights-report": "4.4.1",
+        "accessibility-insights-report": "4.6.3",
         "ajv": "^8.11.2",
         "apify": "^2.3.2",
         "applicationinsights": "^2.3.1",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -43,7 +43,7 @@
     "dependencies": {
         "@axe-core/puppeteer": "^4.5.0",
         "@medv/finder": "^2.1.0",
-        "accessibility-insights-report": "4.4.1",
+        "accessibility-insights-report": "4.6.3",
         "apify": "^2.3.2",
         "axe-core": "4.6.3",
         "browser-pool": "^3.1.4",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -45,7 +45,7 @@
         "@medv/finder": "^2.1.0",
         "accessibility-insights-report": "4.4.1",
         "apify": "^2.3.2",
-        "axe-core": "4.4.1",
+        "axe-core": "4.6.3",
         "browser-pool": "^3.1.4",
         "common": "workspace:*",
         "dotenv": "^16.0.1",

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@axe-core/puppeteer": "^4.5.0",
-        "axe-core": "4.4.1",
+        "axe-core": "4.6.3",
         "common": "workspace:*",
         "inversify": "^6.0.1",
         "lodash": "^4.17.21",

--- a/packages/scanner-global-library/src/factories/rule-exclusion.ts
+++ b/packages/scanner-global-library/src/factories/rule-exclusion.ts
@@ -33,7 +33,6 @@ export class RuleExclusion {
         'landmark-no-duplicate-main',
         'landmark-one-main',
         'landmark-unique',
-        'meta-viewport',
         'meta-viewport-large',
         'no-autoplay-audio',
         'p-as-heading',

--- a/packages/scanner-global-library/src/factories/rule-exclusion.ts
+++ b/packages/scanner-global-library/src/factories/rule-exclusion.ts
@@ -33,7 +33,6 @@ export class RuleExclusion {
         'landmark-no-duplicate-main',
         'landmark-one-main',
         'landmark-unique',
-        'link-in-text-block',
         'meta-viewport',
         'meta-viewport-large',
         'no-autoplay-audio',

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -44,7 +44,7 @@
         "@azure/functions": "^3.5.0",
         "@azure/identity": "^3.1.2",
         "@azure/storage-blob": "^12.12.0",
-        "accessibility-insights-report": "4.4.1",
+        "accessibility-insights-report": "4.6.3",
         "async-mutex": "^0.3.2",
         "axe-core": "4.6.3",
         "axe-result-converter": "workspace:*",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -46,7 +46,7 @@
         "@azure/storage-blob": "^12.12.0",
         "accessibility-insights-report": "4.4.1",
         "async-mutex": "^0.3.2",
-        "axe-core": "4.4.1",
+        "axe-core": "4.6.3",
         "axe-result-converter": "workspace:*",
         "azure-services": "workspace:*",
         "common": "workspace:*",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -54,7 +54,7 @@
         "accessibility-insights-report": "4.4.1",
         "apify": "^2.3.2",
         "applicationinsights": "^2.3.1",
-        "axe-core": "4.4.1",
+        "axe-core": "4.6.3",
         "axe-result-converter": "workspace:*",
         "axe-sarif-converter": "^2.9.0",
         "azure-services": "workspace:*",
@@ -80,7 +80,7 @@
         "yargs": "^17.6.2"
     },
     "resolutions": {
-        "axe-core": "4.4.1"
+        "axe-core": "4.6.3"
     },
     "overrides": {
         "apify": {

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -51,7 +51,7 @@
         "@axe-core/puppeteer": "^4.5.0",
         "@azure/cosmos": "^3.17.2",
         "accessibility-insights-crawler": "workspace:*",
-        "accessibility-insights-report": "4.4.1",
+        "accessibility-insights-report": "4.6.3",
         "apify": "^2.3.2",
         "applicationinsights": "^2.3.1",
         "axe-core": "4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3999,7 +3999,7 @@ __metadata:
     "@types/puppeteer": ^5.4.6
     accessibility-insights-report: 4.4.1
     apify: ^2.3.2
-    axe-core: 4.4.1
+    axe-core: 4.6.3
     browser-pool: ^3.1.4
     common: "workspace:*"
     dotenv: ^16.0.1
@@ -4063,7 +4063,7 @@ __metadata:
     ajv: ^8.11.2
     apify: ^2.3.2
     applicationinsights: ^2.3.1
-    axe-core: 4.4.1
+    axe-core: 4.6.3
     axe-result-converter: "workspace:*"
     browser-pool: ^3.1.4
     cli-spinner: ^0.2.10
@@ -4741,10 +4741,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:4.4.1":
-  version: 4.4.1
-  resolution: "axe-core@npm:4.4.1"
-  checksum: ad14c5b71059dc3d24ef2519b8cd96e98b4a572379396201ce449d1c4262181821d6ca9550df65b22371faf06d28bbe94d391fe5675f2a08e6550f7b5da8416d
+"axe-core@npm:4.6.3":
+  version: 4.6.3
+  resolution: "axe-core@npm:4.6.3"
+  checksum: d0c46be92b9707c48b88a53cd5f471b155a2bfc8bf6beffb514ecd14e30b4863e340b5fc4f496d82a3c562048088c1f3ff5b93b9b3b026cb9c3bfacfd535da10
   languageName: node
   linkType: hard
 
@@ -4756,7 +4756,7 @@ __metadata:
     "@types/lodash": ^4.14.182
     "@types/node": ^16.18.11
     accessibility-insights-report: 4.4.1
-    axe-core: 4.4.1
+    axe-core: 4.6.3
     common: "workspace:*"
     inversify: ^6.0.1
     jest: ^27.5.1
@@ -13029,7 +13029,7 @@ __metadata:
     "@types/lodash": ^4.14.182
     "@types/node": ^16.18.11
     "@types/puppeteer": ^5.4.6
-    axe-core: 4.4.1
+    axe-core: 4.6.3
     common: "workspace:*"
     cpy-cli: ^4.1.0
     inversify: ^6.0.1
@@ -13192,7 +13192,7 @@ __metadata:
     "@types/yargs": ^17.0.18
     accessibility-insights-report: 4.4.1
     async-mutex: ^0.3.2
-    axe-core: 4.4.1
+    axe-core: 4.6.3
     axe-result-converter: "workspace:*"
     azure-services: "workspace:*"
     common: "workspace:*"
@@ -14963,7 +14963,7 @@ __metadata:
     accessibility-insights-report: 4.4.1
     apify: ^2.3.2
     applicationinsights: ^2.3.1
-    axe-core: 4.4.1
+    axe-core: 4.6.3
     axe-result-converter: "workspace:*"
     axe-sarif-converter: ^2.9.0
     azure-services: "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3997,7 +3997,7 @@ __metadata:
     "@types/levelup": ^5.1.1
     "@types/node": ^16.18.11
     "@types/puppeteer": ^5.4.6
-    accessibility-insights-report: 4.4.1
+    accessibility-insights-report: 4.6.3
     apify: ^2.3.2
     axe-core: 4.6.3
     browser-pool: ^3.1.4
@@ -4025,20 +4025,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"accessibility-insights-report@npm:4.4.1":
-  version: 4.4.1
-  resolution: "accessibility-insights-report@npm:4.4.1"
+"accessibility-insights-report@npm:4.6.3":
+  version: 4.6.3
+  resolution: "accessibility-insights-report@npm:4.6.3"
   dependencies:
     "@fluentui/react": ^8.96.1
-    axe-core: 4.4.1
+    axe-core: 4.6.3
     classnames: ^2.3.2
     lodash: ^4.17.21
-    luxon: ^3.1.1
+    luxon: ^3.2.1
     react: ^16.14.0
     react-dom: ^16.14.0
     react-helmet: ^6.1.0
     uuid: ^9.0.0
-  checksum: d63df40f517184dd80fb32796efc8c10ec1dbb6a68a8401776cfdb20e1295434896a529faf8172bafdf384dc6c8f29a9e00a96e0dd9f213027bf9c9211a65442
+  checksum: 34ba89cd5b1fbe1e2e126212148f5c4728c2dd31085e0ee97bb3ef3bc46e1cbb9c54c6f9fb5762fe152bdb4e54edc95593123d565d33ce0bc378fdf9f2d44e7a
   languageName: node
   linkType: hard
 
@@ -4059,7 +4059,7 @@ __metadata:
     "@types/puppeteer": ^5.4.6
     "@types/table": ^6.3.2
     accessibility-insights-crawler: "workspace:*"
-    accessibility-insights-report: 4.4.1
+    accessibility-insights-report: 4.6.3
     ajv: ^8.11.2
     apify: ^2.3.2
     applicationinsights: ^2.3.1
@@ -4125,7 +4125,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.48.1
     "@typescript-eslint/eslint-plugin-tslint": ^5.48.1
     "@typescript-eslint/parser": ^5.48.1
-    accessibility-insights-report: 4.4.1
+    accessibility-insights-report: 4.6.3
     combine-dependabot-prs: ^1.0.5
     commander: ^9.4.1
     eslint: ^7.32.0
@@ -4755,7 +4755,7 @@ __metadata:
     "@types/jest": ^27.4.1
     "@types/lodash": ^4.14.182
     "@types/node": ^16.18.11
-    accessibility-insights-report: 4.4.1
+    accessibility-insights-report: 4.6.3
     axe-core: 4.6.3
     common: "workspace:*"
     inversify: ^6.0.1
@@ -10427,7 +10427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"luxon@npm:^3.1.1":
+"luxon@npm:^3.2.1":
   version: 3.2.1
   resolution: "luxon@npm:3.2.1"
   checksum: 3fa3def2c5f5d3032b4c46220c4da8aeb467ac979888fc9d2557adcd22195f93516b4ad5909a75862bec8dc6ddc0953b0f38e6d2f4a8ab8450ddc531a83cf20d
@@ -13190,7 +13190,7 @@ __metadata:
     "@types/puppeteer": ^5.4.6
     "@types/sha.js": ^2.4.0
     "@types/yargs": ^17.0.18
-    accessibility-insights-report: 4.4.1
+    accessibility-insights-report: 4.6.3
     async-mutex: ^0.3.2
     axe-core: 4.6.3
     axe-result-converter: "workspace:*"
@@ -14960,7 +14960,7 @@ __metadata:
     "@types/sha.js": ^2.4.0
     "@types/yargs": ^17.0.18
     accessibility-insights-crawler: "workspace:*"
-    accessibility-insights-report: 4.4.1
+    accessibility-insights-report: 4.6.3
     apify: ^2.3.2
     applicationinsights: ^2.3.1
     axe-core: 4.6.3


### PR DESCRIPTION
#### Details

This PR:

* Updates `axe-core` to v4.6.3
* Updates `accessibility-insights-report` to corresponding v4.6.3
* Removes `link-in-text-block` and `meta-viewport` from the rule exclusion list, matching the new AI4Web behavior enabling them as automated checks
* Enables a new report feature to include "Related paths" for failure cards of axe results with "relatedNodes" info by propogating this axe property in `combined-report-data-converter.ts`
* Bumps the `accessibility-insights-scan` minor version to `1.6.0` in anticipation of a corresponding release for that package

Screenshot of combined report segment with new Related paths UX generated using the following CLI command in this PR branch: `node C:\repos\accessibility-insights-service\packages\cli\dist\ai-scan-cli.js --crawl --url https://developer.microsoft.com/en-us/fluentui#/controls/web/detailslist --maxUrls 5`

![screenshot highlighting new "Related paths" field in a failure card in a combined report](https://user-images.githubusercontent.com/376284/216456916-648a9aaa-c18e-4a6a-b8cd-b1b741d1799a.png)


##### Motivation

Keep service rules version in sync with AI4Web, which has begun release validation today for its corresponding release (2.37.0)

##### Context

* [web 4.6.3 PR (#6334)](https://github.com/microsoft/accessibility-insights-web/pull/6334)
* [web "Related paths" PR with screenshots of new report UI (#6388)](https://github.com/microsoft/accessibility-insights-web/pull/6388)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: 2017450
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
