### PR TITLE
chore: Update CLI README to document authentication options

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -233,3 +233,24 @@ If the results do not match the baseline file, a new baseline will be written to
 type: boolean
 describe: Use with --baselineFile to update the baseline file in-place, rather than writing any updated baseline to the output directory.
 ```
+
+-   authType: --authType
+
+```sh
+type: string
+describe: For sites with authenticated pages, specify the authentication type. The CLI currently supports "AAD" (Azure Active Directory). Use with --serviceAccountName and --serviceAccountPassword.
+```
+
+-   serviceAccountName: --serviceAccountName
+
+```sh
+type: string
+describe: For sites with authenticated pages, set the email address for the non-people service account.
+```
+
+-   serviceAccountPassword: --serviceAccountPassword
+
+```sh
+type: string
+describe: For sites with authenticated pages, set the password for the non-people service account.
+```


### PR DESCRIPTION
#### Details

Adds `authType`, `serviceAccountName`, and `serviceAccountPassword` to the CLI README.

##### Motivation

Document authentication options.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
