### PR TITLE
Bypass service worker on page load

### DIFF
--- a/packages/scanner-global-library/src/network/page-operation-handler.spec.ts
+++ b/packages/scanner-global-library/src/network/page-operation-handler.spec.ts
@@ -79,29 +79,6 @@ describe(PageOperationHandler, () => {
         expect(actualResponse).toEqual(expectedResponse);
     });
 
-    it('reload when no requests were intercepted', async () => {
-        let count = 0;
-        response = {
-            url: () => url,
-        } as Puppeteer.HTTPResponse;
-        pageOperation = () => {
-            if (count === 0) {
-                count++;
-
-                return Promise.resolve(null);
-            }
-
-            return Promise.resolve(response);
-        };
-        const expectedResponse = {
-            response,
-            navigationTiming: { goto: 100 } as PageNavigationTiming,
-        };
-
-        const actualResponse = await pageOperationHandler.invoke(pageOperation, puppeteerPageMock.object);
-        expect(actualResponse).toEqual(expectedResponse);
-    });
-
     it('override when request timeout', async () => {
         response = {
             url: () => url,
@@ -149,7 +126,7 @@ describe(PageOperationHandler, () => {
         pageRequestInterceptorMock
             .setup((o) => o.interceptedRequests)
             .returns(() => interceptedRequests)
-            .verifiable(Times.exactly(3));
+            .verifiable(Times.exactly(2));
         const expectedResponse = {
             response,
             navigationTiming: { goto: 100 } as PageNavigationTiming,

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -166,7 +166,9 @@ export class PageNavigator {
                 return await page.waitForNavigation({ waitUntil: 'networkidle0', timeout: puppeteerTimeoutConfig.networkIdleTimeoutMsec });
             } catch (error) {
                 this.logger?.logWarn(
-                    `Page still has network activity after ${puppeteerTimeoutConfig.networkIdleTimeoutMsec / 1000} secs.`,
+                    `Page still has network activity or stale requests after waiting for ${
+                        puppeteerTimeoutConfig.networkIdleTimeoutMsec / 1000
+                    } secs.`,
                     {
                         timeout: `${puppeteerTimeoutConfig.networkIdleTimeoutMsec}`,
                         error: System.serializeError(error),

--- a/packages/scanner-global-library/src/page-timeout-config.ts
+++ b/packages/scanner-global-library/src/page-timeout-config.ts
@@ -44,6 +44,8 @@ export const puppeteerTimeoutConfig = {
 
     /**
      * Maximum wait time, in milliseconds, to scroll to the bottom of the page.
+     *
+     * Do not decrease scroll timeout as it will break accessibility scan for long pages.
      */
     scrollTimeoutMsec: 30000,
 


### PR DESCRIPTION
#### Details

Bypass service worker on page load to intercept page navigation network trace.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
