### PR TITLE
Fixed puppeteer launch args

### DIFF
--- a/packages/crawler/src/crawler/site-crawler-engine.spec.ts
+++ b/packages/crawler/src/crawler/site-crawler-engine.spec.ts
@@ -93,7 +93,7 @@ describe(SiteCrawlerEngine, () => {
             launchContext: {
                 launcher: puppeteerExtraMock.object,
                 launchOptions: {
-                    ignoreDefaultArgs: puppeteerDefaultOptions,
+                    args: puppeteerDefaultOptions,
                     defaultViewport: {
                         width: 1920,
                         height: 1080,

--- a/packages/crawler/src/crawler/site-crawler-engine.ts
+++ b/packages/crawler/src/crawler/site-crawler-engine.ts
@@ -20,6 +20,11 @@ import { CrawlerConfiguration } from './crawler-configuration';
 import { CrawlerFactory } from './crawler-factory';
 import { CrawlerEngine } from './crawler-engine';
 
+const windowSize = {
+    width: 1920,
+    height: 1080,
+};
+
 @injectable()
 export class SiteCrawlerEngine implements CrawlerEngine {
     public constructor(
@@ -60,10 +65,9 @@ export class SiteCrawlerEngine implements CrawlerEngine {
             launchContext: {
                 launcher: this.puppeteerExtra,
                 launchOptions: {
-                    ignoreDefaultArgs: puppeteerDefaultOptions,
+                    args: puppeteerDefaultOptions,
                     defaultViewport: {
-                        width: 1920,
-                        height: 1080,
+                        ...windowSize,
                         deviceScaleFactor: 1,
                     },
                     executablePath: crawlerRunOptions.chromePath ?? this.puppeteer.executablePath(),


### PR DESCRIPTION
#### Details

Fixed puppeteer launch args to ensure they are pass to the browser's command line.

##### Motivation

Addresses issue #2437

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: Fixes #2437
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
