### PR TITLE
Moved scan request query limit from DB to service process

### DIFF
--- a/packages/report-generator-job-manager/src/worker/worker.spec.ts
+++ b/packages/report-generator-job-manager/src/worker/worker.spec.ts
@@ -259,7 +259,7 @@ describe(Worker, () => {
             statusCode: 200,
         };
         reportGeneratorRequestProviderMock
-            .setup((o) => o.readScanGroupIds(failedScanRetryIntervalInMinutes, poolLoadSnapshot.tasksIncrementCountPerInterval, undefined))
+            .setup((o) => o.readScanGroupIds(failedScanRetryIntervalInMinutes, undefined))
             .returns(() => Promise.resolve(cosmosOperationResponse))
             .verifiable();
 
@@ -283,8 +283,7 @@ describe(Worker, () => {
     });
 
     it('get report requests for new scan report groups only', async () => {
-        const poolLoadSnapshot = setupPoolLoadSnapshot();
-
+        setupPoolLoadSnapshot();
         reportRequestGenerator.queueMessagesGeneratorFn()();
         const scanReportGroups = reportRequestGenerator.scanMessages.map((m) => {
             return {
@@ -303,7 +302,7 @@ describe(Worker, () => {
             statusCode: 200,
         };
         reportGeneratorRequestProviderMock
-            .setup((o) => o.readScanGroupIds(failedScanRetryIntervalInMinutes, poolLoadSnapshot.tasksIncrementCountPerInterval, undefined))
+            .setup((o) => o.readScanGroupIds(failedScanRetryIntervalInMinutes, undefined))
             .returns(() => Promise.resolve(cosmosOperationResponse))
             .verifiable();
 

--- a/packages/report-generator-job-manager/src/worker/worker.ts
+++ b/packages/report-generator-job-manager/src/worker/worker.ts
@@ -116,13 +116,12 @@ export class Worker extends BatchTaskCreator {
         );
     }
 
-    private async readReportMessages(requestCount: number): Promise<ScanReportGroup[]> {
+    private async readReportMessages(maxMessages: number): Promise<ScanReportGroup[]> {
         const reportMessages: ScanReportGroup[] = [];
         let continuationToken: string;
         do {
             const response: CosmosOperationResponse<ScanReportGroup[]> = await this.reportGeneratorRequestProvider.readScanGroupIds(
                 this.runDurationInMinutes,
-                requestCount,
                 continuationToken,
             );
             client.ensureSuccessStatusCode(response);
@@ -131,9 +130,9 @@ export class Worker extends BatchTaskCreator {
             if (response.item?.length > 0) {
                 reportMessages.push(...response.item);
             }
-        } while (reportMessages.length < requestCount && continuationToken !== undefined);
+        } while (reportMessages.length < maxMessages && continuationToken !== undefined);
 
-        return reportMessages;
+        return reportMessages.slice(0, maxMessages);
     }
 
     private reduceReportMessages(reportRequests: ScanReportGroup[]): ScanReportGroup[] {

--- a/packages/report-generator-runner/src/report-processor/report-processor.ts
+++ b/packages/report-generator-runner/src/report-processor/report-processor.ts
@@ -55,7 +55,7 @@ export class ReportProcessor {
     private async generateReport(targetReportProcessor: TargetReportProcessor, queuedRequest: QueuedRequest): Promise<QueuedRequest> {
         let pageScanResult: OnDemandPageScanResult;
         try {
-            this.logger.logInfo(`Generating accessibility consolidated report.`, {
+            this.logger.logInfo(`Generating consolidated report.`, {
                 scanId: queuedRequest.request.scanId,
                 scanGroupId: queuedRequest.request.scanGroupId,
             });
@@ -65,7 +65,7 @@ export class ReportProcessor {
 
             this.setRunResult(pageScanResult, 'completed');
             queuedRequest.condition = 'completed';
-            this.logger.logInfo(`The accessibility consolidated report generated successfully.`, {
+            this.logger.logInfo(`The consolidated report generated successfully.`, {
                 scanId: queuedRequest.request.scanId,
                 scanGroupId: queuedRequest.request.scanGroupId,
             });

--- a/packages/report-generator-runner/src/runner/request-selector.spec.ts
+++ b/packages/report-generator-runner/src/runner/request-selector.spec.ts
@@ -18,7 +18,8 @@ const scanGroupId = 'scanGroupId';
 let reportGeneratorRequestProviderMock: IMock<ReportGeneratorRequestProvider>;
 let serviceConfigMock: IMock<ServiceConfiguration>;
 let requestSelector: RequestSelector;
-let queryCount: number;
+let maxRequestsToProcess: number;
+let maxRequestsToDelete: number;
 let dateNow: Date;
 
 describe(RequestSelector, () => {
@@ -26,7 +27,8 @@ describe(RequestSelector, () => {
         dateNow = new Date();
         MockDate.set(dateNow);
 
-        queryCount = 10;
+        maxRequestsToProcess = 10;
+        maxRequestsToDelete = 20;
 
         reportGeneratorRequestProviderMock = Mock.ofType<ReportGeneratorRequestProvider>();
         serviceConfigMock = Mock.ofType<ServiceConfiguration>();
@@ -106,7 +108,7 @@ describe(RequestSelector, () => {
             continuationToken,
         };
         reportGeneratorRequestProviderMock
-            .setup((o) => o.readRequests(scanGroupId, queryCount, undefined))
+            .setup((o) => o.readRequests(scanGroupId, undefined))
             .returns(() => Promise.resolve(response1 as CosmosOperationResponse<ReportGeneratorRequest[]>))
             .verifiable();
 
@@ -115,7 +117,7 @@ describe(RequestSelector, () => {
             statusCode: 200,
         };
         reportGeneratorRequestProviderMock
-            .setup((o) => o.readRequests(scanGroupId, queryCount, continuationToken))
+            .setup((o) => o.readRequests(scanGroupId, continuationToken))
             .returns(() => Promise.resolve(response2 as CosmosOperationResponse<ReportGeneratorRequest[]>))
             .verifiable();
 
@@ -132,7 +134,7 @@ describe(RequestSelector, () => {
             ],
         };
 
-        const result = await requestSelector.getQueuedRequests(scanGroupId, queryCount);
+        const result = await requestSelector.getQueuedRequests(scanGroupId, maxRequestsToProcess, maxRequestsToDelete);
 
         expect(result.requestsToDelete).toEqual(filteredRequests.requestsToDelete);
         expect(result.requestsToProcess).toEqual(filteredRequests.requestsToProcess);

--- a/packages/report-generator-runner/src/runner/runner.spec.ts
+++ b/packages/report-generator-runner/src/runner/runner.spec.ts
@@ -328,7 +328,7 @@ function setupDeleteRequests(queuedRequests: ReportGeneratorRequest[]): void {
 
 function setupGetQueuedRequests(queuedRequests: QueuedRequests): void {
     requestSelectorMock
-        .setup((o) => o.getQueuedRequests(reportGeneratorMetadata.scanGroupId, maxQueuedRequests, runner.maxRequestsToDelete))
+        .setup((o) => o.getQueuedRequests(reportGeneratorMetadata.scanGroupId, maxQueuedRequests, (runner as any).maxRequestsToDelete))
         .returns(() => Promise.resolve(queuedRequests))
         .verifiable();
 }

--- a/packages/report-generator-runner/src/runner/runner.spec.ts
+++ b/packages/report-generator-runner/src/runner/runner.spec.ts
@@ -16,6 +16,8 @@ import { ReportProcessor } from '../report-processor/report-processor';
 import { RequestSelector, QueuedRequests, QueuedRequest, DispatchCondition } from './request-selector';
 import { Runner } from './runner';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 const maxQueuedRequests = 10;
 
 interface ReportGeneratorRequestMockType extends ReportGeneratorRequest {
@@ -94,7 +96,7 @@ describe(Runner, () => {
             reportGeneratorRunnerTelemetryManagerMock.object,
             loggerMock.object,
         );
-        runner.maxQueuedRequests = maxQueuedRequests;
+        (runner as any).maxRequestsToMerge = maxQueuedRequests;
     });
 
     afterEach(() => {
@@ -326,7 +328,7 @@ function setupDeleteRequests(queuedRequests: ReportGeneratorRequest[]): void {
 
 function setupGetQueuedRequests(queuedRequests: QueuedRequests): void {
     requestSelectorMock
-        .setup((o) => o.getQueuedRequests(reportGeneratorMetadata.scanGroupId, maxQueuedRequests))
+        .setup((o) => o.getQueuedRequests(reportGeneratorMetadata.scanGroupId, maxQueuedRequests, runner.maxRequestsToDelete))
         .returns(() => Promise.resolve(queuedRequests))
         .verifiable();
 }

--- a/packages/report-generator-runner/src/runner/runner.ts
+++ b/packages/report-generator-runner/src/runner/runner.ts
@@ -26,7 +26,9 @@ import { RequestSelector, QueuedRequest, QueuedRequests } from './request-select
 
 @injectable()
 export class Runner {
-    public maxQueuedRequests = 10;
+    public readonly maxRequestsToMerge = 10;
+
+    public readonly maxRequestsToDelete = 100;
 
     constructor(
         @inject(RunMetadataConfig) private readonly runMetadataConfig: RunMetadataConfig,
@@ -46,7 +48,11 @@ export class Runner {
 
         this.telemetryManager.trackRequestStarted(runMetadata.id);
         try {
-            const queuedRequests = await this.requestSelector.getQueuedRequests(runMetadata.scanGroupId, this.maxQueuedRequests);
+            const queuedRequests = await this.requestSelector.getQueuedRequests(
+                runMetadata.scanGroupId,
+                this.maxRequestsToMerge,
+                this.maxRequestsToDelete,
+            );
             this.logger.logInfo('Selecting report generator requests from a queue.', {
                 toProcess: queuedRequests.requestsToProcess.length.toString(),
                 toDelete: queuedRequests.requestsToDelete.length.toString(),

--- a/packages/report-generator-runner/src/runner/runner.ts
+++ b/packages/report-generator-runner/src/runner/runner.ts
@@ -26,9 +26,9 @@ import { RequestSelector, QueuedRequest, QueuedRequests } from './request-select
 
 @injectable()
 export class Runner {
-    public readonly maxRequestsToMerge = 10;
+    private readonly maxRequestsToMerge = 10;
 
-    public readonly maxRequestsToDelete = 100;
+    private readonly maxRequestsToDelete = 100;
 
     constructor(
         @inject(RunMetadataConfig) private readonly runMetadataConfig: RunMetadataConfig,

--- a/packages/resource-deployment/scripts/function-app-create.sh
+++ b/packages/resource-deployment/scripts/function-app-create.sh
@@ -77,7 +77,7 @@ installAzureFunctionsCoreToolsOnLinux() {
     sudo apt-get update -y
 
     # Install the Core Tools package
-    sudo apt-get install azure-functions-core-tools-4=4.0.3971-1 -y
+    sudo apt-get install azure-functions-core-tools-4 -y
     echo "Azure Functions Core Tools installed successfully"
 }
 

--- a/packages/resource-deployment/templates/blob-storage.template.json
+++ b/packages/resource-deployment/templates/blob-storage.template.json
@@ -80,7 +80,7 @@
         {
             "name": "[parameters('storageAccountName')]",
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2018-07-01",
+            "apiVersion": "2022-09-01",
             "location": "[parameters('location')]",
             "kind": "[parameters('storageAccountKind')]",
             "sku": {
@@ -112,31 +112,31 @@
                 {
                     "name": "[concat('default/', parameters('poolStartupScriptContainerName'))]",
                     "type": "blobServices/containers",
-                    "apiVersion": "2018-07-01",
+                    "apiVersion": "2022-09-01",
                     "dependsOn": ["[parameters('storageAccountName')]"]
                 },
                 {
                     "name": "[concat('default/', parameters('runtimeConfigurationContainerName'))]",
                     "type": "blobServices/containers",
-                    "apiVersion": "2018-07-01",
+                    "apiVersion": "2022-09-01",
                     "dependsOn": ["[parameters('storageAccountName')]"]
                 },
                 {
                     "name": "[concat('default/', parameters('pageScanRunReportContainerName'))]",
                     "type": "blobServices/containers",
-                    "apiVersion": "2018-07-01",
+                    "apiVersion": "2022-09-01",
                     "dependsOn": ["[parameters('storageAccountName')]"]
                 },
                 {
                     "name": "[concat('default/', parameters('combinedResultsContainerName'))]",
                     "type": "blobServices/containers",
-                    "apiVersion": "2018-07-01",
+                    "apiVersion": "2022-09-01",
                     "dependsOn": ["[parameters('storageAccountName')]"]
                 },
                 {
                     "name": "[concat('default/', parameters('batchLogsContainerName'))]",
                     "type": "blobServices/containers",
-                    "apiVersion": "2018-07-01",
+                    "apiVersion": "2022-09-01",
                     "dependsOn": ["[parameters('storageAccountName')]"],
                     "properties": {
                         "deleteRetentionPolicy": {
@@ -150,7 +150,7 @@
         {
             "name": "[concat(parameters('storageAccountName'), '/default')]",
             "type": "Microsoft.Storage/storageAccounts/managementPolicies",
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-09-01",
             "dependsOn": ["[parameters('storageAccountName')]"],
             "properties": {
                 "policy": {

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
@@ -57,7 +57,7 @@ export class CombinedScanResultProcessor {
         const length = Buffer.byteLength(JSON.stringify(combinedResultsBlob), 'utf8');
         if (length > this.maxCombinedResultsBlobSize) {
             this.logger.logError(
-                `Failure to generate combined scan result. Combined scan result blob exceeds maximum supported size of ${
+                `Failure to generate combined scan result. Combined scan result blob exceeded maximum supported size of ${
                     this.maxCombinedResultsBlobSize / (1024 * 1024)
                 } MB.`,
             );

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
@@ -18,6 +18,8 @@ export class CombinedScanResultProcessor {
 
     private readonly msecBetweenRetries: number = 1000;
 
+    private readonly maxCombinedResultsBlobSize = 50 * 1024 * 1024;
+
     constructor(
         @inject(CombinedAxeResultBuilder) protected readonly combinedAxeResultBuilder: CombinedAxeResultBuilder,
         @inject(CombinedReportGenerator) protected readonly combinedReportGenerator: CombinedReportGenerator,
@@ -51,6 +53,17 @@ export class CombinedScanResultProcessor {
             combinedResultsBlobId,
             websiteScanId: websiteScanRef.id,
         });
+
+        const length = Buffer.byteLength(JSON.stringify(combinedResultsBlob), 'utf8');
+        if (length > this.maxCombinedResultsBlobSize) {
+            this.logger.logError(
+                `Failure to generate combined scan result. Combined scan result blob exceeds maximum supported size of ${
+                    this.maxCombinedResultsBlobSize / (1024 * 1024)
+                } MB.`,
+            );
+
+            return;
+        }
 
         const combinedAxeResults = await this.combinedAxeResultBuilder.mergeAxeResults(axeScanResults.results, combinedResultsBlob);
         const generatedReport = this.combinedReportGenerator.generate(

--- a/packages/service-library/src/data-providers/page-scan-request-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-request-provider.spec.ts
@@ -54,7 +54,6 @@ describe(PageScanRequestProvider, () => {
             itemType: ItemType.onDemandPageScanRequest,
             partitionKey: PartitionKey.pageScanRequestDocuments,
         };
-        const itemCount = 5;
         const continuationToken = 'token1';
         const response = {
             continuationToken: 'token2',
@@ -64,11 +63,11 @@ describe(PageScanRequestProvider, () => {
         } as CosmosOperationResponse<OnDemandPageScanRequest[]>;
 
         cosmosContainerClientMock
-            .setup((o) => o.queryDocuments(getQuery(itemCount), continuationToken))
+            .setup((o) => o.queryDocuments(getQuery(), continuationToken))
             .returns(() => Promise.resolve(response))
             .verifiable();
 
-        const actualResponse = await testSubject.getRequests(continuationToken, itemCount);
+        const actualResponse = await testSubject.getRequests(continuationToken);
 
         cosmosContainerClientMock.verifyAll();
         expect(actualResponse).toBe(response);
@@ -92,14 +91,10 @@ describe(PageScanRequestProvider, () => {
         cosmosContainerClientMock.verifyAll();
     });
 
-    function getQuery(itemsCount: number): cosmos.SqlQuerySpec {
+    function getQuery(): cosmos.SqlQuerySpec {
         return {
-            query: 'SELECT TOP @itemsCount * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType ORDER BY c.priority DESC',
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType ORDER BY c.priority DESC',
             parameters: [
-                {
-                    name: '@itemsCount',
-                    value: itemsCount,
-                },
                 {
                     name: '@partitionKey',
                     value: PartitionKey.pageScanRequestDocuments,

--- a/packages/service-library/src/data-providers/page-scan-request-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-request-provider.ts
@@ -15,17 +15,10 @@ export class PageScanRequestProvider {
         private readonly cosmosContainerClient: CosmosContainerClient,
     ) {}
 
-    public async getRequests(
-        continuationToken?: string,
-        itemsCount: number = 100,
-    ): Promise<CosmosOperationResponse<OnDemandPageScanRequest[]>> {
+    public async getRequests(continuationToken?: string): Promise<CosmosOperationResponse<OnDemandPageScanRequest[]>> {
         const query = {
-            query: 'SELECT TOP @itemsCount * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType ORDER BY c.priority DESC',
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType ORDER BY c.priority DESC',
             parameters: [
-                {
-                    name: '@itemsCount',
-                    value: itemsCount,
-                },
                 {
                     name: '@partitionKey',
                     value: PartitionKey.pageScanRequestDocuments,

--- a/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
+++ b/packages/service-library/src/data-providers/report-generator-request-data-provider.ts
@@ -28,18 +28,10 @@ export class ReportGeneratorRequestProvider {
         @inject(GlobalLogger) private readonly logger: GlobalLogger,
     ) {}
 
-    public async readRequests(
-        scanGroupId: string,
-        itemCount: number = 100,
-        continuationToken?: string,
-    ): Promise<CosmosOperationResponse<ReportGeneratorRequest[]>> {
+    public async readRequests(scanGroupId: string, continuationToken?: string): Promise<CosmosOperationResponse<ReportGeneratorRequest[]>> {
         const query = {
-            query: 'SELECT TOP @itemCount * FROM c WHERE c.itemType = @itemType AND c.scanGroupId = @scanGroupId ORDER BY c.priority DESC',
+            query: 'SELECT * FROM c WHERE c.itemType = @itemType AND c.scanGroupId = @scanGroupId ORDER BY c.priority DESC',
             parameters: [
-                {
-                    name: '@itemCount',
-                    value: itemCount,
-                },
                 {
                     name: '@itemType',
                     value: ItemType.reportGeneratorRequest,
@@ -56,18 +48,13 @@ export class ReportGeneratorRequestProvider {
 
     public async readScanGroupIds(
         runDurationInMinutes: number,
-        itemCount: number = 100,
         continuationToken?: string,
     ): Promise<CosmosOperationResponse<ScanReportGroup[]>> {
         const query = {
-            query: `SELECT TOP @itemCount COUNT(1) as scanCount, t.scanGroupId, t.targetReport FROM (
+            query: `SELECT COUNT(1) as scanCount, t.scanGroupId, t.targetReport FROM (
                 SELECT * FROM c WHERE c.itemType = @itemType AND (NOT IS_DEFINED(c.run.state) OR c.run.state != "running" OR (c.run.state = "running" AND DateTimeToTimestamp(c.run.timestamp) < @availabilityTimestamp))
                 ) t GROUP BY t.scanGroupId, t.targetReport`,
             parameters: [
-                {
-                    name: '@itemCount',
-                    value: itemCount,
-                },
                 {
                     name: '@itemType',
                     value: ItemType.reportGeneratorRequest,

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
@@ -17,6 +17,7 @@ import { ScanRequestSelector, ScanRequests } from './scan-request-selector';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const accessabilityScanQueueName = 'accessabilityScanQueueName';
 const privacyScanQueueName = 'privacyScanQueueName';
+const maxRequestsToDelete = 100;
 
 let queueMock: IMock<Queue>;
 let pageScanRequestProviderMock: IMock<PageScanRequestProvider>;
@@ -342,7 +343,7 @@ function setupPageScanRequestProvider(scanRequests: ScanRequests): void {
 
 function setupScanRequestSelector(scanRequests: ScanRequests): void {
     scanRequestSelectorMock
-        .setup((o) => o.getRequests(maxQueueSize - accessibilityMessageCount, maxQueueSize - privacyMessageCount))
+        .setup((o) => o.getRequests(maxQueueSize - accessibilityMessageCount, maxQueueSize - privacyMessageCount, maxRequestsToDelete))
         .returns(() => Promise.resolve(scanRequests))
         .verifiable();
 }

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -18,6 +18,8 @@ import { ScanRequestSelector, ScanRequest, DispatchCondition } from './scan-requ
 /* eslint-disable max-len */
 @injectable()
 export class OnDemandDispatcher {
+    public readonly maxRequestsToDelete = 100;
+
     constructor(
         @inject(Queue) private readonly queue: Queue,
         @inject(PageScanRequestProvider) private readonly pageScanRequestProvider: PageScanRequestProvider,
@@ -48,6 +50,7 @@ export class OnDemandDispatcher {
         const scanRequests = await this.scanRequestSelector.getRequests(
             configQueueSize - accessibilityCurrentQueueSize,
             configQueueSize - privacyCurrentQueueSize,
+            this.maxRequestsToDelete,
         );
         await this.addScanRequests(scanRequests.accessibilityRequestsToQueue, this.storageConfig.scanQueue);
         await this.addScanRequests(scanRequests.privacyRequestsToQueue, this.storageConfig.privacyScanQueue);

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -18,7 +18,7 @@ import { ScanRequestSelector, ScanRequest, DispatchCondition } from './scan-requ
 /* eslint-disable max-len */
 @injectable()
 export class OnDemandDispatcher {
-    public readonly maxRequestsToDelete = 100;
+    private readonly maxRequestsToDelete = 100;
 
     constructor(
         @inject(Queue) private readonly queue: Queue,


### PR DESCRIPTION
#### Details

Moved scan request query limit from DB to service process to avoid stale/abandon requests.
Restricted maximum blob size of consolidated accessibility scan results.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
