### PR TITLE
Added workaround to restore actual user agent string

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/crawler/src/crawler/site-crawler-engine.ts
+++ b/packages/crawler/src/crawler/site-crawler-engine.ts
@@ -20,6 +20,8 @@ import { CrawlerConfiguration } from './crawler-configuration';
 import { CrawlerFactory } from './crawler-factory';
 import { CrawlerEngine } from './crawler-engine';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 const windowSize = {
     width: 1920,
     height: 1080,
@@ -74,8 +76,14 @@ export class SiteCrawlerEngine implements CrawlerEngine {
                 },
             },
             browserPoolOptions: {
-                // disable default user agent string generation
+                // disable default user agent string generation as part of fingerprints
                 useFingerprints: false,
+                preLaunchHooks: [
+                    async (pageId, launchContext) => {
+                        // workaround to disable --user-agent browser launch option
+                        launchContext.fingerprint = {} as any;
+                    },
+                ],
                 postPageCreateHooks: [
                     async (page) => {
                         // add custom HTTP headers

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -142,7 +142,7 @@ export abstract class PageProcessorBase implements PageProcessor {
             return;
         }
 
-        // Set actually loaded URL in crawler context. This is workaround of crawler bug the prevents
+        // Set actually loaded URL in crawler context. This is workaround for crawler bug the prevents
         // converting relative href link to absolute link.
         context.request.loadedUrl = context.page.url();
 

--- a/packages/scanner-global-library/src/network/page-operation-handler.ts
+++ b/packages/scanner-global-library/src/network/page-operation-handler.ts
@@ -68,7 +68,7 @@ export class PageOperationHandler {
             const elapsed = System.getElapsedTime(timestamp);
 
             // Waits for page script redirection after initial page navigation was completed.
-            await System.wait(3000);
+            await System.wait(2000);
 
             return { response, navigationTiming: { goto: elapsed } as PageNavigationTiming };
         } catch (error) {

--- a/packages/scanner-global-library/src/network/page-request-interceptor.ts
+++ b/packages/scanner-global-library/src/network/page-request-interceptor.ts
@@ -67,13 +67,15 @@ export class PageRequestInterceptor {
             return;
         }
 
-        // trace page instance to manage requests interception
+        // Trace page instance to not break requests interception events
         if (page.id === undefined) {
             page.id = `${System.getTimestamp()}`;
         }
         this.pageId = page.id;
 
         await page.setBypassServiceWorker(true);
+        // Enable requests interception for a life duration of the page instance.
+        // Disabling requests interception will break web page load.
         await page.setRequestInterception(true);
 
         this.pageOnRequestEventHandler = async (request: Puppeteer.HTTPRequest) => {

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -140,11 +140,11 @@ export class PageNavigator {
                 });
                 await page.goto(`file:///${__dirname}/blank-page.html`);
                 await this.browserCache.clear(page);
-                await System.wait(1000);
+                await System.wait(500);
             } else {
                 // Navigate forward and back to mitigate the cache error.
                 await page.goto(`file:///${__dirname}/blank-page.html`);
-                await System.wait(1000);
+                await System.wait(500);
             }
 
             const pageOperation = async () => page.goBack(this.waitForOptions);

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -283,7 +283,7 @@ export class Page {
         await this.close();
         await this.create({ ...this.browserStartOptions, clearBrowserCache: false });
         // wait for browser to start
-        await System.wait(5000);
+        await System.wait(3000);
     }
 
     private async setExtraHTTPHeaders(): Promise<void> {


### PR DESCRIPTION
#### Details

Added workaround to restore actual user agent string. The new crawlee library failed to use useFingerprints option to disable fixed user agent string.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
