### PR TITLE
Extended web sites document support for all scan types

### DIFF
--- a/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.spec.ts
+++ b/packages/privacy-scan-runner/src/combined-report/combined-privacy-scan-result-processor.spec.ts
@@ -4,7 +4,6 @@
 import 'reflect-metadata';
 
 import { GuidGenerator, RetryHelper } from 'common';
-import _ from 'lodash';
 import { GlobalLogger } from 'logger';
 import { PrivacyScanResult } from 'scanner-global-library';
 import {
@@ -69,12 +68,11 @@ describe(CombinedPrivacyScanResultProcessor, () => {
         } as WebsiteScanResult;
         pageScanResult = {
             id: 'page scan id',
-            websiteScanRefs: [
-                {
-                    id: websiteScanResult.id,
-                    scanGroupType: 'consolidated-scan-report',
-                },
-            ],
+            websiteScanRef: {
+                id: websiteScanResult.id,
+                scanGroupType: 'consolidated-scan',
+            },
+
             url: 'scan url',
             reports: [
                 {
@@ -106,15 +104,7 @@ describe(CombinedPrivacyScanResultProcessor, () => {
     });
 
     it('Does nothing if websiteScanRefs is undefined', async () => {
-        pageScanResult.websiteScanRefs = undefined;
-
-        websiteScanResultProviderMock.setup((w) => w.read(It.isAny())).verifiable(Times.never());
-
-        await testSubject.generateCombinedScanResults(privacyResults, pageScanResult);
-    });
-
-    it('Does nothing if websiteScanRefs is empty', async () => {
-        pageScanResult.websiteScanRefs = [];
+        pageScanResult.websiteScanRef = undefined;
 
         websiteScanResultProviderMock.setup((w) => w.read(It.isAny())).verifiable(Times.never());
 

--- a/packages/privacy-scan-runner/src/runner/runner.spec.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.spec.ts
@@ -211,10 +211,9 @@ describe(Runner, () => {
 function setupUpdateScanResult(): void {
     onDemandPageScanRunResultProviderMock.setup((o) => o.updateScanRun(It.isValue(pageScanResult))).verifiable();
 
-    const websiteScanRef = pageScanResult.websiteScanRefs?.find((ref) => ref.scanGroupType === 'deep-scan');
-    if (websiteScanRef) {
+    if (pageScanResult.websiteScanRef) {
         const updatedWebsiteScanResult: Partial<WebsiteScanResult> = {
-            id: websiteScanRef.id,
+            id: pageScanResult.websiteScanRef.id,
             pageScans: [
                 {
                     scanId: scanMetadata.id,

--- a/packages/privacy-scan-runner/src/runner/runner.ts
+++ b/packages/privacy-scan-runner/src/runner/runner.ts
@@ -135,21 +135,17 @@ export class Runner {
         this.setRunResult(pageScanResult, runState, this.convertToScanError(privacyScanResult.error));
     }
 
-    private async updateScanResult(
-        scanMetadata: PrivacyScanMetadata,
-        pageScanResult: Partial<OnDemandPageScanResult>,
-    ): Promise<WebsiteScanResult> {
+    private async updateScanResult(scanMetadata: PrivacyScanMetadata, pageScanResult: Partial<OnDemandPageScanResult>): Promise<void> {
         await this.onDemandPageScanRunResultProvider.updateScanRun(pageScanResult);
 
-        const websiteScanRef = pageScanResult.websiteScanRefs?.find((ref) => ref.scanGroupType === 'deep-scan');
-        if (websiteScanRef) {
+        if (pageScanResult.websiteScanRef) {
             const runState =
                 pageScanResult.run.state === 'completed' || pageScanResult.run.retryCount >= this.maxFailedScanRetryCount
                     ? pageScanResult.run.state
                     : undefined;
 
             const updatedWebsiteScanResult: Partial<WebsiteScanResult> = {
-                id: websiteScanRef.id,
+                id: pageScanResult.websiteScanRef.id,
                 pageScans: [
                     {
                         scanId: scanMetadata.id,
@@ -161,10 +157,8 @@ export class Runner {
                 ],
             };
 
-            return this.websiteScanResultProvider.mergeOrCreate(scanMetadata.id, updatedWebsiteScanResult);
+            await this.websiteScanResultProvider.mergeOrCreate(scanMetadata.id, updatedWebsiteScanResult);
         }
-
-        return undefined;
     }
 
     private async generateScanReports(privacyScanResult: PrivacyScanResult): Promise<OnDemandPageScanReport[]> {

--- a/packages/privacy-scan-runner/src/scanner/page-scan-processor.spec.ts
+++ b/packages/privacy-scan-runner/src/scanner/page-scan-processor.spec.ts
@@ -39,7 +39,7 @@ describe(PageScanProcessor, () => {
         scanMetadata = {
             url: url,
             id: 'id',
-            deepScan: false,
+            deepScan: undefined,
         };
         pageMock
             .setup((o) => o.getPageScreenshot())
@@ -77,7 +77,6 @@ describe(PageScanProcessor, () => {
     });
 
     it('run successful scan with known pages list', async () => {
-        scanMetadata.deepScan = true;
         setupOpenPage();
         setupClosePage();
         privacyScannerMock

--- a/packages/privacy-scan-runner/src/scanner/page-scan-processor.ts
+++ b/packages/privacy-scan-runner/src/scanner/page-scan-processor.ts
@@ -32,9 +32,7 @@ export class PageScanProcessor {
             privacyScanResults = await this.runPrivacyScan(scanMetadata.url);
             privacyScanResults = { ...privacyScanResults, ...pageState };
 
-            if (scanMetadata.deepScan) {
-                await this.pageScanScheduler.schedulePageScan(pageScanResult);
-            }
+            await this.pageScanScheduler.schedulePageScan(pageScanResult);
         } finally {
             await this.closePage();
         }

--- a/packages/privacy-scan-runner/src/scanner/page-scan-scheduler.spec.ts
+++ b/packages/privacy-scan-runner/src/scanner/page-scan-scheduler.spec.ts
@@ -27,10 +27,10 @@ describe(PageScanScheduler, () => {
 
         pageScanResult = {
             url: 'url',
-            websiteScanRefs: [
-                { id: 'some id', scanGroupType: 'consolidated-scan-report' },
-                { id: websiteScanResultId, scanGroupType: 'deep-scan' },
-            ],
+            websiteScanRef: {
+                id: websiteScanResultId,
+                scanGroupType: 'consolidated-scan',
+            },
         } as OnDemandPageScanResult;
         websiteScanResult = {
             id: websiteScanResultId,

--- a/packages/privacy-scan-runner/src/scanner/scan-feed-generator.spec.ts
+++ b/packages/privacy-scan-runner/src/scanner/scan-feed-generator.spec.ts
@@ -156,7 +156,6 @@ function createScanRequests(urls: string[]): ScanRunBatchRequest[] {
             scanId: `${url} id`,
             url,
             priority: pageScanResult.priority,
-            deepScan: true,
             scanNotifyUrl: pageScanResult.notification.scanNotifyUrl,
             site: {
                 baseUrl: websiteScanResult.baseUrl,

--- a/packages/privacy-scan-runner/src/scanner/scan-feed-generator.ts
+++ b/packages/privacy-scan-runner/src/scanner/scan-feed-generator.ts
@@ -106,7 +106,6 @@ export class ScanFeedGenerator {
                 scanId,
                 url,
                 priority: isNil(pageScanResult.priority) ? 0 : pageScanResult.priority,
-                deepScan: true,
                 scanNotifyUrl: pageScanResult.notification?.scanNotifyUrl ?? undefined,
                 site: {
                     baseUrl: websiteScanResult.baseUrl,

--- a/packages/report-generator-runner/src/report-processor/report-processor.spec.ts
+++ b/packages/report-generator-runner/src/report-processor/report-processor.spec.ts
@@ -72,12 +72,10 @@ describe(ReportProcessor, () => {
                 run: {
                     retryCount: maxFailedScanRetryCount,
                 },
-                websiteScanRefs: [
-                    {
-                        id: `websiteScanId-${i}`,
-                        scanGroupType: 'deep-scan',
-                    },
-                ],
+                websiteScanRef: {
+                    id: `websiteScanId-${i}`,
+                    scanGroupType: 'deep-scan',
+                },
             } as OnDemandPageScanResult;
             pageScanResults.push(pageScanResult);
 
@@ -92,7 +90,7 @@ describe(ReportProcessor, () => {
             } as QueuedRequest);
 
             const websiteScanResult = {
-                id: pageScanResult.websiteScanRefs[0].id,
+                id: pageScanResult.websiteScanRef.id,
                 pageScans: [
                     {
                         scanId: pageScanResult.id,
@@ -111,38 +109,6 @@ describe(ReportProcessor, () => {
             });
         }
     }
-
-    // function setupWebsiteScanResultProviderMock(): void {
-    //     pageScanResults.map((r) => {
-    //         const websiteScanResult = websiteScanResults.find((w) => r.id === w.pageScans[0].scanId);
-    //         const websiteScanResultUpdated = websiteScanResultsUpdated.find((w) => w.id === websiteScanResult.id);
-    //         websiteScanResultProviderMock
-    //             .setup((o) => o.read(websiteScanResult.id))
-    //             .returns(() => Promise.resolve(websiteScanResultUpdated))
-    //             .verifiable();
-    //     });
-    // }
-
-    // function setupScanNotificationProcessorMock(): void {
-    //     websiteScanResultsUpdated.map((websiteScanResultUpdated) => {
-    //         const pageScanResultUpdated = pageScanResults.find((r) => r.id === websiteScanResultUpdated.pageScans[0].scanId);
-    //         const runnerScanMetadata = {
-    //             id: pageScanResultUpdated.id,
-    //             url: pageScanResultUpdated.url,
-    //             deepScan: websiteScanResultUpdated.deepScanId !== undefined ? true : false,
-    //         } as RunnerScanMetadata;
-    //         scanNotificationProcessorMock
-    //             .setup((o) =>
-    //                 o.sendScanCompletionNotification(
-    //                     It.isValue(runnerScanMetadata),
-    //                     It.isValue(pageScanResultUpdated),
-    //                     It.isValue(websiteScanResultUpdated),
-    //                 ),
-    //             )
-    //             .returns(() => Promise.resolve())
-    //             .verifiable();
-    //     });
-    // }
 
     function setupOnDemandPageScanRunResultProvider(): void {
         queuedRequests.map((queuedRequest) => {

--- a/packages/report-generator-runner/src/runner/runner.spec.ts
+++ b/packages/report-generator-runner/src/runner/runner.spec.ts
@@ -10,7 +10,6 @@ import {
     OperationResult,
     WebsiteScanResultProvider,
     ScanNotificationProcessor,
-    RunnerScanMetadata,
 } from 'service-library';
 import { GlobalLogger } from 'logger';
 import { ReportGeneratorRequest, OnDemandPageScanResult, ReportScanRunState, WebsiteScanResult } from 'storage-documents';
@@ -348,13 +347,11 @@ function setupSetScanRunStatesOnCompletion(queuedRequests: ReportGeneratorReques
                 run: {
                     state: request.run?.state,
                 },
-                websiteScanRefs: [
-                    {
-                        id: websiteScanRefId,
-                        scanGroupId: request.scanGroupId,
-                        scanGroupType: 'deep-scan',
-                    },
-                ],
+                websiteScanRef: {
+                    id: websiteScanRefId,
+                    scanGroupId: request.scanGroupId,
+                    scanGroupType: 'deep-scan',
+                },
             } as OnDemandPageScanResult,
         };
 
@@ -380,15 +377,9 @@ function setupSetScanRunStatesOnCompletion(queuedRequests: ReportGeneratorReques
             .returns(() => Promise.resolve(updatedWebsiteScanResult as WebsiteScanResult))
             .verifiable();
 
-        const runnerScanMetadata: RunnerScanMetadata = {
-            id: pageScanResultUpdated.result.id,
-            url: pageScanResultUpdated.result.url,
-            deepScan: updatedWebsiteScanResult?.deepScanId !== undefined ? true : false,
-        };
         scanNotificationProcessorMock
             .setup((o) =>
                 o.sendScanCompletionNotification(
-                    It.isValue(runnerScanMetadata),
                     It.isValue(pageScanResultUpdated.result),
                     It.isValue(updatedWebsiteScanResult as WebsiteScanResult),
                 ),

--- a/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
+++ b/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
@@ -108,7 +108,7 @@ createAppInsightsApiKey() {
     # If api key already exists, delete and recreate it
     if [[ -n "$apiKeyExists" ]]; then
         echo "Deleting existing app insights API key"
-        az monitor app-insights api-key delete $apiKeyParams 1>/dev/null
+        az monitor app-insights api-key delete $apiKeyParams --yes 1>/dev/null
     fi
 
     appInsightsApiKey=$(az monitor app-insights api-key create $apiKeyParams --read-properties ReadTelemetry --query "apiKey" -o tsv)

--- a/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
+++ b/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
@@ -108,7 +108,7 @@ createAppInsightsApiKey() {
     # If api key already exists, delete and recreate it
     if [[ -n "$apiKeyExists" ]]; then
         echo "Deleting existing app insights API key"
-        az monitor app-insights api-key delete $apiKeyParams 1>/dev/null
+        tmp=$(az monitor app-insights api-key delete $apiKeyParams)
     fi
 
     appInsightsApiKey=$(az monitor app-insights api-key create $apiKeyParams --read-properties ReadTelemetry --query "apiKey" -o tsv)

--- a/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
+++ b/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
@@ -108,7 +108,7 @@ createAppInsightsApiKey() {
     # If api key already exists, delete and recreate it
     if [[ -n "$apiKeyExists" ]]; then
         echo "Deleting existing app insights API key"
-        tmp=$(az monitor app-insights api-key delete $apiKeyParams)
+        az monitor app-insights api-key delete $apiKeyParams 1>/dev/null
     fi
 
     appInsightsApiKey=$(az monitor app-insights api-key create $apiKeyParams --read-properties ReadTelemetry --query "apiKey" -o tsv)

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.spec.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.spec.ts
@@ -110,12 +110,10 @@ describe(CombinedScanResultProcessor, () => {
         (combinedScanResultProcessor as any).maxCombinedResultsBlobSize = 2;
         pageScanResult = {
             id: 'id',
-            websiteScanRefs: [
-                {
-                    id: websiteScanId,
-                    scanGroupType: 'consolidated-scan-report',
-                },
-            ],
+            websiteScanRef: {
+                id: websiteScanId,
+                scanGroupType: 'consolidated-scan',
+            },
         } as OnDemandPageScanResult;
 
         setupFullPass();
@@ -137,12 +135,10 @@ describe(CombinedScanResultProcessor, () => {
     it('generate combined report for consolidated scan request', async () => {
         pageScanResult = {
             id: 'id',
-            websiteScanRefs: [
-                {
-                    id: websiteScanId,
-                    scanGroupType: 'consolidated-scan-report',
-                },
-            ],
+            websiteScanRef: {
+                id: websiteScanId,
+                scanGroupType: 'consolidated-scan',
+            },
         } as OnDemandPageScanResult;
         setupFullPass();
 
@@ -154,12 +150,10 @@ describe(CombinedScanResultProcessor, () => {
     it('generate combined report for deep scan request', async () => {
         pageScanResult = {
             id: 'id',
-            websiteScanRefs: [
-                {
-                    id: websiteScanId,
-                    scanGroupType: 'deep-scan',
-                },
-            ],
+            websiteScanRef: {
+                id: websiteScanId,
+                scanGroupType: 'deep-scan',
+            },
         } as OnDemandPageScanResult;
         setupFullPass();
 
@@ -171,12 +165,10 @@ describe(CombinedScanResultProcessor, () => {
     it('should replace report reference if already exists', async () => {
         pageScanResult = {
             id: 'id',
-            websiteScanRefs: [
-                {
-                    id: websiteScanId,
-                    scanGroupType: 'deep-scan',
-                },
-            ],
+            websiteScanRef: {
+                id: websiteScanId,
+                scanGroupType: 'deep-scan',
+            },
             reports: [
                 {
                     reportId: 'reportId',

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -52,7 +52,7 @@ export interface OnDemandPageScanResult extends StorageDocument {
     itemType: ItemType.onDemandPageScanRunResult;
     batchRequestId?: string;
     url: string;
-    websiteScanRefs?: WebsiteScanRef[];
+    websiteScanRef?: WebsiteScanRef;
     priority: number;
     scannedUrl?: string;
     scanResult?: OnDemandScanResult;

--- a/packages/storage-documents/src/website-scan-result.ts
+++ b/packages/storage-documents/src/website-scan-result.ts
@@ -6,7 +6,7 @@ import { StorageDocument } from './storage-document';
 import { ItemType } from './item-type';
 import { ReportFormat, OnDemandPageScanRunState, ScanState } from './on-demand-page-scan-result';
 
-export declare type ScanGroupType = 'consolidated-scan-report' | 'deep-scan';
+export declare type ScanGroupType = 'single-scan' | 'consolidated-scan' | 'deep-scan';
 
 /**
  * Represents website scan result composite document.

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.spec.ts
@@ -198,12 +198,10 @@ describe(OnDemandDispatcher, () => {
                                 timestamp: new Date().toJSON(),
                                 retryCount: 2,
                             },
-                            websiteScanRefs: [
-                                {
-                                    id: 'websiteScanRefId',
-                                    scanGroupType: 'deep-scan',
-                                },
-                            ],
+                            websiteScanRef: {
+                                id: 'websiteScanRefId',
+                                scanGroupType: 'deep-scan',
+                            },
                         },
                         condition: 'noRetry',
                     },
@@ -217,11 +215,11 @@ describe(OnDemandDispatcher, () => {
 
             const pageScanResult = scanRequests.requestsToDelete[0].result;
             websiteScanResultProviderMock
-                .setup((o) => o.read(pageScanResult.websiteScanRefs[0].id, false, pageScanResult.id))
+                .setup((o) => o.read(pageScanResult.websiteScanRef.id, false, pageScanResult.id))
                 .returns(() => Promise.resolve({ pageScans: pageScanPart ? [pageScanPart] : undefined } as WebsiteScanResult))
                 .verifiable();
             const updatedWebsiteScanResult: Partial<WebsiteScanResult> = {
-                id: pageScanResult.websiteScanRefs[0].id,
+                id: pageScanResult.websiteScanRef.id,
                 pageScans: [
                     {
                         scanId: pageScanResult.id,

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -165,13 +165,12 @@ export class OnDemandDispatcher {
         }
 
         // ensure that website scan result has final state of a page scan to generate up-to-date website scan status result
-        const websiteScanRef = pageScanResult.websiteScanRefs?.find((ref) => ref.scanGroupType === 'deep-scan');
-        if (websiteScanRef !== undefined) {
-            const websiteScanResult = await this.websiteScanResultProvider.read(websiteScanRef.id, false, pageScanResult.id);
+        if (pageScanResult.websiteScanRef !== undefined) {
+            const websiteScanResult = await this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, false, pageScanResult.id);
             const pageScan = websiteScanResult.pageScans?.find((s) => s.scanId === pageScanResult.id);
             if (pageScan?.runState === undefined) {
                 const updatedWebsiteScanResult: Partial<WebsiteScanResult> = {
-                    id: websiteScanRef.id,
+                    id: pageScanResult.websiteScanRef.id,
                     pageScans: [
                         {
                             scanId: pageScanResult.id,

--- a/packages/web-api-scan-runner/src/crawl-runner/scan-feed-generator.ts
+++ b/packages/web-api-scan-runner/src/crawl-runner/scan-feed-generator.ts
@@ -29,7 +29,7 @@ export class ScanFeedGenerator {
         return this.retryHelper.executeWithRetries(
             () => this.queueDiscoveredPagesImpl(websiteScanResult, pageScanResult),
             async (error: Error) => {
-                this.logger.logError(`Failure to queue discovered pages to scan. Retrying on error.`, {
+                this.logger.logError(`Failure to queue new pages to scan. Retrying on error.`, {
                     error: System.serializeError(error),
                 });
             },
@@ -41,18 +41,18 @@ export class ScanFeedGenerator {
     private async queueDiscoveredPagesImpl(websiteScanResult: WebsiteScanResult, pageScanResult: OnDemandPageScanResult): Promise<void> {
         const urlsToScan = this.getUrlsToScan(websiteScanResult);
         if (urlsToScan.length > 0) {
-            this.logger.logInfo(`Discovered ${urlsToScan.length} new pages to scan.`, {
+            this.logger.logInfo(`Found ${urlsToScan.length} new pages to scan.`, {
                 discoveredUrls: JSON.stringify(urlsToScan),
             });
         } else {
-            this.logger.logInfo(`Discovered no new pages to scan.`);
+            this.logger.logInfo(`Found no new pages to scan.`);
 
             return;
         }
 
         const scanRequests = await this.createBatchRequests(urlsToScan, websiteScanResult, pageScanResult);
         await this.updateWebsiteScanResult(scanRequests, websiteScanResult, pageScanResult);
-        this.logger.logInfo(`Discovered pages has been queued for scanning.`);
+        this.logger.logInfo(`New pages has been queued for scanning.`);
     }
 
     private async createBatchRequests(
@@ -96,7 +96,7 @@ export class ScanFeedGenerator {
         return urls.map((url) => {
             // preserve GUID origin for a single batch scope
             const scanId = this.guidGenerator.createGuidFromBaseGuid(batchId);
-            this.logger.logInfo('Generated new scan id for the discovered page.', {
+            this.logger.logInfo('Generated new scan id for the found page.', {
                 batchId,
                 discoveredScanId: scanId,
                 discoveredUrl: url,
@@ -106,7 +106,7 @@ export class ScanFeedGenerator {
                 scanId,
                 url,
                 priority: isNil(pageScanResult.priority) ? 0 : pageScanResult.priority,
-                deepScan: true,
+                deepScan: pageScanResult.websiteScanRef.scanGroupType === 'deep-scan',
                 scanNotifyUrl: pageScanResult.notification?.scanNotifyUrl ?? undefined,
                 site: {
                     baseUrl: websiteScanResult.baseUrl,

--- a/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.spec.ts
+++ b/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.spec.ts
@@ -16,8 +16,13 @@ describe(createDiscoveryPattern, () => {
     });
 
     it('creates discovery pattern', () => {
-        const expectedPattern = `http(s?)://${host}${pathname}(.*)`;
+        const expectedPattern = `^http(s?)://${host}${pathname}(.*)`;
         const actualPattern = createDiscoveryPattern(url);
         expect(actualPattern).toEqual(expectedPattern);
+    });
+
+    it('ignore empty base url', () => {
+        const actualPattern = createDiscoveryPattern('');
+        expect(actualPattern).toBeUndefined();
     });
 });

--- a/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.ts
+++ b/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.ts
@@ -2,9 +2,17 @@
 // Licensed under the MIT License.
 
 import url from 'url';
+import { isEmpty } from 'lodash';
 
+/**
+ * Returns RegEx string that is used to find new links on a page.
+ */
 export function createDiscoveryPattern(pseudoUrl: string): string {
+    if (isEmpty(pseudoUrl)) {
+        return undefined;
+    }
+
     const urlObj = url.parse(pseudoUrl);
 
-    return `http(s?)://${urlObj.host}${urlObj.pathname}(.*)`;
+    return `^http(s?)://${urlObj.host}${urlObj.pathname}(.*)`;
 }

--- a/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
+++ b/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
@@ -65,10 +65,10 @@ describe(DeepScanner, () => {
         };
         pageScanResult = {
             url,
-            websiteScanRefs: [
-                { id: 'some id', scanGroupType: 'consolidated-scan-report' },
-                { id: websiteScanResultId, scanGroupType: 'deep-scan' },
-            ],
+            websiteScanRef: {
+                id: websiteScanResultId,
+                scanGroupType: 'consolidated-scan',
+            },
         } as OnDemandPageScanResult;
         updatedWebsiteScanResult = {
             id: websiteScanResultId,
@@ -164,14 +164,6 @@ describe(DeepScanner, () => {
             .verifiable();
 
         await testSubject.runDeepScan(runnerScanMetadata, pageScanResult, pageMock.object);
-    });
-
-    it('logs and throws if websiteScanRefs is missing', async () => {
-        pageScanResult.websiteScanRefs = undefined;
-
-        loggerMock.setup((l) => l.logError(It.isAny(), It.isAny())).verifiable();
-
-        await expect(testSubject.runDeepScan(runnerScanMetadata, pageScanResult, pageMock.object)).rejects.toThrow();
     });
 
     it('crawls and updates results with generated discovery pattern', async () => {

--- a/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
+++ b/packages/web-api-scan-runner/src/scanner/deep-scanner.spec.ts
@@ -139,7 +139,7 @@ describe(DeepScanner, () => {
         setupLoggerProperties();
         loggerMock
             .setup((o) =>
-                o.logInfo('The website deep scan completed since maximum discovered pages limit was reached.', {
+                o.logInfo('The website deep scan completed since maximum pages limit was reached.', {
                     discoveredUrls: `${websiteScanResult.pageCount}`,
                     discoveryLimit: `${websiteScanResult.deepScanLimit}`,
                 }),
@@ -156,7 +156,7 @@ describe(DeepScanner, () => {
         setupLoggerProperties();
         loggerMock
             .setup((o) =>
-                o.logInfo('The website deep scan completed since maximum discovered pages limit was reached.', {
+                o.logInfo('The website deep scan completed since maximum pages limit was reached.', {
                     discoveredUrls: `${websiteScanResult.pageCount}`,
                     discoveryLimit: `${websiteScanResult.deepScanLimit}`,
                 }),

--- a/packages/web-api-scan-runner/src/scanner/deep-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/deep-scanner.ts
@@ -38,7 +38,7 @@ export class DeepScanner {
         const deepScanDiscoveryLimit = websiteScanResult.deepScanLimit;
         const canDeepScan = await this.canDeepScan(websiteScanResult);
         if (canDeepScan === false) {
-            this.logger.logInfo(`The website deep scan completed since maximum discovered pages limit was reached.`, {
+            this.logger.logInfo(`The website deep scan completed since maximum pages limit was reached.`, {
                 discoveredUrls: `${websiteScanResult.pageCount}`,
                 discoveryLimit: `${deepScanDiscoveryLimit}`,
             });

--- a/packages/web-api/src/controllers/base-scan-result-controller.ts
+++ b/packages/web-api/src/controllers/base-scan-result-controller.ts
@@ -5,7 +5,7 @@ import { GuidGenerator } from 'common';
 import { Dictionary, keyBy } from 'lodash';
 import moment from 'moment';
 import { ApiController, OnDemandPageScanRunResultProvider, ScanResultResponse, WebsiteScanResultProvider } from 'service-library';
-import { OnDemandPageScanResult, WebsiteScanResult, ScanGroupType } from 'storage-documents';
+import { OnDemandPageScanResult, WebsiteScanResult } from 'storage-documents';
 import { ScanResponseConverter } from '../converters/scan-response-converter';
 
 export abstract class BaseScanResultController extends ApiController {
@@ -31,13 +31,9 @@ export abstract class BaseScanResultController extends ApiController {
         return keyBy(scanResultItems, (item) => item.id);
     }
 
-    protected async getWebsiteScanResult(
-        pageScanResult: OnDemandPageScanResult,
-        scanGroupType: ScanGroupType = 'deep-scan',
-    ): Promise<WebsiteScanResult> {
-        const websiteScanRef = pageScanResult.websiteScanRefs?.find((ref) => ref.scanGroupType === scanGroupType);
-        if (websiteScanRef) {
-            return this.websiteScanResultProvider.read(websiteScanRef.id, true);
+    protected async getWebsiteScanResult(pageScanResult: OnDemandPageScanResult): Promise<WebsiteScanResult> {
+        if (pageScanResult.websiteScanRef) {
+            return this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, true);
         }
 
         return undefined;

--- a/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
@@ -45,13 +45,11 @@ describe(BatchScanResultController, () => {
         priority: 1,
         itemType: ItemType.onDemandPageScanRunResult,
         batchRequestId: 'batch-id',
-        websiteScanRefs: [
-            {
-                id: 'websiteScanId',
-                scanGroupId: 'scanGroupId',
-                scanGroupType: 'deep-scan',
-            },
-        ],
+        websiteScanRef: {
+            id: 'websiteScanId',
+            scanGroupId: 'scanGroupId',
+            scanGroupType: 'deep-scan',
+        },
     };
     const scanClientResponseForFetchedResponse: ScanResultResponse = {
         scanId: validScanId,
@@ -107,7 +105,7 @@ describe(BatchScanResultController, () => {
 
         websiteScanResultProviderMock = Mock.ofType<WebsiteScanResultProvider>();
         websiteScanResultProviderMock
-            .setup((o) => o.read(scanFetchedResponse.websiteScanRefs[0].id, true))
+            .setup((o) => o.read(scanFetchedResponse.websiteScanRef.id, true))
             .returns(() => Promise.resolve(websiteScanResult));
     });
 

--- a/packages/web-api/src/controllers/scan-request-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.spec.ts
@@ -162,7 +162,7 @@ describe(ScanRequestController, () => {
         it('rejects deepScan requests if they are missing required properties', async () => {
             context.req.rawBody = JSON.stringify([
                 {
-                    // missing both site and reportGroups
+                    // missing site
                     deepScan: true,
                     url: 'https://abc/path/',
                 },
@@ -172,18 +172,11 @@ describe(ScanRequestController, () => {
                     url: 'https://def/path/',
                     reportGroups: [{ consolidatedId: 'reportGroupId' }],
                 },
-                {
-                    // missing reportGroups
-                    deepScan: true,
-                    url: 'https://hij/path/',
-                    site: { baseUrl: 'https://base/path' },
-                },
             ]);
 
             const expectedResponse = [
                 { url: 'https://abc/path/', error: WebApiErrorCodes.missingRequiredDeepScanProperties.error },
                 { url: 'https://def/path/', error: WebApiErrorCodes.missingRequiredDeepScanProperties.error },
-                { url: 'https://hij/path/', error: WebApiErrorCodes.missingRequiredDeepScanProperties.error },
             ];
 
             scanRequestController = createScanRequestController(context);

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -190,7 +190,7 @@ export class ScanRequestController extends ApiController {
         const emptyReportGroup =
             isEmpty(scanRunRequest.reportGroups) || scanRunRequest.reportGroups.some((g) => isEmpty(g?.consolidatedId));
 
-        if (scanRunRequest.deepScan && (emptyBaseUrl || emptyReportGroup)) {
+        if (scanRunRequest.deepScan && emptyBaseUrl) {
             return { valid: false, error: WebApiErrorCodes.missingRequiredDeepScanProperties.error };
         }
 

--- a/packages/web-api/src/controllers/scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.spec.ts
@@ -50,13 +50,11 @@ describe(ScanResultController, () => {
         priority: 1,
         itemType: ItemType.onDemandPageScanRunResult,
         batchRequestId: 'batch-id',
-        websiteScanRefs: [
-            {
-                id: 'websiteScanId',
-                scanGroupId: 'scanGroupId',
-                scanGroupType: 'deep-scan',
-            },
-        ],
+        websiteScanRef: {
+            id: 'websiteScanId',
+            scanGroupId: 'scanGroupId',
+            scanGroupType: 'deep-scan',
+        },
     };
     const scanClientResponseForDbResponse: ScanResultResponse = {
         scanId: scanId,
@@ -114,7 +112,7 @@ describe(ScanResultController, () => {
         scanResponseConverterMock = Mock.ofType<ScanResponseConverter>();
         websiteScanResultProviderMock = Mock.ofType<WebsiteScanResultProvider>();
         websiteScanResultProviderMock
-            .setup((o) => o.read(dbResponse.websiteScanRefs[0].id, true))
+            .setup((o) => o.read(dbResponse.websiteScanRef.id, true))
             .returns(() => Promise.resolve(websiteScanResult));
     });
 

--- a/packages/web-api/src/converters/scan-response-converter.ts
+++ b/packages/web-api/src/converters/scan-response-converter.ts
@@ -164,9 +164,8 @@ export class ScanResponseConverter {
         return { notification: notificationResponse };
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    private getDeepScanResult(websiteScanResult: WebsiteScanResult): { [deepScanResult: string]: DeepScanResultItem[] } | {} {
-        if (isNil(websiteScanResult) || !(websiteScanResult.pageScans?.length > 0)) {
+    private getDeepScanResult(websiteScanResult: WebsiteScanResult): { [deepScanResult: string]: DeepScanResultItem[] } {
+        if (websiteScanResult === undefined || websiteScanResult.scanGroupType === 'single-scan') {
             return {};
         }
 


### PR DESCRIPTION
#### Details

Extended web sites document support for all scan types to support combined scans without crawling.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
