### PR TITLE
Disable deep scan result for descendant scan response

### DIFF
--- a/azure-pipeline/build-artifacts-and-run-tests-job.yaml
+++ b/azure-pipeline/build-artifacts-and-run-tests-job.yaml
@@ -79,4 +79,8 @@ steps:
           script: |
               queuedBy="queued-by-$(Build.QueuedBy)"
               echo "##vso[build.addbuildtag]$queuedBy"
-      displayName: 'Apply build tag'
+              pipeline="pipeline-$(Build.DefinitionName)"
+              echo "##vso[build.addbuildtag]$pipeline"
+              reason="reason-$(Build.Reason)"
+              echo "##vso[build.addbuildtag]$reason"
+      displayName: 'Apply build tags'

--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -300,6 +300,8 @@ components:
                     type: string
                 url:
                     type: string
+                deepScanId:
+                    type: string
                 scanResult:
                     $ref: '#/components/schemas/ScanResult'
                 deepScanResult:

--- a/packages/privacy-scan-runner/src/scanner/scan-feed-generator.spec.ts
+++ b/packages/privacy-scan-runner/src/scanner/scan-feed-generator.spec.ts
@@ -168,6 +168,7 @@ function createScanRequests(urls: string[]): ScanRunBatchRequest[] {
             privacyScan: {
                 cookieBannerType: pageScanResult.privacyScan.cookieBannerType,
             },
+            deepScanId: websiteScanResult.deepScanId,
         } as ScanRunBatchRequest;
     });
 }

--- a/packages/privacy-scan-runner/src/scanner/scan-feed-generator.ts
+++ b/packages/privacy-scan-runner/src/scanner/scan-feed-generator.ts
@@ -106,18 +106,20 @@ export class ScanFeedGenerator {
                 scanId,
                 url,
                 priority: isNil(pageScanResult.priority) ? 0 : pageScanResult.priority,
-                scanNotifyUrl: pageScanResult.notification?.scanNotifyUrl ?? undefined,
-                site: {
-                    baseUrl: websiteScanResult.baseUrl,
+                // Propagate the original scan id to descendant requests.
+                deepScanId: websiteScanResult.deepScanId,
+                privacyScan: {
+                    cookieBannerType: pageScanResult.privacyScan.cookieBannerType,
                 },
                 reportGroups: [
                     {
                         consolidatedId: websiteScanResult.scanGroupId,
                     },
                 ],
-                privacyScan: {
-                    cookieBannerType: pageScanResult.privacyScan.cookieBannerType,
+                site: {
+                    baseUrl: websiteScanResult.baseUrl,
                 },
+                scanNotifyUrl: pageScanResult.notification?.scanNotifyUrl ?? undefined,
             };
         });
     }

--- a/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
+++ b/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
@@ -41,13 +41,14 @@ export interface ScanRunResultResponse {
     scanId: string;
     url: string;
     scanType: ScanType;
+    deepScanId?: string;
+    run: ScanRun;
+    authentication?: AuthenticationResult;
     scannedUrl?: string;
     scanResult?: ScanResult;
     deepScanResult?: DeepScanResultItem[];
     reports?: ScanReport[];
-    run: ScanRun;
     notification?: ScanCompletedNotification;
-    authentication?: AuthenticationResult;
 }
 
 export interface ScanRunErrorResponse {

--- a/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
@@ -30,11 +30,12 @@ export interface PrivacyScan {
 export interface ScanRunBatchRequest {
     scanId: string;
     url: string;
-    site?: WebsiteRequest;
     priority: number;
-    reportGroups?: ReportGroupRequest[];
-    scanNotifyUrl?: string;
     deepScan?: boolean;
+    deepScanId?: string;
+    scanNotifyUrl?: string;
+    site?: WebsiteRequest;
+    reportGroups?: ReportGroupRequest[];
     privacyScan?: PrivacyScan;
     authenticationType?: AuthenticationType;
 }

--- a/packages/storage-documents/src/on-demand-page-scan-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-request.ts
@@ -9,11 +9,12 @@ import { AuthenticationType } from './on-demand-page-scan-result';
 export interface OnDemandPageScanRequest extends StorageDocument {
     itemType: ItemType.onDemandPageScanRequest;
     url: string;
-    site?: WebsiteRequest;
     priority: number;
-    reportGroups?: ReportGroupRequest[];
-    scanNotifyUrl?: string;
     deepScan?: boolean;
+    deepScanId?: string;
+    scanNotifyUrl?: string;
+    site?: WebsiteRequest;
+    reportGroups?: ReportGroupRequest[];
     privacyScan?: PrivacyScan;
     authenticationType?: AuthenticationType;
 }

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -58,15 +58,16 @@ export interface ScanError {
  */
 export interface OnDemandPageScanResult extends StorageDocument {
     itemType: ItemType.onDemandPageScanRunResult;
-    batchRequestId?: string;
     url: string;
-    websiteScanRef?: WebsiteScanRef;
     priority: number;
+    batchRequestId?: string;
+    deepScanId?: string;
+    websiteScanRef?: WebsiteScanRef;
     scannedUrl?: string;
-    scanResult?: OnDemandScanResult;
-    reports?: OnDemandPageScanReport[];
     run: OnDemandPageScanRunResult;
     subRuns?: WorkflowRunResults;
+    scanResult?: OnDemandScanResult;
+    reports?: OnDemandPageScanReport[];
     notification?: ScanCompletedNotification;
     privacyScan?: PrivacyScan;
     authentication?: AuthenticationResult;

--- a/packages/storage-documents/src/website-scan-result.ts
+++ b/packages/storage-documents/src/website-scan-result.ts
@@ -30,6 +30,7 @@ export interface WebsiteScanResultBase extends StorageDocument {
     baseUrl: string;
     scanGroupId: string;
     scanGroupType: ScanGroupType;
+    // This value is immutable and set on new db document creation.
     deepScanId?: string;
     discoveryPatterns?: string[];
     reports?: WebsiteScanReport[];

--- a/packages/web-api-scan-runner/src/crawler/scan-feed-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/crawler/scan-feed-generator.spec.ts
@@ -216,6 +216,7 @@ function createScanRequests(urls: string[], deepScan: boolean = true): ScanRunBa
             url,
             priority: pageScanResult.priority,
             deepScan,
+            deepScanId: websiteScanResult.deepScanId,
             scanNotifyUrl: pageScanResult.notification.scanNotifyUrl,
             site: {
                 baseUrl: websiteScanResult.baseUrl,

--- a/packages/web-api-scan-runner/src/crawler/scan-feed-generator.ts
+++ b/packages/web-api-scan-runner/src/crawler/scan-feed-generator.ts
@@ -107,16 +107,18 @@ export class ScanFeedGenerator {
                 url,
                 priority: isNil(pageScanResult.priority) ? 0 : pageScanResult.priority,
                 deepScan: pageScanResult.websiteScanRef.scanGroupType === 'deep-scan',
-                scanNotifyUrl: pageScanResult.notification?.scanNotifyUrl ?? undefined,
-                site: {
-                    baseUrl: websiteScanResult.baseUrl,
-                },
+                // Propagate the original scan id to descendant requests.
+                deepScanId: websiteScanResult.deepScanId,
+                authenticationType: pageScanResult.authentication?.hint ?? undefined,
                 reportGroups: [
                     {
                         consolidatedId: websiteScanResult.scanGroupId,
                     },
                 ],
-                authenticationType: pageScanResult.authentication?.hint ?? undefined,
+                site: {
+                    baseUrl: websiteScanResult.baseUrl,
+                },
+                scanNotifyUrl: pageScanResult.notification?.scanNotifyUrl ?? undefined,
             };
         });
     }

--- a/packages/web-api/src/controllers/base-scan-result-controller.ts
+++ b/packages/web-api/src/controllers/base-scan-result-controller.ts
@@ -33,7 +33,21 @@ export abstract class BaseScanResultController extends ApiController {
 
     protected async getWebsiteScanResult(pageScanResult: OnDemandPageScanResult): Promise<WebsiteScanResult> {
         if (pageScanResult.websiteScanRef) {
-            return this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, true);
+            // TODO remove after 11/15/23. This is temporary solution to support backward compatibility.
+            // start - to remove
+            if (pageScanResult.deepScanId === undefined) {
+                const websiteScanResult = await this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, false);
+                if (pageScanResult.id === websiteScanResult.deepScanId) {
+                    return this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, true);
+                }
+            } else {
+                // end - to remove
+
+                // Expand scan result for original scan only. Result for descendant scans do not include deep scan result collection.
+                const expandResult = pageScanResult.id === pageScanResult.deepScanId;
+
+                return this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, expandResult);
+            }
         }
 
         return undefined;

--- a/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/batch-scan-result-controller.spec.ts
@@ -105,6 +105,9 @@ describe(BatchScanResultController, () => {
 
         websiteScanResultProviderMock = Mock.ofType<WebsiteScanResultProvider>();
         websiteScanResultProviderMock
+            .setup((o) => o.read(scanFetchedResponse.websiteScanRef.id, false))
+            .returns(() => Promise.resolve({ deepScanId: validScanId } as WebsiteScanResult));
+        websiteScanResultProviderMock
             .setup((o) => o.read(scanFetchedResponse.websiteScanRef.id, true))
             .returns(() => Promise.resolve(websiteScanResult));
     });

--- a/packages/web-api/src/controllers/scan-request-controller.ts
+++ b/packages/web-api/src/controllers/scan-request-controller.ts
@@ -107,11 +107,11 @@ export class ScanRequestController extends ApiController {
         const isV2 = this.context.req.query['api-version'] === '2.0';
         let payload: ScanRunRequest[];
         if (isV2) {
-            const singularReq: ScanRunRequest = this.tryGetPayload<ScanRunRequest>();
-            if (Array.isArray(singularReq)) {
-                throw new Error('Malformed request body');
+            const singularRequest: ScanRunRequest = this.tryGetPayload<ScanRunRequest>();
+            if (Array.isArray(singularRequest)) {
+                throw new Error('Malformed HTTP request body.');
             }
-            payload = [singularReq];
+            payload = [singularRequest];
         } else {
             payload = this.tryGetPayload<ScanRunRequest[]>();
         }
@@ -130,14 +130,14 @@ export class ScanRequestController extends ApiController {
                 const scanId = this.guidGenerator.createGuidFromBaseGuid(batchId);
                 scanRequestsToBeStoredInDb.push({
                     scanId: scanId,
-                    priority: isNil(scanRunRequest.priority) ? 0 : scanRunRequest.priority,
                     url: scanRunRequest.url,
-                    ...(scanRunRequest.authenticationType === undefined ? {} : { authenticationType: scanRunRequest.authenticationType }),
+                    priority: isNil(scanRunRequest.priority) ? 0 : scanRunRequest.priority,
                     ...(scanRunRequest.deepScan === undefined ? {} : { deepScan: scanRunRequest.deepScan }),
-                    ...(isEmpty(scanRunRequest.scanNotifyUrl) ? {} : { scanNotifyUrl: scanRunRequest.scanNotifyUrl }),
-                    ...(isEmpty(scanRunRequest.site) ? {} : { site: scanRunRequest.site }),
-                    ...(isEmpty(scanRunRequest.reportGroups) ? {} : { reportGroups: scanRunRequest.reportGroups }),
+                    ...(scanRunRequest.authenticationType === undefined ? {} : { authenticationType: scanRunRequest.authenticationType }),
                     ...(scanRunRequest.privacyScan === undefined ? {} : { privacyScan: scanRunRequest.privacyScan }),
+                    ...(isEmpty(scanRunRequest.reportGroups) ? {} : { reportGroups: scanRunRequest.reportGroups }),
+                    ...(isEmpty(scanRunRequest.site) ? {} : { site: scanRunRequest.site }),
+                    ...(isEmpty(scanRunRequest.scanNotifyUrl) ? {} : { scanNotifyUrl: scanRunRequest.scanNotifyUrl }),
                 });
 
                 scanResponses.push({

--- a/packages/web-api/src/controllers/scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.spec.ts
@@ -112,6 +112,9 @@ describe(ScanResultController, () => {
         scanResponseConverterMock = Mock.ofType<ScanResponseConverter>();
         websiteScanResultProviderMock = Mock.ofType<WebsiteScanResultProvider>();
         websiteScanResultProviderMock
+            .setup((o) => o.read(dbResponse.websiteScanRef.id, false))
+            .returns(() => Promise.resolve({ deepScanId: scanId } as WebsiteScanResult));
+        websiteScanResultProviderMock
             .setup((o) => o.read(dbResponse.websiteScanRef.id, true))
             .returns(() => Promise.resolve(websiteScanResult));
     });

--- a/packages/web-api/src/controllers/scan-result-controller.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.ts
@@ -48,11 +48,11 @@ export class ScanResultController extends BaseScanResultController {
                     status: 200,
                     body: this.getTooSoonRequestResponse(scanId),
                 };
-                this.logger.logInfo('Scan result is not ready in a storage.');
+                this.logger.logWarn('Scan result is not ready in a storage.');
             } else {
                 // return scan not found response
                 this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.resourceNotFound);
-                this.logger.logInfo('Scan result not found in a storage.');
+                this.logger.logError('Scan result not found in a storage.');
             }
         } else {
             const websiteScanResult = await this.getWebsiteScanResult(pageScanResult);

--- a/packages/web-api/src/converters/scan-response-converter.spec.ts
+++ b/packages/web-api/src/converters/scan-response-converter.spec.ts
@@ -191,6 +191,7 @@ function getDeepScanResult(deepScanOverallState: RunState = 'pending'): DeepScan
 
 function getWebsiteScanResult(deepScanOverallState: RunState = 'pending'): WebsiteScanResult {
     const result = {
+        deepScanId: 'id',
         pageScans: [
             {
                 scanId: 'scanId1',

--- a/packages/web-api/src/converters/scan-response-converter.ts
+++ b/packages/web-api/src/converters/scan-response-converter.ts
@@ -92,6 +92,13 @@ export class ScanResponseConverter {
                       },
                   }
                 : {}),
+            run: {
+                state: effectiveRunState,
+                timestamp: pageScanResult.run.timestamp,
+                pageResponseCode: pageScanResult.run.pageResponseCode,
+                pageTitle: pageScanResult.run.pageTitle,
+            },
+            ...this.getRunCompleteNotificationResponse(pageScanResult.notification),
             ...(pageScanResult.authentication !== undefined
                 ? {
                       authentication: {
@@ -100,15 +107,11 @@ export class ScanResponseConverter {
                       },
                   }
                 : {}),
-            run: {
-                state: effectiveRunState,
-                timestamp: pageScanResult.run.timestamp,
-                pageResponseCode: pageScanResult.run.pageResponseCode,
-                pageTitle: pageScanResult.run.pageTitle,
-            },
-            ...this.getRunCompleteNotificationResponse(pageScanResult.notification),
             reports: this.getScanReports(baseUrl, apiVersion, pageScanResult),
-            ...this.getDeepScanResult(websiteScanResult),
+            // Expand scan result for original scan only. Result for descendant scans do not include deep scan result collection.
+            // TODO replace with commented line below after 11/15/23. This is temporary solution to support backward compatibility.
+            ...(pageScanResult.id === websiteScanResult?.deepScanId ? this.getDeepScanResult(websiteScanResult) : {}),
+            // ...(pageScanResult.id === pageScanResult.deepScanId ? this.getDeepScanResult(websiteScanResult) : {}),
         };
 
         if (pageScanResult.scannedUrl !== undefined) {

--- a/packages/web-api/src/converters/scan-response-converter.ts
+++ b/packages/web-api/src/converters/scan-response-converter.ts
@@ -50,6 +50,7 @@ export class ScanResponseConverter {
             scanId: pageScanResult.id,
             url: pageScanResult.url,
             scanType: pageScanResult.privacyScan ? 'privacy' : 'accessibility',
+            deepScanId: pageScanResult.deepScanId,
             run: {
                 state: effectiveRunState,
             },
@@ -62,6 +63,7 @@ export class ScanResponseConverter {
             scanId: pageScanResult.id,
             url: pageScanResult.url,
             scanType: pageScanResult.privacyScan ? 'privacy' : 'accessibility',
+            deepScanId: pageScanResult.deepScanId,
             run: {
                 state: effectiveRunState,
                 timestamp: pageScanResult.run?.timestamp,
@@ -84,6 +86,7 @@ export class ScanResponseConverter {
             scanId: pageScanResult.id,
             url: pageScanResult.url,
             scanType: pageScanResult.privacyScan ? 'privacy' : 'accessibility',
+            deepScanId: pageScanResult.deepScanId,
             ...(pageScanResult.scanResult !== undefined
                 ? {
                       scanResult: {

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.spec.ts
@@ -326,6 +326,7 @@ function setupOnDemandPageScanRunResultProviderMock(
                         timestamp: dateNow.toJSON(),
                     },
                     batchRequestId: document.id,
+                    deepScanId: request.deepScanId ?? request.scanId,
                     ...(isEmpty(request.scanNotifyUrl)
                         ? {}
                         : {
@@ -357,6 +358,7 @@ function setupPageScanRequestProviderMock(documents: OnDemandPageScanBatchReques
                     itemType: ItemType.onDemandPageScanRequest,
                     partitionKey: PartitionKey.pageScanRequestDocuments,
                     deepScan: scanRequest.deepScan,
+                    deepScanId: scanRequest.deepScanId ?? scanRequest.scanId,
                     ...(scanRequest.authenticationType === undefined ? {} : { authenticationType: scanRequest.authenticationType }),
                 };
 

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -110,7 +110,7 @@ export class ScanBatchRequestFeedController extends WebController {
                 priority: request.priority,
                 itemType: ItemType.onDemandPageScanRunResult,
                 batchRequestId: batchRequestId,
-                // We use scan id from the original scan request. The original scan id is propagated to descendant requests.
+                // Deep scan id is the original scan request id. The deep scan id is propagated to descendant requests in scan request.
                 deepScanId: request.deepScanId ?? request.scanId,
                 partitionKey: this.partitionKeyFactory.createPartitionKeyForDocument(ItemType.onDemandPageScanRunResult, request.scanId),
                 websiteScanRef,
@@ -189,7 +189,7 @@ export class ScanBatchRequestFeedController extends WebController {
                 url: request.url,
                 priority: request.priority,
                 deepScan: request.deepScan,
-                // We use scan id from the original scan request. The original scan id is propagated to descendant requests.
+                // Deep scan id is the original scan request id. The deep scan id is propagated to descendant requests in scan request.
                 deepScanId: request.deepScanId ?? request.scanId,
                 itemType: ItemType.onDemandPageScanRequest,
                 partitionKey: PartitionKey.pageScanRequestDocuments,


### PR DESCRIPTION
#### Details

Disable deep scan result for descendant scan REST API response to preserve actual scan response. The original scan run state had cumulated state for all descendant scans. Disabling deep scan result for descendant scan allow return an actual scan run state instead of cumulated state.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
