### PR TITLE
Enable scan URLs from the same domain location

### DIFF
--- a/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.spec.ts
+++ b/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.spec.ts
@@ -21,6 +21,12 @@ describe(createDiscoveryPattern, () => {
         expect(actualPattern).toEqual(expectedPattern);
     });
 
+    it('creates discovery pattern without path', () => {
+        const expectedPattern = `^http(s?)://${host}(.*)`;
+        const actualPattern = createDiscoveryPattern(url, false);
+        expect(actualPattern).toEqual(expectedPattern);
+    });
+
     it('ignore empty base url', () => {
         const actualPattern = createDiscoveryPattern('');
         expect(actualPattern).toBeUndefined();

--- a/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.ts
+++ b/packages/web-api-scan-runner/src/crawler/discovery-pattern-factory.ts
@@ -7,12 +7,12 @@ import { isEmpty } from 'lodash';
 /**
  * Returns RegEx string that is used to find new links on a page.
  */
-export function createDiscoveryPattern(pseudoUrl: string): string {
+export function createDiscoveryPattern(pseudoUrl: string, includePath: boolean = true): string {
     if (isEmpty(pseudoUrl)) {
         return undefined;
     }
 
     const urlObj = url.parse(pseudoUrl);
 
-    return `^http(s?)://${urlObj.host}${urlObj.pathname}(.*)`;
+    return includePath ? `^http(s?)://${urlObj.host}${urlObj.pathname}(.*)` : `^http(s?)://${urlObj.host}(.*)`;
 }

--- a/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.spec.ts
@@ -11,7 +11,7 @@ import { PageMetadataGenerator } from './page-metadata-generator';
 import { UrlLocationValidator } from './url-location-validator';
 
 let pageMock: IMock<Page>;
-let discoveryPatternFactoryMock: IMock<typeof createDiscoveryPattern>;
+let createDiscoveryPatternMock: IMock<typeof createDiscoveryPattern>;
 let urlLocationValidatorMock: IMock<UrlLocationValidator>;
 let websiteScanResult: WebsiteScanResult;
 let pageAnalysisResult: PageAnalysisResult;
@@ -23,21 +23,22 @@ const generatedDiscoveryPattern = `^http(s?)://localhost(.*)`;
 describe(PageMetadataGenerator, () => {
     beforeEach(() => {
         pageMock = Mock.ofType<Page>();
-        discoveryPatternFactoryMock = Mock.ofType<typeof createDiscoveryPattern>();
+        createDiscoveryPatternMock = Mock.ofType<typeof createDiscoveryPattern>();
         urlLocationValidatorMock = Mock.ofType<UrlLocationValidator>();
 
         pageAnalysisResult = { redirection: false } as PageAnalysisResult;
         pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
         websiteScanResult = {} as WebsiteScanResult;
-        discoveryPatternFactoryMock.setup((o) => o(url)).returns(() => generatedDiscoveryPattern);
+        createDiscoveryPatternMock.setup((o) => o(url, It.isAny())).returns(() => generatedDiscoveryPattern);
         urlLocationValidatorMock.setup((o) => o.allowed(It.isAny())).returns(() => true);
 
-        pageMetadataGenerator = new PageMetadataGenerator(urlLocationValidatorMock.object);
+        pageMetadataGenerator = new PageMetadataGenerator(urlLocationValidatorMock.object, createDiscoveryPatternMock.object);
     });
 
     afterEach(() => {
         pageMock.verifyAll();
-        discoveryPatternFactoryMock.verifyAll();
+        urlLocationValidatorMock.verifyAll();
+        createDiscoveryPatternMock.verifyAll();
     });
 
     it('return page metadata for disallowed loaded URL', async () => {


### PR DESCRIPTION
#### Details

Enable scan URLs from the same domain location when scan request URL was redirected to different path.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
