### PR TITLE
Added REST API error code for unscannable URLs

### DIFF
--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -362,19 +362,21 @@ components:
                 code:
                     type: string
                     enum:
-                        - InternalError
-                        - UrlNavigationTimeout
-                        - SslError
-                        - ResourceLoadFailure
-                        - InvalidUrl
-                        - EmptyPage
-                        - HttpErrorCode
-                        - NavigationError
-                        - InvalidContentType
-                        - UrlNotResolved
-                        - ScanTimeout
-                        - BannerXPathNotDetected
                         - AuthenticationError
+                        - BannerXPathNotDetected
+                        - EmptyPage
+                        - ForeignResourceRedirection
+                        - HttpErrorCode
+                        - InternalError
+                        - InvalidContentType
+                        - InvalidUrl
+                        - NavigationError
+                        - ResourceLoadFailure
+                        - ScanTimeout
+                        - SslError
+                        - UnsupportedResource
+                        - UrlNavigationTimeout
+                        - UrlNotResolved
                 codeId:
                     type: integer
                     format: int32

--- a/packages/scanner-global-library/src/authenticator/login-page-detector.ts
+++ b/packages/scanner-global-library/src/authenticator/login-page-detector.ts
@@ -6,7 +6,7 @@ import { Url } from 'common';
 import { AuthenticationType } from 'storage-documents';
 
 const entraLoginDomains = ['login.microsoftonline.com', 'login.live.com'];
-const urlLoginHints = ['auth', 'onmicrosoft', 'sso', 'signin', 'login', 'openid', 'token'];
+const urlLoginHints = ['auth', 'onmicrosoft', 'sso', 'login', 'openid', 'token'];
 
 @injectable()
 export class LoginPageDetector {

--- a/packages/scanner-global-library/src/browser-error.ts
+++ b/packages/scanner-global-library/src/browser-error.ts
@@ -1,22 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type BrowserErrorTypes =
-    | 'UrlNavigationTimeout'
-    | 'SslError'
-    | 'ResourceLoadFailure'
-    | 'InvalidUrl'
-    | 'EmptyPage'
-    | 'HttpErrorCode'
-    | 'NavigationError'
-    | 'InvalidContentType'
-    | 'UrlNotResolved'
-    | 'ScanTimeout'
-    | 'BannerXPathNotDetected'
-    | 'AuthenticationError';
+import { ScanErrorTypes } from 'storage-documents';
 
 export interface BrowserError {
-    errorType: BrowserErrorTypes;
+    errorType: ScanErrorTypes;
     statusCode?: number;
     statusText?: string;
     message: string;

--- a/packages/scanner-global-library/src/browser-error.ts
+++ b/packages/scanner-global-library/src/browser-error.ts
@@ -8,5 +8,5 @@ export interface BrowserError {
     statusCode?: number;
     statusText?: string;
     message: string;
-    stack: string;
+    stack?: string;
 }

--- a/packages/scanner-global-library/src/index.ts
+++ b/packages/scanner-global-library/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export { setupScannerContainer } from './setup-scanner-container';
-export { BrowserError, BrowserErrorTypes } from './browser-error';
+export { BrowserError } from './browser-error';
 export { PageConfigurator } from './page-configurator';
 export { PageHandler } from './page-handler';
 export { PageResponseProcessor } from './page-response-processor';

--- a/packages/scanner-global-library/src/page-navigation-error-patterns.ts
+++ b/packages/scanner-global-library/src/page-navigation-error-patterns.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { BrowserErrorTypes } from './browser-error';
+import { ScanErrorTypes } from 'storage-documents';
 
-export const pageNavigationErrorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = {
+export const pageNavigationErrorPatterns: Partial<Record<ScanErrorTypes, string[]>> = {
     UrlNavigationTimeout: ['Navigation timeout', 'net::ERR_CONNECTION_TIMED_OUT', 'Timeout exceeded'],
     SslError: [
         'net::ERR_CERT_AUTHORITY_INVALID',

--- a/packages/scanner-global-library/src/page-response-processor.spec.ts
+++ b/packages/scanner-global-library/src/page-response-processor.spec.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 
 import { HTTPResponse } from 'puppeteer';
 import { IMock, Mock, Times } from 'typemoq';
-import { BrowserErrorTypes } from './browser-error';
+import { ScanErrorTypes } from 'storage-documents';
 import { PageResponseProcessor } from './page-response-processor';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
@@ -92,13 +92,13 @@ describe(PageResponseProcessor, () => {
 });
 
 describe('handles navigation errors', () => {
-    const stubPatterns: Partial<Record<BrowserErrorTypes, string[]>> = {
+    const stubPatterns: Partial<Record<ScanErrorTypes, string[]>> = {
         SslError: ['SSL_ERROR_UNKNOWN'],
         UrlNavigationTimeout: ['Navigation timeout'],
     };
     interface NavigationErrorTestCase {
         message: string;
-        expectedErrorType: BrowserErrorTypes;
+        expectedErrorType: ScanErrorTypes;
     }
 
     const testCaseMappings: NavigationErrorTestCase[] = [

--- a/packages/scanner-global-library/src/page-response-processor.ts
+++ b/packages/scanner-global-library/src/page-response-processor.ts
@@ -3,12 +3,13 @@
 
 import { injectable } from 'inversify';
 import * as Puppeteer from 'puppeteer';
-import { BrowserError, BrowserErrorTypes } from './browser-error';
+import { ScanErrorTypes } from 'storage-documents';
+import { BrowserError } from './browser-error';
 import { pageNavigationErrorPatterns } from './page-navigation-error-patterns';
 
 @injectable()
 export class PageResponseProcessor {
-    constructor(private readonly navigationErrorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = pageNavigationErrorPatterns) {}
+    constructor(private readonly navigationErrorPatterns: Partial<Record<ScanErrorTypes, string[]>> = pageNavigationErrorPatterns) {}
 
     public getResponseError(response: Puppeteer.HTTPResponse, error: Error = new Error()): BrowserError {
         if (!response.ok()) {
@@ -36,7 +37,7 @@ export class PageResponseProcessor {
 
     public getNavigationError(error: Error): BrowserError {
         const matchingErrorType = Object.keys(this.navigationErrorPatterns)
-            .map((k) => k as BrowserErrorTypes)
+            .map((k) => k as ScanErrorTypes)
             .find((errorType) => this.navigationErrorPatterns[errorType].some((errorPattern) => error.message.includes(errorPattern)));
 
         return {

--- a/packages/service-library/src/web-api/scan-run-error-codes.ts
+++ b/packages/service-library/src/web-api/scan-run-error-codes.ts
@@ -4,19 +4,21 @@
 /* eslint-disable @typescript-eslint/no-extraneous-class, @typescript-eslint/naming-convention,no-underscore-dangle,id-match */
 
 export declare type ScanRunErrorCodeName =
-    | 'InternalError'
-    | 'UrlNavigationTimeout'
-    | 'HttpErrorCode'
-    | 'SslError'
-    | 'ResourceLoadFailure'
-    | 'InvalidUrl'
-    | 'EmptyPage'
-    | 'NavigationError'
-    | 'InvalidContentType'
-    | 'UrlNotResolved'
-    | 'ScanTimeout'
+    | 'AuthenticationError'
     | 'BannerXPathNotDetected'
-    | 'AuthenticationError';
+    | 'EmptyPage'
+    | 'ForeignResourceRedirection'
+    | 'HttpErrorCode'
+    | 'InternalError'
+    | 'InvalidContentType'
+    | 'InvalidUrl'
+    | 'NavigationError'
+    | 'ResourceLoadFailure'
+    | 'ScanTimeout'
+    | 'SslError'
+    | 'UnsupportedResource'
+    | 'UrlNavigationTimeout'
+    | 'UrlNotResolved';
 
 export interface ScanRunErrorCode {
     // This type is part of the REST API client response.
@@ -103,22 +105,36 @@ export class ScanRunErrorCodes {
     public static authenticationError: ScanRunErrorCode = {
         code: 'AuthenticationError',
         codeId: 9013,
-        message: 'Resource authentication error',
+        message: 'The resource was redirected to an unsupported authentication provider',
+    };
+
+    public static foreignResourceRedirection: ScanRunErrorCode = {
+        code: 'ForeignResourceRedirection',
+        codeId: 9014,
+        message: 'The resource was redirected to a foreign location',
+    };
+
+    public static unsupportedResource: ScanRunErrorCode = {
+        code: 'UnsupportedResource',
+        codeId: 9015,
+        message: 'The resource is not supported',
     };
 }
 
 export const scanErrorNameToErrorMap: { [key in ScanRunErrorCodeName]: ScanRunErrorCode } = {
-    InternalError: ScanRunErrorCodes.internalError,
-    UrlNavigationTimeout: ScanRunErrorCodes.urlNavigationTimeout,
-    SslError: ScanRunErrorCodes.sslError,
-    HttpErrorCode: ScanRunErrorCodes.httpErrorCode,
-    ResourceLoadFailure: ScanRunErrorCodes.resourceLoadFailure,
-    InvalidUrl: ScanRunErrorCodes.invalidUrl,
-    EmptyPage: ScanRunErrorCodes.emptyPage,
-    NavigationError: ScanRunErrorCodes.navigationError,
-    InvalidContentType: ScanRunErrorCodes.invalidContentType,
-    UrlNotResolved: ScanRunErrorCodes.urlNotResolved,
-    ScanTimeout: ScanRunErrorCodes.scanTimedOut,
-    BannerXPathNotDetected: ScanRunErrorCodes.bannerXPathNotDetected,
     AuthenticationError: ScanRunErrorCodes.authenticationError,
+    BannerXPathNotDetected: ScanRunErrorCodes.bannerXPathNotDetected,
+    EmptyPage: ScanRunErrorCodes.emptyPage,
+    ForeignResourceRedirection: ScanRunErrorCodes.foreignResourceRedirection,
+    HttpErrorCode: ScanRunErrorCodes.httpErrorCode,
+    InternalError: ScanRunErrorCodes.internalError,
+    InvalidContentType: ScanRunErrorCodes.invalidContentType,
+    InvalidUrl: ScanRunErrorCodes.invalidUrl,
+    NavigationError: ScanRunErrorCodes.navigationError,
+    ResourceLoadFailure: ScanRunErrorCodes.resourceLoadFailure,
+    ScanTimeout: ScanRunErrorCodes.scanTimedOut,
+    SslError: ScanRunErrorCodes.sslError,
+    UnsupportedResource: ScanRunErrorCodes.unsupportedResource,
+    UrlNavigationTimeout: ScanRunErrorCodes.urlNavigationTimeout,
+    UrlNotResolved: ScanRunErrorCodes.urlNotResolved,
 };

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -34,19 +34,21 @@ export declare type ReportFormat =
     | 'page.png';
 
 export declare type ScanErrorTypes =
-    | 'UrlNavigationTimeout'
-    | 'SslError'
-    | 'ResourceLoadFailure'
-    | 'InvalidUrl'
-    | 'EmptyPage'
-    | 'HttpErrorCode'
-    | 'NavigationError'
-    | 'InvalidContentType'
-    | 'UrlNotResolved'
-    | 'ScanTimeout'
-    | 'InternalError'
+    | 'AuthenticationError'
     | 'BannerXPathNotDetected'
-    | 'AuthenticationError';
+    | 'EmptyPage'
+    | 'ForeignResourceRedirection'
+    | 'HttpErrorCode'
+    | 'InternalError'
+    | 'InvalidContentType'
+    | 'InvalidUrl'
+    | 'NavigationError'
+    | 'ResourceLoadFailure'
+    | 'ScanTimeout'
+    | 'SslError'
+    | 'UnsupportedResource'
+    | 'UrlNavigationTimeout'
+    | 'UrlNotResolved';
 
 export interface ScanError {
     errorType: ScanErrorTypes;

--- a/packages/web-api-scan-runner/src/runner/runner.spec.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.spec.ts
@@ -92,6 +92,7 @@ describe(Runner, () => {
                 id: 'websiteScanId',
                 scanGroupType: 'consolidated-scan',
             },
+            scannedUrl: 'scannedUrl',
         } as OnDemandPageScanResult;
         pageScanResult = {} as OnDemandPageScanResult;
         axeScanResults = {
@@ -169,6 +170,7 @@ describe(Runner, () => {
     it.each([true, false])(
         'execute runner with page scanner exception with useReportGeneratorWorkflow=%s',
         async (useReportGeneratorWorkflow) => {
+            pageScanResultDbDocument.scannedUrl = undefined;
             pageScanResultDbDocument.websiteScanRef.scanGroupId = useReportGeneratorWorkflow ? 'scanGroupId' : undefined;
             const error = new Error('page scan processor error');
             const errorMessage = System.serializeError(error);

--- a/packages/web-api-scan-runner/src/scanner/page-scan-processor.ts
+++ b/packages/web-api-scan-runner/src/scanner/page-scan-processor.ts
@@ -59,35 +59,21 @@ export class PageScanProcessor {
     }
 
     private getScannableState(pageMetadata: PageMetadata): AxeScanResults {
-        // Not allowed location
-        if (pageMetadata.allowed === false) {
-            this.logger.logWarn(`The scan URL location is not allowed and will not be processed further.`, {
+        if (pageMetadata.browserError !== undefined) {
+            this.logger.logWarn(pageMetadata.browserError.message, {
                 loadedUrl: pageMetadata.loadedUrl,
             });
 
             return {
                 unscannable: true,
-                error: `The scan URL location is not allowed and will not be processed further. URL ${pageMetadata.loadedUrl}`,
-            };
-        }
-
-        // Redirected to foreign location or foreign unknown authentication location
-        if (
-            pageMetadata.foreignLocation === true &&
-            (pageMetadata.authentication !== true || pageMetadata.authenticationType === 'undetermined')
-        ) {
-            this.logger.logWarn(`The scan URL was redirected to foreign location and will not be processed further.`, {
-                loadedUrl: pageMetadata.loadedUrl,
-            });
-
-            return {
-                unscannable: true,
-                error: `The scan URL was redirected to foreign location and will not be processed further. URL ${pageMetadata.loadedUrl}`,
+                scannedUrl: pageMetadata.loadedUrl,
+                error: pageMetadata.browserError,
             };
         }
 
         return {
             unscannable: false,
+            scannedUrl: pageMetadata.loadedUrl,
         };
     }
 

--- a/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.spec.ts
@@ -205,4 +205,36 @@ describe(PageMetadataGenerator, () => {
 
         expect(results).toEqual(expectedPageMetadata);
     });
+
+    it('detect redirect to an unsupported authentication provider', async () => {
+        const loadedUrl = 'http://example.org';
+        pageAnalysisResult = {
+            redirection: true,
+            loadedUrl,
+            authentication: true,
+            authenticationType: 'undetermined',
+        } as PageAnalysisResult;
+        pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
+        pageMock
+            .setup((o) => o.analyze(url))
+            .returns(() => Promise.resolve())
+            .verifiable();
+        const expectedPageMetadata = {
+            url,
+            allowed: true,
+            authentication: true,
+            authenticationType: 'undetermined',
+            foreignLocation: true,
+            loadedUrl,
+            redirection: true,
+            browserError: {
+                errorType: 'AuthenticationError',
+                message: 'The resource was redirected to an unsupported authentication provider.',
+            },
+        };
+
+        const results = await pageMetadataGenerator.getMetadata(url, pageMock.object, websiteScanResult);
+
+        expect(results).toEqual(expectedPageMetadata);
+    });
 });

--- a/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.spec.ts
@@ -67,6 +67,10 @@ describe(PageMetadataGenerator, () => {
             foreignLocation: false,
             loadedUrl,
             redirection: false,
+            browserError: {
+                errorType: 'UnsupportedResource',
+                message: 'The resource is not supported.',
+            },
         };
 
         const results = await pageMetadataGenerator.getMetadata(url, pageMock.object, websiteScanResult);
@@ -140,6 +144,10 @@ describe(PageMetadataGenerator, () => {
             foreignLocation: true,
             loadedUrl,
             redirection: true,
+            browserError: {
+                errorType: 'ForeignResourceRedirection',
+                message: 'The resource was redirected to a foreign location.',
+            },
         };
 
         const results = await pageMetadataGenerator.getMetadata(url, pageMock.object, websiteScanResult);
@@ -162,6 +170,10 @@ describe(PageMetadataGenerator, () => {
             foreignLocation: true,
             loadedUrl,
             redirection: true,
+            browserError: {
+                errorType: 'ForeignResourceRedirection',
+                message: 'The resource was redirected to a foreign location.',
+            },
         };
 
         const results = await pageMetadataGenerator.getMetadata(url, pageMock.object, websiteScanResult);
@@ -183,6 +195,10 @@ describe(PageMetadataGenerator, () => {
             foreignLocation: true,
             loadedUrl,
             redirection: true,
+            browserError: {
+                errorType: 'ForeignResourceRedirection',
+                message: 'The resource was redirected to a foreign location.',
+            },
         };
 
         const results = await pageMetadataGenerator.getMetadata(url, pageMock.object, websiteScanResult);

--- a/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.ts
+++ b/packages/web-api-scan-runner/src/website-builder/page-metadata-generator.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { Page } from 'scanner-global-library';
+import { BrowserError, Page } from 'scanner-global-library';
 import { AuthenticationType, WebsiteScanResult } from 'storage-documents';
 import { createDiscoveryPattern } from '../crawler/discovery-pattern-factory';
 import { UrlLocationValidator } from './url-location-validator';
@@ -15,6 +15,7 @@ export interface PageMetadata {
     authentication?: boolean;
     authenticationType?: AuthenticationType;
     foreignLocation?: boolean;
+    browserError?: BrowserError;
 }
 
 @injectable()
@@ -33,11 +34,13 @@ export class PageMetadataGenerator {
             foreignLocation = await this.hasForeignLocation(url, page, websiteScanResult);
         }
 
+        const allowed =
+            urlAllowed &&
+            (page.pageAnalysisResult?.loadedUrl === undefined || this.urlLocationValidator.allowed(page.pageAnalysisResult.loadedUrl));
+
         return {
             url,
-            allowed:
-                urlAllowed &&
-                (page.pageAnalysisResult?.loadedUrl === undefined || this.urlLocationValidator.allowed(page.pageAnalysisResult.loadedUrl)),
+            allowed,
             loadedUrl: page.pageAnalysisResult?.loadedUrl,
             redirection: page.pageAnalysisResult?.redirection,
             authentication: page.pageAnalysisResult?.authentication,

--- a/packages/web-api/src/converters/scan-error-converter.spec.ts
+++ b/packages/web-api/src/converters/scan-error-converter.spec.ts
@@ -6,27 +6,31 @@ import 'reflect-metadata';
 import { ScanNotificationErrorCodes, ScanRunErrorCodes } from 'service-library';
 import { ScanErrorConverter } from './scan-error-converter';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+let testSubject: ScanErrorConverter;
 
 describe(ScanErrorConverter, () => {
-    let testSubject: ScanErrorConverter;
     beforeEach(() => {
         testSubject = new ScanErrorConverter();
     });
 
     describe('getScanRunErrorCode', () => {
-        it('should return internal error for null or undefined', () => {
-            let errorCode = testSubject.getScanRunErrorCode(null);
+        it('should return internal error for string error', () => {
+            const errorCode = testSubject.getScanRunErrorCode('error message');
             expect(errorCode).toEqual(ScanRunErrorCodes.internalError);
+        });
 
-            errorCode = testSubject.getScanRunErrorCode(undefined);
-            expect(errorCode).toEqual(ScanRunErrorCodes.internalError);
+        it('should return undefined for undefined or null error', () => {
+            let errorCode = testSubject.getScanRunErrorCode(undefined);
+            expect(errorCode).toBeUndefined();
+
+            errorCode = testSubject.getScanRunErrorCode(null);
+            expect(errorCode).toBeUndefined();
         });
 
         it('should resolve scanError to scanErrorCode', () => {
             const errorCode = testSubject.getScanRunErrorCode({
                 errorType: 'InvalidContentType',
-                message: 'some message',
+                message: 'error message',
             });
 
             expect(errorCode).toEqual(ScanRunErrorCodes.invalidContentType);
@@ -34,15 +38,18 @@ describe(ScanErrorConverter, () => {
     });
 
     describe('getScanNotificationErrorCode', () => {
-        it('should return internal error for string input', () => {
-            const errorCode = testSubject.getScanNotificationErrorCode('hello');
-            expect(errorCode).toEqual(ScanNotificationErrorCodes.InternalError);
+        it('should return undefined for undefined or null error', () => {
+            let errorCode = testSubject.getScanNotificationErrorCode(undefined);
+            expect(errorCode).toBeUndefined();
+
+            errorCode = testSubject.getScanNotificationErrorCode(null);
+            expect(errorCode).toBeUndefined();
         });
 
         it('should resolve scanError to scanErrorCode', () => {
             const errorCode = testSubject.getScanNotificationErrorCode({
                 errorType: 'InternalError',
-                message: 'some message',
+                message: 'error message',
             });
 
             expect(errorCode).toEqual(ScanNotificationErrorCodes.InternalError);

--- a/packages/web-api/src/converters/scan-error-converter.ts
+++ b/packages/web-api/src/converters/scan-error-converter.ts
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { isString } from 'util';
 import { injectable } from 'inversify';
-import { isNil } from 'lodash';
+import { isNil, isString } from 'lodash';
 import {
     notificationErrorNameToErrorMap,
     scanErrorNameToErrorMap,
     ScanNotificationErrorCode,
-    ScanNotificationErrorCodes,
     ScanRunErrorCode,
     ScanRunErrorCodes,
 } from 'service-library';
@@ -18,16 +16,20 @@ import { NotificationError, ScanError } from 'storage-documents';
 @injectable()
 export class ScanErrorConverter {
     public getScanRunErrorCode(scanError: string | ScanError): ScanRunErrorCode {
-        if (isNil(scanError) || isString(scanError)) {
+        if (isNil(scanError)) {
+            return undefined;
+        }
+
+        if (isString(scanError)) {
             return ScanRunErrorCodes.internalError;
         }
 
         return scanErrorNameToErrorMap[scanError.errorType];
     }
 
-    public getScanNotificationErrorCode(scanNotificationError: string | NotificationError): ScanNotificationErrorCode {
-        if (isString(scanNotificationError)) {
-            return ScanNotificationErrorCodes.InternalError;
+    public getScanNotificationErrorCode(scanNotificationError: NotificationError): ScanNotificationErrorCode {
+        if (isNil(scanNotificationError)) {
+            return undefined;
         }
 
         return notificationErrorNameToErrorMap[scanNotificationError.errorType];


### PR DESCRIPTION
#### Details

Added REST API error codes for unscannable URLs.

```
{
    "run": {
        "state": "completed",
        "error": {
            "code": "ForeignResourceRedirection | UnsupportedResource",
            "codeId": 9014 | 9015,
        }
    }
}
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
