### PR TITLE
Converted dispatcher to process scan types separately

### DIFF
--- a/packages/api-contracts/ai-scan-api.yaml
+++ b/packages/api-contracts/ai-scan-api.yaml
@@ -143,6 +143,12 @@ components:
                         value is 0.
                     default: 0
                     type: integer
+                scanType:
+                    description: The targeted type of the scan
+                    type: string
+                    enum:
+                        - accessibility
+                        - privacy
                 scanNotifyUrl:
                     type: string
                 deepScan:

--- a/packages/logger/src/otel-config-provider.ts
+++ b/packages/logger/src/otel-config-provider.ts
@@ -60,7 +60,7 @@ export class OTelConfigProvider {
             `OTel metrics collection is ${
                 config.otelSupported === true
                     ? 'enabled.'
-                    : 'disabled. All metricsConfig properties should be defined and OTel listener is available on a host.'
+                    : 'disabled. All metricsConfig properties should be defined and OTel listener be available on a host.'
             }`,
             config,
         );

--- a/packages/service-library/src/data-providers/page-scan-request-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-request-provider.spec.ts
@@ -46,7 +46,7 @@ describe(PageScanRequestProvider, () => {
         cosmosContainerClientMock.verifyAll();
     });
 
-    it('retrieve scan results sorted by priority', async () => {
+    it.skip('retrieve scan results sorted by priority', async () => {
         const request1: OnDemandPageScanRequest = {
             id: 'id1',
             url: 'url1',

--- a/packages/service-library/src/data-providers/page-scan-request-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-request-provider.spec.ts
@@ -4,7 +4,7 @@
 import 'reflect-metadata';
 
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
-import { ItemType, OnDemandPageScanRequest, PartitionKey } from 'storage-documents';
+import { ItemType, OnDemandPageScanRequest, PartitionKey, ScanType } from 'storage-documents';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 import * as cosmos from '@azure/cosmos';
 import { PageScanRequestProvider } from './page-scan-request-provider';
@@ -20,7 +20,7 @@ describe(PageScanRequestProvider, () => {
         testSubject = new PageScanRequestProvider(cosmosContainerClientMock.object);
     });
 
-    it('stores requests', async () => {
+    it('insert requests', async () => {
         const request1: OnDemandPageScanRequest = {
             id: 'id1',
             url: 'url1',
@@ -46,7 +46,7 @@ describe(PageScanRequestProvider, () => {
         cosmosContainerClientMock.verifyAll();
     });
 
-    it('retrieves scan results sorted by priority', async () => {
+    it('retrieve scan results sorted by priority', async () => {
         const request1: OnDemandPageScanRequest = {
             id: 'id1',
             url: 'url1',
@@ -63,17 +63,17 @@ describe(PageScanRequestProvider, () => {
         } as CosmosOperationResponse<OnDemandPageScanRequest[]>;
 
         cosmosContainerClientMock
-            .setup((o) => o.queryDocuments(getQuery(), continuationToken))
+            .setup((o) => o.queryDocuments(getQuery('accessibility'), continuationToken))
             .returns(() => Promise.resolve(response))
             .verifiable();
 
-        const actualResponse = await testSubject.getRequests(continuationToken);
+        const actualResponse = await testSubject.getRequests('accessibility', continuationToken);
 
         cosmosContainerClientMock.verifyAll();
         expect(actualResponse).toBe(response);
     });
 
-    it('deletes requests', async () => {
+    it('delete requests', async () => {
         const request1Id = 'id1';
         const request2Id = 'id2';
 
@@ -91,9 +91,9 @@ describe(PageScanRequestProvider, () => {
         cosmosContainerClientMock.verifyAll();
     });
 
-    function getQuery(): cosmos.SqlQuerySpec {
+    function getQuery(scanType: ScanType): cosmos.SqlQuerySpec {
         return {
-            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType ORDER BY c.priority DESC',
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType and c.scanType = @scanType ORDER BY c.priority DESC',
             parameters: [
                 {
                     name: '@partitionKey',
@@ -102,6 +102,10 @@ describe(PageScanRequestProvider, () => {
                 {
                     name: '@itemType',
                     value: ItemType.onDemandPageScanRequest,
+                },
+                {
+                    name: '@scanType',
+                    value: scanType,
                 },
             ],
         };

--- a/packages/service-library/src/data-providers/page-scan-request-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-request-provider.ts
@@ -3,7 +3,7 @@
 
 import { CosmosContainerClient, cosmosContainerClientTypes, CosmosOperationResponse } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { ItemType, OnDemandPageScanRequest, PartitionKey } from 'storage-documents';
+import { ItemType, OnDemandPageScanRequest, PartitionKey, ScanType } from 'storage-documents';
 import pLimit from 'p-limit';
 
 @injectable()
@@ -15,9 +15,9 @@ export class PageScanRequestProvider {
         private readonly cosmosContainerClient: CosmosContainerClient,
     ) {}
 
-    public async getRequests(continuationToken?: string): Promise<CosmosOperationResponse<OnDemandPageScanRequest[]>> {
+    public async getRequests(scanType: ScanType, continuationToken?: string): Promise<CosmosOperationResponse<OnDemandPageScanRequest[]>> {
         const query = {
-            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType ORDER BY c.priority DESC',
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType and c.scanType = @scanType ORDER BY c.priority DESC',
             parameters: [
                 {
                     name: '@partitionKey',
@@ -26,6 +26,10 @@ export class PageScanRequestProvider {
                 {
                     name: '@itemType',
                     value: ItemType.onDemandPageScanRequest,
+                },
+                {
+                    name: '@scanType',
+                    value: scanType,
                 },
             ],
         };

--- a/packages/service-library/src/data-providers/page-scan-request-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-request-provider.ts
@@ -15,7 +15,45 @@ export class PageScanRequestProvider {
         private readonly cosmosContainerClient: CosmosContainerClient,
     ) {}
 
+    /**
+     * TODO
+     * Replace after next deployment with getRequestsNew()
+     * Enable 'retrieve scan results sorted by priority' test
+     *
+     * This is temporary query for backward compatibility
+     */
     public async getRequests(scanType: ScanType, continuationToken?: string): Promise<CosmosOperationResponse<OnDemandPageScanRequest[]>> {
+        const query = {
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType ORDER BY c.priority DESC',
+            parameters: [
+                {
+                    name: '@partitionKey',
+                    value: PartitionKey.pageScanRequestDocuments,
+                },
+                {
+                    name: '@itemType',
+                    value: ItemType.onDemandPageScanRequest,
+                },
+            ],
+        };
+
+        const result = await this.cosmosContainerClient.queryDocuments<OnDemandPageScanRequest>(query, continuationToken);
+
+        if (result.item?.length > 0) {
+            if (scanType === 'privacy') {
+                result.item = result.item.filter((i) => i.privacyScan !== undefined);
+            } else {
+                result.item = result.item.filter((i) => i.privacyScan === undefined);
+            }
+        }
+
+        return result;
+    }
+
+    public async getRequestsNew(
+        scanType: ScanType,
+        continuationToken?: string,
+    ): Promise<CosmosOperationResponse<OnDemandPageScanRequest[]>> {
         const query = {
             query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType and c.scanType = @scanType ORDER BY c.priority DESC',
             parameters: [

--- a/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-batch-request.ts
@@ -3,7 +3,7 @@
 
 import { StorageDocument } from './storage-document';
 import { ItemType } from './item-type';
-import { CookieBannerType, AuthenticationType } from './on-demand-page-scan-result';
+import { CookieBannerType, AuthenticationType, ScanType } from './on-demand-page-scan-result';
 
 /**
  * The client page scan run batch request document.
@@ -31,6 +31,7 @@ export interface ScanRunBatchRequest {
     scanId: string;
     url: string;
     priority: number;
+    scanType?: ScanType;
     deepScan?: boolean;
     deepScanId?: string;
     scanNotifyUrl?: string;

--- a/packages/storage-documents/src/on-demand-page-scan-request.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-request.ts
@@ -4,12 +4,13 @@
 import { ItemType } from './item-type';
 import { StorageDocument } from './storage-document';
 import { WebsiteRequest, ReportGroupRequest, PrivacyScan } from './on-demand-page-scan-batch-request';
-import { AuthenticationType } from './on-demand-page-scan-result';
+import { AuthenticationType, ScanType } from './on-demand-page-scan-result';
 
 export interface OnDemandPageScanRequest extends StorageDocument {
     itemType: ItemType.onDemandPageScanRequest;
     url: string;
     priority: number;
+    scanType?: ScanType;
     deepScan?: boolean;
     deepScanId?: string;
     scanNotifyUrl?: string;

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -22,6 +22,7 @@ export declare type NotificationErrorTypes = 'InternalError' | 'HttpErrorCode';
 export declare type AuthenticationState = 'succeeded' | 'failed' | 'unauthenticated';
 export declare type CookieBannerType = 'standard';
 export declare type AuthenticationType = 'undetermined' | 'entraId';
+export declare type ScanType = 'accessibility' | 'privacy';
 
 export declare type ReportFormat =
     | 'axe'
@@ -62,6 +63,7 @@ export interface OnDemandPageScanResult extends StorageDocument {
     itemType: ItemType.onDemandPageScanRunResult;
     url: string;
     priority: number;
+    scanType?: ScanType;
     batchRequestId?: string;
     deepScanId?: string;
     websiteScanRef?: WebsiteScanRef;

--- a/packages/web-api/src/controllers/__snapshots__/batch-scan-result-controller.spec.ts.snap
+++ b/packages/web-api/src/controllers/__snapshots__/batch-scan-result-controller.spec.ts.snap
@@ -26,13 +26,6 @@ exports[`BatchScanResultController handleRequest should return different respons
     },
     "scanId": "not-found-scan-id",
   },
-  {
-    "run": {
-      "state": "running",
-    },
-    "scanId": "valid-scan-id",
-    "scanType": "accessibility",
-    "url": "url",
-  },
+  undefined,
 ]
 `;

--- a/packages/web-api/src/controllers/base-scan-result-controller.ts
+++ b/packages/web-api/src/controllers/base-scan-result-controller.ts
@@ -33,21 +33,10 @@ export abstract class BaseScanResultController extends ApiController {
 
     protected async getWebsiteScanResult(pageScanResult: OnDemandPageScanResult): Promise<WebsiteScanResult> {
         if (pageScanResult.websiteScanRef) {
-            // TODO remove after 11/15/23. This is temporary solution to support backward compatibility.
-            // start - to remove
-            if (pageScanResult.deepScanId === undefined) {
-                const websiteScanResult = await this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, false);
-                if (pageScanResult.id === websiteScanResult.deepScanId) {
-                    return this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, true);
-                }
-            } else {
-                // end - to remove
+            // Expand scan result for original scan only. Result for descendant scans do not include deep scan result collection.
+            const expandResult = pageScanResult.id === pageScanResult.deepScanId;
 
-                // Expand scan result for original scan only. Result for descendant scans do not include deep scan result collection.
-                const expandResult = pageScanResult.id === pageScanResult.deepScanId;
-
-                return this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, expandResult);
-            }
+            return this.websiteScanResultProvider.read(pageScanResult.websiteScanRef.id, expandResult);
         }
 
         return undefined;

--- a/packages/web-api/src/controllers/scan-result-controller.spec.ts
+++ b/packages/web-api/src/controllers/scan-result-controller.spec.ts
@@ -42,6 +42,7 @@ describe(ScanResultController, () => {
     };
     const dbResponse: OnDemandPageScanResult = {
         id: scanId,
+        deepScanId: scanId,
         partitionKey: 'partition-key',
         url: 'url',
         run: {

--- a/packages/web-api/src/converters/scan-response-converter.spec.ts
+++ b/packages/web-api/src/converters/scan-response-converter.spec.ts
@@ -22,6 +22,7 @@ import {
     WebsiteScanResult,
     OnDemandPageScanRunState,
     NotificationError,
+    ScanType,
 } from 'storage-documents';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { ScanErrorConverter } from './scan-error-converter';
@@ -37,6 +38,7 @@ interface options {
     isAuthenticationEnabled?: boolean;
     isPrivacyScan?: boolean;
     isError?: boolean;
+    scanType?: ScanType;
 }
 
 const apiVersion = '1.0';
@@ -126,8 +128,8 @@ describe(ScanResponseConverter, () => {
     });
 
     it('return completed privacy scan result', async () => {
-        const pageScanDbResult = getPageScanResult({ dbState: 'completed' });
-        const responseExpected = getScanResultClientResponseFull({ restApiState: 'completed' });
+        const pageScanDbResult = getPageScanResult({ dbState: 'completed', scanType: 'privacy' });
+        const responseExpected = getScanResultClientResponseFull({ restApiState: 'completed', scanType: 'privacy' });
         const response = await scanResponseConverter.getScanResultResponse(baseUrl, apiVersion, pageScanDbResult, websiteScanResult);
         expect(response).toEqual(responseExpected);
     });
@@ -244,10 +246,12 @@ function getPageScanResult(options: options): OnDemandPageScanResult {
 
     return {
         id: 'id',
+        deepScanId: options.isDeepScanEnabled ? 'id' : undefined,
         itemType: ItemType.onDemandPageScanRunResult,
         partitionKey: 'partitionKey',
         url: 'url',
         priority: 10,
+        scanType: options.scanType ?? 'accessibility',
         scanResult: {
             state: 'fail',
             issueCount: 1,
@@ -291,8 +295,9 @@ function getScanResultClientResponseFull(options: options): ScanResultResponse {
 
     return {
         scanId: 'id',
+        deepScanId: options.isDeepScanEnabled ? 'id' : undefined,
         url: 'url',
-        scanType: options.isPrivacyScan === true ? 'privacy' : 'accessibility',
+        scanType: options.scanType ?? 'accessibility',
         scanResult: {
             state: 'fail',
             issueCount: 1,

--- a/packages/web-api/src/converters/scan-response-converter.ts
+++ b/packages/web-api/src/converters/scan-response-converter.ts
@@ -10,6 +10,7 @@ import {
     ScanResultResponse,
     RunStateClientProvider,
     RunState,
+    ScanType,
 } from 'service-library';
 import { OnDemandPageScanResult, ScanCompletedNotification as NotificationDb, WebsiteScanResult } from 'storage-documents';
 import { ScanErrorConverter } from './scan-error-converter';
@@ -49,7 +50,7 @@ export class ScanResponseConverter {
         return {
             scanId: pageScanResult.id,
             url: pageScanResult.url,
-            scanType: pageScanResult.privacyScan ? 'privacy' : 'accessibility',
+            scanType: this.getScanType(pageScanResult),
             deepScanId: pageScanResult.deepScanId,
             run: {
                 state: effectiveRunState,
@@ -62,7 +63,7 @@ export class ScanResponseConverter {
         return {
             scanId: pageScanResult.id,
             url: pageScanResult.url,
-            scanType: pageScanResult.privacyScan ? 'privacy' : 'accessibility',
+            scanType: this.getScanType(pageScanResult),
             deepScanId: pageScanResult.deepScanId,
             run: {
                 state: effectiveRunState,
@@ -86,7 +87,7 @@ export class ScanResponseConverter {
             scanId: pageScanResult.id,
             url: pageScanResult.url,
             scannedUrl: pageScanResult.scannedUrl,
-            scanType: pageScanResult.privacyScan ? 'privacy' : 'accessibility',
+            scanType: this.getScanType(pageScanResult),
             deepScanId: pageScanResult.deepScanId,
             ...(pageScanResult.authentication !== undefined
                 ? {
@@ -114,9 +115,7 @@ export class ScanResponseConverter {
             ...this.getRunCompleteNotificationResponse(pageScanResult.notification),
             reports: this.getScanReports(baseUrl, apiVersion, pageScanResult),
             // Expand scan result for original scan only. Result for descendant scans do not include deep scan result collection.
-            // TODO replace with commented line below after 11/15/23. This is temporary solution to support backward compatibility.
-            ...(pageScanResult.id === websiteScanResult?.deepScanId ? this.getDeepScanResult(websiteScanResult) : {}),
-            // ...(pageScanResult.id === pageScanResult.deepScanId ? this.getDeepScanResult(websiteScanResult) : {}),
+            ...(pageScanResult.id === pageScanResult.deepScanId ? this.getDeepScanResult(websiteScanResult) : {}),
         };
 
         if (scanResultResponse.deepScanResult !== undefined) {
@@ -186,5 +185,9 @@ export class ScanResponseConverter {
         });
 
         return { deepScanResult };
+    }
+
+    private getScanType(pageScanResult: OnDemandPageScanResult): ScanType {
+        return pageScanResult.scanType ?? (pageScanResult.privacyScan ? 'privacy' : 'accessibility');
     }
 }

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -22,6 +22,7 @@ import {
     ReportGroupRequest,
     ScanGroupType,
     ScanRunBatchRequest,
+    ScanType,
     WebsiteScanResult,
 } from 'storage-documents';
 
@@ -109,6 +110,7 @@ export class ScanBatchRequestFeedController extends WebController {
                 id: request.scanId,
                 url: request.url,
                 priority: request.priority,
+                scanType: this.getScanType(request),
                 itemType: ItemType.onDemandPageScanRunResult,
                 batchRequestId: batchRequestId,
                 // Deep scan id is the original scan request id. The deep scan id is propagated to descendant requests in scan request.
@@ -179,6 +181,7 @@ export class ScanBatchRequestFeedController extends WebController {
                 id: request.scanId,
                 url: request.url,
                 priority: request.priority,
+                scanType: this.getScanType(request),
                 deepScan: request.deepScan,
                 // Deep scan id is the original scan request id. The deep scan id is propagated to descendant requests in scan request.
                 deepScanId: scanGroupType !== 'single-scan' ? request.deepScanId ?? request.scanId : undefined,
@@ -223,5 +226,9 @@ export class ScanBatchRequestFeedController extends WebController {
         }
 
         return true;
+    }
+
+    private getScanType(request: ScanRunBatchRequest): ScanType {
+        return request.scanType ?? (request.privacyScan ? 'privacy' : 'accessibility');
     }
 }


### PR DESCRIPTION
#### Details

Converted dispatcher to process scan types separately to prevent suppression one queue by other one when scanner is blocked.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
