### PR TITLE
Preserve authentication cookies

### DIFF
--- a/packages/scanner-global-library/src/authenticator/azure-login-page-client.spec.ts
+++ b/packages/scanner-global-library/src/authenticator/azure-login-page-client.spec.ts
@@ -60,7 +60,7 @@ describe(AzureLoginPageClient, () => {
 });
 
 function setupKMSIPrompt(): void {
-    setupGetElementContent('#idSIButton9', '');
+    setupPageWaitForSelector('#idSIButton9');
     puppeteerKeyboardMock
         .setup((o) => o.press('Enter'))
         .returns(() => Promise.resolve())

--- a/packages/scanner-global-library/src/dev-tools-session.ts
+++ b/packages/scanner-global-library/src/dev-tools-session.ts
@@ -20,7 +20,7 @@ export class DevToolsSession {
     // Default puppeteer CDP protocol timeout is 180 secs. Increasing protocolTimeout beyond
     // default value will require to increase the 'protocolTimeout' setting in browser
     // launch/connect calls.
-    public protocolTimeout = 30000;
+    public protocolTimeout = 90000;
 
     public async send<T extends keyof Puppeteer.ProtocolMapping.Commands>(
         page: Puppeteer.Page,

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -258,7 +258,7 @@ describe(Page, () => {
                 .returns(() => Promise.resolve(puppeteerPageMock.object))
                 .verifiable();
             webDriverMock
-                .setup(async (m) => m.launch({ browserExecutablePath: 'path', clearDiskCache: false }))
+                .setup(async (o) => o.launch({ browserExecutablePath: 'path', clearDiskCache: false, keepUserData: false }))
                 .returns(() => Promise.resolve(browserMock.object))
                 .verifiable();
             webDriverMock
@@ -313,7 +313,9 @@ describe(Page, () => {
                 .returns(() => Promise.resolve(puppeteerPageMock.object))
                 .verifiable();
             webDriverMock
-                .setup(async (m) => m.launch(It.isValue({ browserExecutablePath: 'path', clearDiskCache: undefined })))
+                .setup(async (m) =>
+                    m.launch(It.isValue({ browserExecutablePath: 'path', clearDiskCache: undefined, keepUserData: undefined })),
+                )
                 .returns(() => Promise.resolve(browserMock.object))
                 .verifiable();
             webDriverMock

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -329,7 +329,7 @@ export class Page {
 
         await this.close();
         await this.create({ ...this.browserStartOptions, clearBrowserCache: false, preserveUserProfile });
-        // wait for browser to start
+        // Wait for browser to start
         await System.wait(3000);
     }
 

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -101,6 +101,7 @@ export class Page {
             this.browser = await this.webDriver.launch({
                 browserExecutablePath: options?.browserExecutablePath,
                 clearDiskCache: options?.clearBrowserCache,
+                keepUserData: options?.preserveUserProfile,
             });
         }
 

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -243,7 +243,7 @@ export class Page {
         if (this.pageAnalysisResult.navigationResponse?.browserError !== undefined) {
             this.setLastNavigationState('analysis', this.pageAnalysisResult.navigationResponse);
         } else {
-            await this.reopenBrowser();
+            await this.reopenBrowser({ hardReload: true });
         }
     }
 

--- a/packages/scanner-global-library/src/puppeteer-options.ts
+++ b/packages/scanner-global-library/src/puppeteer-options.ts
@@ -26,6 +26,6 @@ export const defaultLaunchOptions: Puppeteer.PuppeteerNodeLaunchOptions = {
         '--js-flags=--max-old-space-size=8192',
         `--window-size=${windowSize.width},${windowSize.height}`,
     ],
-    protocolTimeout: 30000,
+    protocolTimeout: 90000,
     ...defaultBrowserOptions,
 };

--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -62,6 +62,10 @@ export class WebDriver {
         return this.browser;
     }
 
+    /**
+     * The method launches a browser instance with given arguments.
+     * @default options = { clearDiskCache: true, keepUserData: false }
+     */
     public async launch(options?: WebDriverConfigurationOptions): Promise<Puppeteer.Browser> {
         this.setupPuppeteerPlugins();
 
@@ -69,7 +73,7 @@ export class WebDriver {
             fs.rmSync(this.userDataDirectory, { recursive: true, force: true });
         }
 
-        if (options?.clearDiskCache === undefined || options.clearDiskCache === true) {
+        if (options?.clearDiskCache !== false) {
             this.browserCache.clearStorage();
         }
 

--- a/packages/scanner-global-library/src/web-driver.ts
+++ b/packages/scanner-global-library/src/web-driver.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { exec } from 'child_process';
+import * as fs from 'fs';
 import { PromiseUtils, System } from 'common';
 import { inject, injectable, optional } from 'inversify';
 import { GlobalLogger, Logger } from 'logger';
@@ -20,10 +21,13 @@ import { BrowserCache } from './browser-cache';
 export interface WebDriverConfigurationOptions {
     browserExecutablePath?: string;
     clearDiskCache?: boolean;
+    keepUserData?: boolean;
 }
 
 @injectable()
 export class WebDriver {
+    public userDataDirectory = `${__dirname}/browser-data`;
+
     public browser: Puppeteer.Browser;
 
     private readonly browserCloseTimeoutMsecs = 10000;
@@ -58,17 +62,21 @@ export class WebDriver {
         return this.browser;
     }
 
-    public async launch(options: WebDriverConfigurationOptions = { clearDiskCache: true }): Promise<Puppeteer.Browser> {
+    public async launch(options?: WebDriverConfigurationOptions): Promise<Puppeteer.Browser> {
         this.setupPuppeteerPlugins();
 
-        if (options.clearDiskCache === true) {
+        if (options?.keepUserData !== true) {
+            fs.rmSync(this.userDataDirectory, { recursive: true, force: true });
+        }
+
+        if (options?.clearDiskCache === undefined || options.clearDiskCache === true) {
             this.browserCache.clearStorage();
         }
 
         const launchOptions = this.createLaunchOptions();
         this.browser = await this.puppeteerExtra.launch({
             ...launchOptions,
-            executablePath: options.browserExecutablePath ?? Puppeteer.executablePath(),
+            executablePath: options?.browserExecutablePath ?? Puppeteer.executablePath(),
         });
 
         this.logger?.logInfo('Chromium browser instance started.');
@@ -125,6 +133,9 @@ export class WebDriver {
             headless: process.env.HEADLESS === 'false' ? false : 'new',
             devtools: process.env.DEV_TOOLS === 'true' ? true : false,
         };
+
+        // Define user profile location to be able reuse it if requested.
+        options.args.push(`--user-data-dir=${this.userDataDirectory}`);
 
         // Define browser cache location to allow reuse it after browser relaunch.
         // Browser profile (storage, settings, etc.) is not part of the cache and will be deleted after browser relaunch.


### PR DESCRIPTION
#### Details

- Preserve authentication cookies to keep resource authenticated when reloaded.
- Updated Microsoft Entra ID client

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
