### PR TITLE
Preserve URLs from a client scan request

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -6,11 +6,7 @@ module.exports = {
     clearMocks: true,
     verbose: true,
     testEnvironment: 'node',
-    globals: {
-        'ts-jest': {
-            isolatedModules: true,
-        },
-    },
+
     collectCoverage: true,
     coverageDirectory: '<rootDir>/test-results/unit/coverage',
     coverageReporters: ['text', 'lcov', 'cobertura'],
@@ -38,6 +34,7 @@ module.exports = {
             'ts-jest',
             {
                 tsconfig: '<rootDir>/tsconfig.json',
+                isolatedModules: true,
             },
         ],
     },

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -41,7 +41,7 @@
     "dependencies": {
         "@azure/batch": "^10.2.0",
         "@azure/core-auth": "^1.3.2",
-        "@azure/cosmos": "^3.17.2",
+        "@azure/cosmos": "^4.0.0",
         "@azure/identity": "^3.1.3",
         "@azure/keyvault-secrets": "^4.6.0",
         "@azure/ms-rest-nodeauth": "^3.1.1",

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -35,7 +35,7 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@azure/cosmos": "^3.17.2",
+        "@azure/cosmos": "^4.0.0",
         "azure-services": "workspace:*",
         "chai": "^4.3.7",
         "common": "workspace:*",

--- a/packages/privacy-scan-runner/package.json
+++ b/packages/privacy-scan-runner/package.json
@@ -47,7 +47,7 @@
         "webpack-ignore-dynamic-require": "^1.0.0"
     },
     "dependencies": {
-        "@azure/cosmos": "^3.17.2",
+        "@azure/cosmos": "^4.0.0",
         "applicationinsights": "^2.3.1",
         "azure-services": "workspace:*",
         "common": "workspace:*",

--- a/packages/privacy-scan-runner/src/scanner/page-scan-processor.ts
+++ b/packages/privacy-scan-runner/src/scanner/page-scan-processor.ts
@@ -63,7 +63,6 @@ export class PageScanProcessor {
 
     private async runPrivacyScan(url: string): Promise<PrivacyScanResult> {
         const privacyScanResult = await this.privacyScanner.scan(url, this.page);
-        this.logger.logInfo('The privacy scan of a webpage is completed.');
 
         return privacyScanResult;
     }

--- a/packages/privacy-scan-runner/src/scanner/privacy-scanner.ts
+++ b/packages/privacy-scan-runner/src/scanner/privacy-scanner.ts
@@ -37,7 +37,7 @@ export class PrivacyScanner {
         try {
             this.logger.logInfo(`Starting privacy scan of a webpage.`);
             const scanResult = await this.privacyScannerCore.scan(url, page);
-            this.logger.logInfo(`Privacy scanning of a webpage successfully completed.`);
+            this.logger.logInfo(`Privacy scanning of a webpage is completed.`);
 
             return scanResult;
         } catch (error) {

--- a/packages/report-generator-runner/package.json
+++ b/packages/report-generator-runner/package.json
@@ -47,7 +47,7 @@
         "webpack-ignore-dynamic-require": "^1.0.0"
     },
     "dependencies": {
-        "@azure/cosmos": "^3.17.2",
+        "@azure/cosmos": "^4.0.0",
         "applicationinsights": "^2.3.1",
         "azure-services": "workspace:*",
         "common": "workspace:*",

--- a/packages/resource-deployment/scripts/create-env-file-for-debug.sh
+++ b/packages/resource-deployment/scripts/create-env-file-for-debug.sh
@@ -40,8 +40,7 @@ getStorageConnectionString() {
         --name "$storageAccountName" \
         --resource-group "$resourceGroupName" \
         --subscription "$subscription" \
-        --query connectionString \
-        --auth-mode login --out tsv)
+        --query connectionString --out tsv)
 }
 
 getCosmosDbConnectionString() {

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -40,7 +40,7 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@azure/cosmos": "^3.17.2",
+        "@azure/cosmos": "^4.0.0",
         "@azure/functions": "^3.5.0",
         "@azure/identity": "^3.1.3",
         "@azure/storage-blob": "^12.12.0",

--- a/packages/service-library/src/crawler/discovered-url-processor.spec.ts
+++ b/packages/service-library/src/crawler/discovered-url-processor.spec.ts
@@ -7,8 +7,8 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { UrlLocationValidator } from '../website-builder/url-location-validator';
 import { DiscoveredUrlProcessor } from './discovered-url-processor';
 
-const urlsList = ['url1', 'url2', 'url3', 'url4'];
-const knownUrls = ['url1', 'url2', 'anotherUrl'];
+const urlsList = ['http://url1?a=1&b=1', 'http://url2', 'http://url3', 'http://url4?b=1&a=1'];
+const knownUrls = ['http://url1?b=1&a=1' /** Should normalize URL */, 'http://url2', 'http://anotherUrl'];
 const maxUrlsLimit = 10;
 
 let discoveredUrlProcessor: DiscoveredUrlProcessor;
@@ -27,8 +27,8 @@ describe(DiscoveredUrlProcessor, () => {
     });
 
     it('filters out known resource type', () => {
-        const blockedList = ['url1/document.pdf', 'url2/picture.png'];
-        const list = [...blockedList, 'url3/path', 'url4'];
+        const blockedList = ['http://url1/document.pdf', 'http://url2/picture.png'];
+        const list = [...blockedList, 'http://url3/path', 'http://url4'];
         urlLocationValidatorMock.reset();
         urlLocationValidatorMock
             .setup((o) => o.allowed(It.isAny()))
@@ -37,14 +37,14 @@ describe(DiscoveredUrlProcessor, () => {
             })
             .verifiable(Times.atLeast(4));
 
-        const expectedUrls = ['url3/path', 'url4'];
+        const expectedUrls = ['http://url3/path', 'http://url4'];
         const processedUrls = discoveredUrlProcessor.process(list, maxUrlsLimit);
 
         expect(processedUrls).toEqual(expectedUrls);
     });
 
     it('filters out known urls', () => {
-        const expectedUrls = ['url3', 'url4'];
+        const expectedUrls = ['http://url3', 'http://url4?b=1&a=1' /** Should not change the original URL */];
         const processedUrls = discoveredUrlProcessor.process(urlsList, maxUrlsLimit, knownUrls);
 
         expect(processedUrls).toEqual(expectedUrls);
@@ -52,7 +52,7 @@ describe(DiscoveredUrlProcessor, () => {
 
     it('limits the number of urls according to config and count of knownUrls', () => {
         const deepScanDiscoveryLimit = 3;
-        const processedUrls = discoveredUrlProcessor.process(urlsList, deepScanDiscoveryLimit, ['some url']);
+        const processedUrls = discoveredUrlProcessor.process(urlsList, deepScanDiscoveryLimit, ['http://someUrl']);
 
         expect(processedUrls.length).toBe(2);
     });

--- a/packages/service-library/src/crawler/discovered-url-processor.ts
+++ b/packages/service-library/src/crawler/discovered-url-processor.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { isNil, pullAll, take } from 'lodash';
+import { isNil, pullAllBy, take } from 'lodash';
 import { inject, injectable } from 'inversify';
+import { Url } from 'common';
 import { UrlLocationValidator } from '../website-builder/url-location-validator';
 
 @injectable()
@@ -23,7 +24,7 @@ export class DiscoveredUrlProcessor {
     }
 
     private removeUrlsFromList(urlList: string[], removeUrls: string[]): string[] {
-        return pullAll(urlList, removeUrls);
+        return pullAllBy(urlList, removeUrls, Url.normalizeUrl);
     }
 
     private limitUrlCount(urlList: string[], numUrls: number): string[] {

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -49,7 +49,7 @@
     },
     "dependencies": {
         "@axe-core/puppeteer": "^4.7.3",
-        "@azure/cosmos": "^3.17.2",
+        "@azure/cosmos": "^4.0.0",
         "accessibility-insights-report": "^4.7.0",
         "applicationinsights": "^2.3.1",
         "axe-core": "^4.7.2",

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -46,7 +46,7 @@
         "webpack-ignore-dynamic-require": "^1.0.0"
     },
     "dependencies": {
-        "@azure/cosmos": "^3.17.2",
+        "@azure/cosmos": "^4.0.0",
         "applicationinsights": "^2.3.1",
         "azure-services": "workspace:*",
         "common": "workspace:*",

--- a/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
+++ b/packages/web-workers/src/controllers/scan-batch-request-feed-controller.ts
@@ -3,7 +3,7 @@
 
 import { GuidGenerator, ServiceConfiguration, Url } from 'common';
 import { inject, injectable } from 'inversify';
-import { filter, groupBy, isEmpty, uniqBy } from 'lodash';
+import { filter, groupBy, isEmpty, pullAllBy, uniqBy } from 'lodash';
 import { ContextAwareLogger, ScanRequestAcceptedMeasurements } from 'logger';
 import {
     OnDemandPageScanRunResultProvider,
@@ -241,7 +241,7 @@ export class ScanBatchRequestFeedController extends WebController {
 
             // Remove duplicate URLs from a client request
             if (duplicates.length > 0) {
-                request.site.knownPages = uniqBy(request.site.knownPages, Url.normalizeUrl);
+                request.site.knownPages = pullAllBy(uniqBy(request.site.knownPages, Url.normalizeUrl), [request.url], Url.normalizeUrl);
                 this.logger.logWarn('Removed duplicate URLs from a client request.', {
                     batchRequestId,
                     scanId: request.scanId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,10 +346,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/cosmos@npm:^3.17.2":
-  version: 3.17.2
-  resolution: "@azure/cosmos@npm:3.17.2"
+"@azure/cosmos@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@azure/cosmos@npm:4.0.0"
   dependencies:
+    "@azure/abort-controller": ^1.0.0
     "@azure/core-auth": ^1.3.0
     "@azure/core-rest-pipeline": ^1.2.0
     "@azure/core-tracing": ^1.0.0
@@ -362,7 +363,7 @@ __metadata:
     tslib: ^2.2.0
     universal-user-agent: ^6.0.0
     uuid: ^8.3.0
-  checksum: f21491dbe23503af43ef74c89689b8f586080f215a0f94d55b44a8896bbd68a11a3e8ae1cf8490ecd0b5a8c45d607ab2387910f5213052c42fb1c9661db6a3b4
+  checksum: 81a11c8c757c62bf3c6edde8ba9335cd86c301660df5091157a8f5c94858be3d490d931ed91f25bc2f970a426c536b361f42f503569d7222c0750eb0fc1ed506
   languageName: node
   linkType: hard
 
@@ -5592,7 +5593,7 @@ __metadata:
   dependencies:
     "@azure/batch": ^10.2.0
     "@azure/core-auth": ^1.3.2
-    "@azure/cosmos": ^3.17.2
+    "@azure/cosmos": ^4.0.0
     "@azure/identity": ^3.1.3
     "@azure/keyvault-secrets": ^4.6.0
     "@azure/ms-rest-nodeauth": ^3.1.1
@@ -8711,7 +8712,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "functional-tests@workspace:packages/functional-tests"
   dependencies:
-    "@azure/cosmos": ^3.17.2
+    "@azure/cosmos": ^4.0.0
     "@types/chai": ^4.3.4
     "@types/deep-equal-in-any-order": ^1.0.1
     "@types/dotenv": ^8.2.0
@@ -13018,7 +13019,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "privacy-scan-runner@workspace:packages/privacy-scan-runner"
   dependencies:
-    "@azure/cosmos": ^3.17.2
+    "@azure/cosmos": ^4.0.0
     "@types/dotenv": ^8.2.0
     "@types/jest": ^29.5.0
     "@types/lodash": ^4.14.182
@@ -13820,7 +13821,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "report-generator-runner@workspace:packages/report-generator-runner"
   dependencies:
-    "@azure/cosmos": ^3.17.2
+    "@azure/cosmos": ^4.0.0
     "@types/dotenv": ^8.2.0
     "@types/jest": ^29.5.0
     "@types/lodash": ^4.14.182
@@ -14349,7 +14350,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "service-library@workspace:packages/service-library"
   dependencies:
-    "@azure/cosmos": ^3.17.2
+    "@azure/cosmos": ^4.0.0
     "@azure/functions": ^3.5.0
     "@azure/identity": ^3.1.3
     "@azure/storage-blob": ^12.12.0
@@ -16190,7 +16191,7 @@ __metadata:
   resolution: "web-api-scan-runner@workspace:packages/web-api-scan-runner"
   dependencies:
     "@axe-core/puppeteer": ^4.7.3
-    "@azure/cosmos": ^3.17.2
+    "@azure/cosmos": ^4.0.0
     "@types/dotenv": ^8.2.0
     "@types/jest": ^29.5.0
     "@types/lodash": ^4.14.182
@@ -16285,7 +16286,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web-api-send-notification-runner@workspace:packages/web-api-send-notification-runner"
   dependencies:
-    "@azure/cosmos": ^3.17.2
+    "@azure/cosmos": ^4.0.0
     "@types/dotenv": ^8.2.0
     "@types/got": ^9.6.11
     "@types/jest": ^29.5.0


### PR DESCRIPTION
#### Details

- Preserve URLs from a client scan request for backward compatibility
- Updated Cosmos DB npm package

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
