### PR TITLE
Removed command option char from command string

### DIFF
--- a/packages/resource-deployment/scripts/docker-scanner-image/build-scanner-image.ps1
+++ b/packages/resource-deployment/scripts/docker-scanner-image/build-scanner-image.ps1
@@ -19,7 +19,7 @@ function deleteShare() {
 
 function createShare() {
     Add-Type -AssemblyName System.Web
-    $env:BUILD_KEY = [System.Web.Security.Membership]::GeneratePassword(14, 1)
+    $env:BUILD_KEY = [System.Web.Security.Membership]::GeneratePassword(14, 1).Replace('/', '#')
 
     net user $userName "${env:BUILD_KEY}" /ADD | Out-Null
     net share $shareName=$sharePath /grant:"$($userName),READ" | Out-Null


### PR DESCRIPTION
#### Details

Removed command option (forward slash) char from command string since Windows net tool fails when it is presented even in an option value.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
