### PR TITLE
Enable crawling for URLs having hash fragments for ai-scan cli

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -165,7 +165,7 @@ function getScanArguments(): ScanArguments {
             },
             keepUrlFragment: {
                 type: 'boolean',
-                describe: `To keep the hash fragment in the URLs. If set to false, it will remove hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com.`,
+                describe: `To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com.`,
                 default: false,
                 alias: 'keepurlfragment',
             },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -163,6 +163,12 @@ function getScanArguments(): ScanArguments {
                 describe: `List of Chrome command line options to pass on browser start. Can be used to disable CORS to scan protected page: --browserOptions disable-web-security`,
                 alias: 'browseroptions',
             },
+            keepUrlFragment: {
+                type: 'boolean',
+                describe: `To keep the hash fragment in the URLs. If set to false, it will remove hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com.`,
+                default: false,
+                alias: 'keepurlfragment',
+            },
         })
         .check((args) => {
             validateScanArguments(args as ScanArguments);

--- a/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
@@ -70,6 +70,7 @@ describe(CrawlerParametersBuilder, () => {
             chromePath: 'chrome path',
             axeSourcePath: 'axe path',
             singleWorker: false,
+            keepUrlFragment: false,
         };
         const actualCrawlOptions = crawlerParametersBuilder.build(scanArguments);
         expect(actualCrawlOptions).toEqual(expectedCrawlOptions);
@@ -112,7 +113,7 @@ describe(CrawlerParametersBuilder, () => {
             .returns(() => fileContent)
             .verifiable();
         const actualCrawlOptions = crawlerParametersBuilder.build(scanArguments);
-        expect(actualCrawlOptions).toEqual({ inputUrls: [urls[0], urls[2]] });
+        expect(actualCrawlOptions).toEqual({ inputUrls: [urls[0], urls[2]], keepUrlFragment: false });
     });
 
     it('validate input file exists', () => {

--- a/packages/cli/src/crawler/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.ts
@@ -62,6 +62,7 @@ export class CrawlerParametersBuilder {
             httpHeaders: headers,
             adhereFilesystemPattern: scanArguments.adhereFilesystemPattern,
             browserOptions: scanArguments.browserOptions,
+            keepUrlFragment: scanArguments.keepUrlFragment ?? false,
         };
     }
 

--- a/packages/cli/src/scan-arguments.ts
+++ b/packages/cli/src/scan-arguments.ts
@@ -30,4 +30,5 @@ export interface ScanArguments {
     httpHeaders?: string;
     adhereFilesystemPattern?: boolean;
     browserOptions?: string[];
+    keepUrlFragment?: boolean;
 }

--- a/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
@@ -18,6 +18,9 @@ describe(ApifyRequestQueueCreator, () => {
 
     const baseUrl = 'url';
     const requestQueueName = 'scanRequests';
+    const userData = {
+        keepUrlFragment : false
+    };
 
     beforeEach(() => {
         settingsHandlerMock = Mock.ofType<ApifySettingsHandler>();
@@ -25,10 +28,6 @@ describe(ApifyRequestQueueCreator, () => {
         queueMock = getPromisableDynamicMock(Mock.ofType<Crawlee.RequestQueue>());
 
         Crawlee.RequestQueue.open = jest.fn().mockImplementation(() => Promise.resolve(queueMock.object));
-        queueMock
-            .setup((o) => o.addRequest({ url: baseUrl, skipNavigation: true }))
-            .returns(() => Promise.resolve(undefined))
-            .verifiable();
 
         apifyResourceCreator = new ApifyRequestQueueCreator(settingsHandlerMock.object, fileSystemMock.object);
     });
@@ -43,6 +42,7 @@ describe(ApifyRequestQueueCreator, () => {
     describe('createRequestQueue', () => {
         it('create queue', async () => {
             fileSystemMock.setup((o) => o.rmSync(It.isAny(), It.isAny())).verifiable(Times.never());
+            setupBaseUrlAddRequestQueue(userData);
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl);
             expect(queue).toBe(queueMock.object);
@@ -50,6 +50,7 @@ describe(ApifyRequestQueueCreator, () => {
 
         it('delete local queue storage', async () => {
             setupClearRequestQueue(true);
+            setupBaseUrlAddRequestQueue(userData);
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: true });
             expect(queue).toBe(queueMock.object);
@@ -57,6 +58,7 @@ describe(ApifyRequestQueueCreator, () => {
 
         it('skip delete local queue storage', async () => {
             setupClearRequestQueue(false);
+            setupBaseUrlAddRequestQueue(userData);
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: true });
             expect(queue).toBe(queueMock.object);
@@ -65,16 +67,35 @@ describe(ApifyRequestQueueCreator, () => {
         it('create queue with input urls"', async () => {
             const inputUrls = ['url1', 'url2'];
 
+            setupBaseUrlAddRequestQueue(userData);
             queueMock
-                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true }, { forefront: true }))
+                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
                 .returns(() => Promise.resolve(undefined))
                 .verifiable();
             queueMock
-                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true }, { forefront: true }))
+                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
                 .returns(() => Promise.resolve(undefined))
                 .verifiable();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: false, inputUrls: inputUrls });
+            expect(queue).toBe(queueMock.object);
+        });
+
+        it('create queue with input urls and keepUrlFragment true', async () => {
+            const inputUrls = ['url1', 'url2'];
+            userData.keepUrlFragment = true;
+
+            setupBaseUrlAddRequestQueue(userData);
+            queueMock
+                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: true, userData }, { forefront: true }))
+                .returns(() => Promise.resolve(undefined))
+                .verifiable();
+            queueMock
+                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: true, userData }, { forefront: true }))
+                .returns(() => Promise.resolve(undefined))
+                .verifiable();
+
+            const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: false, inputUrls: inputUrls, keepUrlFragment: true });
             expect(queue).toBe(queueMock.object);
         });
     });
@@ -88,5 +109,12 @@ describe(ApifyRequestQueueCreator, () => {
             });
         fileSystemMock.setup((o) => o.existsSync(localStorageDir)).returns(() => dirExists);
         fileSystemMock.setup((o) => o.rmSync(localStorageDir, { recursive: true })).verifiable(dirExists ? Times.once() : Times.never());
+    }
+
+    function setupBaseUrlAddRequestQueue(userData: any) : void {
+        queueMock
+        .setup((o) => o.addRequest({ url: baseUrl, skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData }))
+        .returns(() => Promise.resolve(undefined))
+        .verifiable();
     }
 });

--- a/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
@@ -15,12 +15,10 @@ describe(ApifyRequestQueueCreator, () => {
     let fileSystemMock: IMock<typeof fs>;
     let queueMock: IMock<Crawlee.RequestQueue>;
     let apifyResourceCreator: ApifyRequestQueueCreator;
+    let userData: Crawlee.Dictionary;
 
     const baseUrl = 'url';
     const requestQueueName = 'scanRequests';
-    const userData = {
-        keepUrlFragment: false,
-    };
 
     beforeEach(() => {
         settingsHandlerMock = Mock.ofType<ApifySettingsHandler>();
@@ -30,6 +28,10 @@ describe(ApifyRequestQueueCreator, () => {
         Crawlee.RequestQueue.open = jest.fn().mockImplementation(() => Promise.resolve(queueMock.object));
 
         apifyResourceCreator = new ApifyRequestQueueCreator(settingsHandlerMock.object, fileSystemMock.object);
+
+        userData = {
+            keepUrlFragment: false,
+        };
     });
 
     afterEach(() => {
@@ -42,7 +44,7 @@ describe(ApifyRequestQueueCreator, () => {
     describe('createRequestQueue', () => {
         it('create queue', async () => {
             fileSystemMock.setup((o) => o.rmSync(It.isAny(), It.isAny())).verifiable(Times.never());
-            setupBaseUrlAddRequestQueue(userData);
+            setupBaseUrlAddRequestQueue();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl);
             expect(queue).toBe(queueMock.object);
@@ -50,7 +52,7 @@ describe(ApifyRequestQueueCreator, () => {
 
         it('delete local queue storage', async () => {
             setupClearRequestQueue(true);
-            setupBaseUrlAddRequestQueue(userData);
+            setupBaseUrlAddRequestQueue();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: true });
             expect(queue).toBe(queueMock.object);
@@ -58,7 +60,7 @@ describe(ApifyRequestQueueCreator, () => {
 
         it('skip delete local queue storage', async () => {
             setupClearRequestQueue(false);
-            setupBaseUrlAddRequestQueue(userData);
+            setupBaseUrlAddRequestQueue();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: true });
             expect(queue).toBe(queueMock.object);
@@ -67,7 +69,7 @@ describe(ApifyRequestQueueCreator, () => {
         it('create queue with input urls"', async () => {
             const inputUrls = ['url1', 'url2'];
 
-            setupBaseUrlAddRequestQueue(userData);
+            setupBaseUrlAddRequestQueue();
             queueMock
                 .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
                 .returns(() => Promise.resolve(undefined))
@@ -85,7 +87,7 @@ describe(ApifyRequestQueueCreator, () => {
             const inputUrls = ['url1', 'url2'];
             userData.keepUrlFragment = true;
 
-            setupBaseUrlAddRequestQueue(userData);
+            setupBaseUrlAddRequestQueue();
             queueMock
                 .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: true, userData }, { forefront: true }))
                 .returns(() => Promise.resolve(undefined))
@@ -115,7 +117,7 @@ describe(ApifyRequestQueueCreator, () => {
         fileSystemMock.setup((o) => o.rmSync(localStorageDir, { recursive: true })).verifiable(dirExists ? Times.once() : Times.never());
     }
 
-    function setupBaseUrlAddRequestQueue(userData: any): void {
+    function setupBaseUrlAddRequestQueue(): void {
         queueMock
             .setup((o) => o.addRequest({ url: baseUrl, skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData }))
             .returns(() => Promise.resolve(undefined))

--- a/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
@@ -19,7 +19,7 @@ describe(ApifyRequestQueueCreator, () => {
     const baseUrl = 'url';
     const requestQueueName = 'scanRequests';
     const userData = {
-        keepUrlFragment : false
+        keepUrlFragment: false,
     };
 
     beforeEach(() => {
@@ -95,7 +95,11 @@ describe(ApifyRequestQueueCreator, () => {
                 .returns(() => Promise.resolve(undefined))
                 .verifiable();
 
-            const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: false, inputUrls: inputUrls, keepUrlFragment: true });
+            const queue = await apifyResourceCreator.createRequestQueue(baseUrl, {
+                clear: false,
+                inputUrls: inputUrls,
+                keepUrlFragment: true,
+            });
             expect(queue).toBe(queueMock.object);
         });
     });
@@ -111,10 +115,10 @@ describe(ApifyRequestQueueCreator, () => {
         fileSystemMock.setup((o) => o.rmSync(localStorageDir, { recursive: true })).verifiable(dirExists ? Times.once() : Times.never());
     }
 
-    function setupBaseUrlAddRequestQueue(userData: any) : void {
+    function setupBaseUrlAddRequestQueue(userData: any): void {
         queueMock
-        .setup((o) => o.addRequest({ url: baseUrl, skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData }))
-        .returns(() => Promise.resolve(undefined))
-        .verifiable();
+            .setup((o) => o.addRequest({ url: baseUrl, skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData }))
+            .returns(() => Promise.resolve(undefined))
+            .verifiable();
     }
 });

--- a/packages/crawler/src/apify/apify-request-queue-creator.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.ts
@@ -37,23 +37,26 @@ export class ApifyRequestQueueCreator implements ResourceCreator {
         const requestQueue = await Crawlee.RequestQueue.open(this.requestQueueName);
         const keepUrlFragment = this.getKeepUrlFragment(options?.keepUrlFragment);
         const userData = {
-            keepUrlFragment : keepUrlFragment
+            keepUrlFragment: keepUrlFragment,
         };
         if (baseUrl) {
-            await requestQueue.addRequest({ url: baseUrl.trim(), skipNavigation: true, keepUrlFragment: keepUrlFragment, userData  });
+            await requestQueue.addRequest({ url: baseUrl.trim(), skipNavigation: true, keepUrlFragment: keepUrlFragment, userData });
         }
-        await this.addUrlsFromList(requestQueue,userData, options?.inputUrls);
+        await this.addUrlsFromList(requestQueue, userData, options?.inputUrls);
 
         return requestQueue;
     }
 
-    private async addUrlsFromList(requestQueue: Crawlee.RequestQueue,userData: any, inputUrls?: string[]): Promise<void> {
+    private async addUrlsFromList(requestQueue: Crawlee.RequestQueue, userData: any, inputUrls?: string[]): Promise<void> {
         if (inputUrls === undefined) {
             return;
         }
 
         for (const url of inputUrls) {
-            await requestQueue.addRequest({ url: url.trim(), skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData }, { forefront: true });
+            await requestQueue.addRequest(
+                { url: url.trim(), skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData },
+                { forefront: true },
+            );
         }
     }
 
@@ -64,7 +67,7 @@ export class ApifyRequestQueueCreator implements ResourceCreator {
         }
     }
 
-    private getKeepUrlFragment(keepUrlFragment?: boolean) : boolean {
-        return keepUrlFragment?? false;
+    private getKeepUrlFragment(keepUrlFragment?: boolean): boolean {
+        return keepUrlFragment ?? false;
     }
 }

--- a/packages/crawler/src/apify/apify-request-queue-creator.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.ts
@@ -38,7 +38,7 @@ export class ApifyRequestQueueCreator implements ResourceCreator {
         const keepUrlFragment = this.getKeepUrlFragment(options?.keepUrlFragment);
         const userData = {
             keepUrlFragment: keepUrlFragment,
-        };
+        } as Crawlee.Dictionary;
         if (baseUrl) {
             await requestQueue.addRequest({ url: baseUrl.trim(), skipNavigation: true, keepUrlFragment: keepUrlFragment, userData });
         }
@@ -47,7 +47,7 @@ export class ApifyRequestQueueCreator implements ResourceCreator {
         return requestQueue;
     }
 
-    private async addUrlsFromList(requestQueue: Crawlee.RequestQueue, userData: any, inputUrls?: string[]): Promise<void> {
+    private async addUrlsFromList(requestQueue: Crawlee.RequestQueue, userData: Crawlee.Dictionary, inputUrls?: string[]): Promise<void> {
         if (inputUrls === undefined) {
             return;
         }

--- a/packages/crawler/src/common/url.spec.ts
+++ b/packages/crawler/src/common/url.spec.ts
@@ -15,11 +15,11 @@ describe('tryParseUrlString()', () => {
         expect(url).toEqual('https://example.com');
 
         // remove hash
-        url = Url.normalizeUrl('https://example.com/#top',false);
+        url = Url.normalizeUrl('https://example.com/#top', false);
         expect(url).toEqual('https://example.com');
 
         // do not remove hash
-        url = Url.normalizeUrl('https://example.com/#top',true);
+        url = Url.normalizeUrl('https://example.com/#top', true);
         expect(url).toEqual('https://example.com/#top');
 
         // keep and sort query parameters

--- a/packages/crawler/src/common/url.spec.ts
+++ b/packages/crawler/src/common/url.spec.ts
@@ -14,6 +14,14 @@ describe('tryParseUrlString()', () => {
         url = Url.normalizeUrl('https://example.com/#top');
         expect(url).toEqual('https://example.com');
 
+        // remove hash
+        url = Url.normalizeUrl('https://example.com/#top',false);
+        expect(url).toEqual('https://example.com');
+
+        // do not remove hash
+        url = Url.normalizeUrl('https://example.com/#top',true);
+        expect(url).toEqual('https://example.com/#top');
+
         // keep and sort query parameters
         url = Url.normalizeUrl('https://example.com?b=two&a=one&c=three');
         expect(url).toEqual('https://example.com/?a=one&b=two&c=three');

--- a/packages/crawler/src/common/url.ts
+++ b/packages/crawler/src/common/url.ts
@@ -4,8 +4,8 @@
 import * as normalizeUrlExt from 'normalize-url';
 
 export namespace Url {
-    export function normalizeUrl(url: string, keepUrlFragment?:boolean): string {
-        const stripHash = keepUrlFragment !== null && keepUrlFragment !== undefined ? !keepUrlFragment : true
+    export function normalizeUrl(url: string, keepUrlFragment?: boolean): string {
+        const stripHash = keepUrlFragment !== null && keepUrlFragment !== undefined ? !keepUrlFragment : true;
         return normalizeUrlExt.default(url, { stripHash: stripHash, removeQueryParameters: false });
     }
 

--- a/packages/crawler/src/common/url.ts
+++ b/packages/crawler/src/common/url.ts
@@ -6,6 +6,7 @@ import * as normalizeUrlExt from 'normalize-url';
 export namespace Url {
     export function normalizeUrl(url: string, keepUrlFragment?: boolean): string {
         const stripHash = keepUrlFragment !== null && keepUrlFragment !== undefined ? !keepUrlFragment : true;
+
         return normalizeUrlExt.default(url, { stripHash: stripHash, removeQueryParameters: false });
     }
 

--- a/packages/crawler/src/common/url.ts
+++ b/packages/crawler/src/common/url.ts
@@ -4,8 +4,9 @@
 import * as normalizeUrlExt from 'normalize-url';
 
 export namespace Url {
-    export function normalizeUrl(url: string): string {
-        return normalizeUrlExt.default(url, { stripHash: true, removeQueryParameters: false });
+    export function normalizeUrl(url: string, keepUrlFragment?:boolean): string {
+        const stripHash = keepUrlFragment !== null && keepUrlFragment !== undefined ? !keepUrlFragment : true
+        return normalizeUrlExt.default(url, { stripHash: stripHash, removeQueryParameters: false });
     }
 
     export function hasQueryParameters(url: string): boolean {

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -74,7 +74,7 @@ describe(CrawlerConfiguration, () => {
                 inputUrls: inputUrls,
                 keepUrlFragment: false,
             };
-    
+
             setupMockRequestQueueOptions();
             crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => undefined);
 
@@ -87,7 +87,7 @@ describe(CrawlerConfiguration, () => {
                 inputUrls: inputUrls,
                 keepUrlFragment: false,
             };
-    
+
             setupMockRequestQueueOptions();
             crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => false);
 
@@ -100,14 +100,14 @@ describe(CrawlerConfiguration, () => {
                 inputUrls: inputUrls,
                 keepUrlFragment: true,
             };
-    
+
             setupMockRequestQueueOptions();
             crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => true);
-            
+
             expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
         });
 
-        function setupMockRequestQueueOptions() : void {
+        function setupMockRequestQueueOptions(): void {
             crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
             crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
             crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -75,10 +75,7 @@ describe(CrawlerConfiguration, () => {
                 keepUrlFragment: false,
             };
     
-            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
-            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
-            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
-            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+            setupMockRequestQueueOptions();
             crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => undefined);
 
             expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
@@ -91,10 +88,7 @@ describe(CrawlerConfiguration, () => {
                 keepUrlFragment: false,
             };
     
-            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
-            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
-            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
-            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+            setupMockRequestQueueOptions();
             crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => false);
 
             expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
@@ -107,15 +101,18 @@ describe(CrawlerConfiguration, () => {
                 keepUrlFragment: true,
             };
     
-            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
-            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
-            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
-            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+            setupMockRequestQueueOptions();
             crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => true);
             
             expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
         });
 
+        function setupMockRequestQueueOptions() : void {
+            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
+            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
+            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
+            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+        }
     });
 
     describe('getDiscoveryPattern', () => {

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -62,22 +62,60 @@ describe(CrawlerConfiguration, () => {
         expect(crawlerConfiguration.simulate()).toEqual(simulate === true);
     });
 
-    it('requestQueueOptions', () => {
+    describe('requestQueueOptions', () => {
         const restartCrawl = true;
         const inputUrls = ['input url'];
         const baseCrawlPage = {} as Puppeteer.Page;
         const discoveryPatterns = ['discoveryPattern'];
-        const expectedOptions: RequestQueueOptions = {
-            clear: restartCrawl,
-            inputUrls: inputUrls,
-        };
 
-        crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
-        crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
-        crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
-        crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+        it('keepUrlFragment = undefined', () => {
+            const expectedOptions: RequestQueueOptions = {
+                clear: restartCrawl,
+                inputUrls: inputUrls,
+                keepUrlFragment: false,
+            };
+    
+            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
+            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
+            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
+            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+            crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => undefined);
 
-        expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+            expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+        });
+
+        it('keepUrlFragment = false', () => {
+            const expectedOptions: RequestQueueOptions = {
+                clear: restartCrawl,
+                inputUrls: inputUrls,
+                keepUrlFragment: false,
+            };
+    
+            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
+            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
+            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
+            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+            crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => false);
+
+            expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+        });
+
+        it('keepUrlFragment = true', () => {
+            const expectedOptions: RequestQueueOptions = {
+                clear: restartCrawl,
+                inputUrls: inputUrls,
+                keepUrlFragment: true,
+            };
+    
+            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
+            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
+            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
+            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+            crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => true);
+            
+            expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+        });
+
     });
 
     describe('getDiscoveryPattern', () => {

--- a/packages/crawler/src/crawler/crawler-configuration.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.ts
@@ -69,6 +69,7 @@ export class CrawlerConfiguration {
         return {
             clear: this.crawlerRunOptions.restartCrawl,
             inputUrls: this.crawlerRunOptions.inputUrls,
+            keepUrlFragment: this.crawlerRunOptions.keepUrlFragment ?? false,
         };
     }
 

--- a/packages/crawler/src/page-operations/enqueue-active-elements-operation.ts
+++ b/packages/crawler/src/page-operations/enqueue-active-elements-operation.ts
@@ -17,10 +17,11 @@ export class EnqueueActiveElementsOperation {
 
     public async enqueue(context: Crawlee.PuppeteerCrawlingContext, selectors: string[]): Promise<void> {
         const url = context.page.url();
+        const keepUrlFragment = context.request?.userData?.keepUrlFragment ?? false;
         const elements = await this.activeElementFinder.getActiveElements(context.page, selectors);
         await Promise.all(
             elements.map(async (e) => {
-                const uniqueKey = `${Url.normalizeUrl(url)}#${e.hash}`;
+                const uniqueKey = `${Url.normalizeUrl(url,keepUrlFragment)}#${e.hash}`;
                 const userData: Operation = {
                     operationType: 'click',
                     data: e,
@@ -31,6 +32,8 @@ export class EnqueueActiveElementsOperation {
                     userData,
                     transformRequestFunction: (request) => {
                         request.uniqueKey = uniqueKey;
+                        request.keepUrlFragment = keepUrlFragment;
+                        request.userData.keepUrlFragment = keepUrlFragment;
 
                         return request;
                     },

--- a/packages/crawler/src/page-operations/enqueue-active-elements-operation.ts
+++ b/packages/crawler/src/page-operations/enqueue-active-elements-operation.ts
@@ -21,7 +21,7 @@ export class EnqueueActiveElementsOperation {
         const elements = await this.activeElementFinder.getActiveElements(context.page, selectors);
         await Promise.all(
             elements.map(async (e) => {
-                const uniqueKey = `${Url.normalizeUrl(url,keepUrlFragment)}#${e.hash}`;
+                const uniqueKey = `${Url.normalizeUrl(url, keepUrlFragment)}#${e.hash}`;
                 const userData: Operation = {
                     operationType: 'click',
                     data: e,

--- a/packages/crawler/src/page-processors/page-processor-base.spec.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.spec.ts
@@ -243,12 +243,44 @@ describe(PageProcessorBase, () => {
                 loadedUrl: undefined,
             },
         } as Crawlee.PuppeteerCrawlingContext;
+        context.request.userData = {
+            keepUrlFragment : undefined
+        }
         context.enqueueLinks = jest.fn().mockImplementation(() => Promise.resolve({ processedRequests: [{}] }));
         (pageProcessorBase as any).discoverLinks = true;
 
         const discoveryPatternsRegEx = discoveryPatterns.map((p) => new RegExp(p));
         await pageProcessorBase.enqueueLinks(context);
-        expect(context.enqueueLinks).toHaveBeenCalledWith({ regexps: discoveryPatternsRegEx });
+        expect(context.enqueueLinks).toHaveBeenCalledWith({ regexps: discoveryPatternsRegEx, transformRequestFunction: expect.any(Function) });
+        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0]
+        // Assert the value of request.keepUrlFragment
+        expect(enqueueLinksArgs.transformRequestFunction({}).keepUrlFragment).toBe(false);
+        expect(context.request.loadedUrl).toEqual('url');
+    });
+
+    it('enqueueLinks to keep hash fragments', async () => {
+        const context = {
+            page: {
+                url: () => 'url',
+            },
+            request: {
+                loadedUrl: undefined,
+            },
+        } as Crawlee.PuppeteerCrawlingContext;
+        context.request.userData = {
+            keepUrlFragment : true
+        }
+        context.enqueueLinks = jest.fn().mockImplementation(() => Promise.resolve({ processedRequests: [{}] }));
+        (pageProcessorBase as any).discoverLinks = true;
+
+        const discoveryPatternsRegEx = discoveryPatterns.map((p) => new RegExp(p));
+        await pageProcessorBase.enqueueLinks(context);
+        expect(context.enqueueLinks).toHaveBeenCalledWith({ regexps: discoveryPatternsRegEx, transformRequestFunction: expect.any(Function) });
+
+        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0]
+
+        // Assert the value of request.keepUrlFragment
+        expect(enqueueLinksArgs.transformRequestFunction({}).keepUrlFragment).toBe(true);
         expect(context.request.loadedUrl).toEqual('url');
     });
 

--- a/packages/crawler/src/page-processors/page-processor-base.spec.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.spec.ts
@@ -244,15 +244,18 @@ describe(PageProcessorBase, () => {
             },
         } as Crawlee.PuppeteerCrawlingContext;
         context.request.userData = {
-            keepUrlFragment : undefined
-        }
+            keepUrlFragment: undefined,
+        };
         context.enqueueLinks = jest.fn().mockImplementation(() => Promise.resolve({ processedRequests: [{}] }));
         (pageProcessorBase as any).discoverLinks = true;
 
         const discoveryPatternsRegEx = discoveryPatterns.map((p) => new RegExp(p));
         await pageProcessorBase.enqueueLinks(context);
-        expect(context.enqueueLinks).toHaveBeenCalledWith({ regexps: discoveryPatternsRegEx, transformRequestFunction: expect.any(Function) });
-        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0]
+        expect(context.enqueueLinks).toHaveBeenCalledWith({
+            regexps: discoveryPatternsRegEx,
+            transformRequestFunction: expect.any(Function),
+        });
+        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0];
         // Assert the value of request.keepUrlFragment
         expect(enqueueLinksArgs.transformRequestFunction({}).keepUrlFragment).toBe(false);
         expect(context.request.loadedUrl).toEqual('url');
@@ -268,16 +271,19 @@ describe(PageProcessorBase, () => {
             },
         } as Crawlee.PuppeteerCrawlingContext;
         context.request.userData = {
-            keepUrlFragment : true
-        }
+            keepUrlFragment: true,
+        };
         context.enqueueLinks = jest.fn().mockImplementation(() => Promise.resolve({ processedRequests: [{}] }));
         (pageProcessorBase as any).discoverLinks = true;
 
         const discoveryPatternsRegEx = discoveryPatterns.map((p) => new RegExp(p));
         await pageProcessorBase.enqueueLinks(context);
-        expect(context.enqueueLinks).toHaveBeenCalledWith({ regexps: discoveryPatternsRegEx, transformRequestFunction: expect.any(Function) });
+        expect(context.enqueueLinks).toHaveBeenCalledWith({
+            regexps: discoveryPatternsRegEx,
+            transformRequestFunction: expect.any(Function),
+        });
 
-        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0]
+        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0];
 
         // Assert the value of request.keepUrlFragment
         expect(enqueueLinksArgs.transformRequestFunction({}).keepUrlFragment).toBe(true);

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -165,21 +165,18 @@ export abstract class PageProcessorBase implements PageProcessor {
 
         try {
             const userData = context.request.userData;
-            const keepUrlFragment = userData?.keepUrlFragment ?? false
+            const keepUrlFragment = userData?.keepUrlFragment ?? false;
             const enqueued = await context.enqueueLinks({
                 // eslint-disable-next-line security/detect-non-literal-regexp
                 regexps: this.discoveryPatterns?.length > 0 ? this.discoveryPatterns.map((p) => new RegExp(p)) : undefined,
                 transformRequestFunction: (request) => {
                     request.keepUrlFragment = keepUrlFragment;
-                    if(request.userData)
-                    {
-                        request.userData.keepUrlFragment = keepUrlFragment
-                    }
-                    else
-                    {
+                    if (request.userData) {
+                        request.userData.keepUrlFragment = keepUrlFragment;
+                    } else {
                         request.userData = {
-                            keepUrlFragment : keepUrlFragment
-                        }
+                            keepUrlFragment: keepUrlFragment,
+                        };
                     }
                     return request;
                 },

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -164,9 +164,26 @@ export abstract class PageProcessorBase implements PageProcessor {
         context.request.loadedUrl = context.page.url();
 
         try {
+            console.log(context.request.userData)
+            const userData = context.request.userData;
+            const keepUrlFragment = userData?.keepUrlFragment ?? false
             const enqueued = await context.enqueueLinks({
                 // eslint-disable-next-line security/detect-non-literal-regexp
                 regexps: this.discoveryPatterns?.length > 0 ? this.discoveryPatterns.map((p) => new RegExp(p)) : undefined,
+                transformRequestFunction: (request) => {
+                    request.keepUrlFragment = keepUrlFragment;
+                    if(request.userData)
+                    {
+                        request.userData.keepUrlFragment = keepUrlFragment
+                    }
+                    else
+                    {
+                        request.userData = {
+                            keepUrlFragment : keepUrlFragment
+                        }
+                    }
+                    return request;
+                },
             });
             this.logger.logInfo(`Enqueued ${enqueued.processedRequests.length} new links.`, {
                 url: context.page.url(),

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -178,6 +178,7 @@ export abstract class PageProcessorBase implements PageProcessor {
                             keepUrlFragment: keepUrlFragment,
                         };
                     }
+
                     return request;
                 },
             });

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -164,7 +164,6 @@ export abstract class PageProcessorBase implements PageProcessor {
         context.request.loadedUrl = context.page.url();
 
         try {
-            console.log(context.request.userData)
             const userData = context.request.userData;
             const keepUrlFragment = userData?.keepUrlFragment ?? false
             const enqueued = await context.enqueueLinks({

--- a/packages/crawler/src/types/crawler-run-options.ts
+++ b/packages/crawler/src/types/crawler-run-options.ts
@@ -27,4 +27,5 @@ export interface CrawlerRunOptions {
     httpHeaders?: Record<string, string>;
     adhereFilesystemPattern?: boolean;
     browserOptions?: string[];
+    keepUrlFragment?: boolean;
 }


### PR DESCRIPTION
#### Details

Added new optional parameter keepUrlFragment to enable crawling for URLs having hash fragments for ai-scan cli and crawler packages.
The default value of it is false so that existing scan work as is.

##### Motivation

[Feature 2114928](https://dev.azure.com/mseng/1ES/_workitems/edit/2114928): ADO Extension should be able to crawl hash-routing SPA apps

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
