### PR TITLE
Enable crawling for URLs having hash fragments for ai-scan cli

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -290,3 +290,10 @@ The URL folder is a resource location equal to base URL up-to the last forward s
 type: array
 describe: List of Chrome command line options to pass on browser start. Can be used to disable CORS to scan protected page: --browserOptions disable-web-security
 ```
+
+-   keepUrlFragment: --keepUrlFragment
+
+```sh
+type: boolean
+describe: To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com. Default value is false.
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,6 +85,13 @@ describe: Output directory. If not set, default is ./ai_scan_cli_output, if you 
 default: './ai_scan_cli_output'
 ```
 
+-   keepUrlFragment: --keepUrlFragment
+
+```sh
+type: boolean
+describe: To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com. Default value is false.
+```
+
 </br></br>
 
 ## Scan & Crawl

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -89,7 +89,8 @@ default: './ai_scan_cli_output'
 
 ```sh
 type: boolean
-describe: To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com. Default value is false.
+describe: To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com.
+default: false
 ```
 
 </br></br>
@@ -302,5 +303,6 @@ describe: List of Chrome command line options to pass on browser start. Can be u
 
 ```sh
 type: boolean
-describe: To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com. Default value is false.
+describe: To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com.
+default: 'false
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "2.4.7",
+    "version": "2.5.0",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "2.4.6",
+    "version": "2.4.7",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -163,6 +163,12 @@ function getScanArguments(): ScanArguments {
                 describe: `List of Chrome command line options to pass on browser start. Can be used to disable CORS to scan protected page: --browserOptions disable-web-security`,
                 alias: 'browseroptions',
             },
+            keepUrlFragment: {
+                type: 'boolean',
+                describe: `To keep the hash fragment in the URLs. If set to false, it will remove the hash fragment from URL. For example, http://www.example.com/#foo will be considered as http://www.example.com.`,
+                default: false,
+                alias: 'keepurlfragment',
+            },
         })
         .check((args) => {
             validateScanArguments(args as ScanArguments);

--- a/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.spec.ts
@@ -70,6 +70,7 @@ describe(CrawlerParametersBuilder, () => {
             chromePath: 'chrome path',
             axeSourcePath: 'axe path',
             singleWorker: false,
+            keepUrlFragment: false,
         };
         const actualCrawlOptions = crawlerParametersBuilder.build(scanArguments);
         expect(actualCrawlOptions).toEqual(expectedCrawlOptions);
@@ -112,7 +113,7 @@ describe(CrawlerParametersBuilder, () => {
             .returns(() => fileContent)
             .verifiable();
         const actualCrawlOptions = crawlerParametersBuilder.build(scanArguments);
-        expect(actualCrawlOptions).toEqual({ inputUrls: [urls[0], urls[2]] });
+        expect(actualCrawlOptions).toEqual({ inputUrls: [urls[0], urls[2]], keepUrlFragment: false });
     });
 
     it('validate input file exists', () => {

--- a/packages/cli/src/crawler/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.ts
@@ -62,6 +62,7 @@ export class CrawlerParametersBuilder {
             httpHeaders: headers,
             adhereFilesystemPattern: scanArguments.adhereFilesystemPattern,
             browserOptions: scanArguments.browserOptions,
+            keepUrlFragment: scanArguments.keepUrlFragment ?? false,
         };
     }
 

--- a/packages/cli/src/scan-arguments.ts
+++ b/packages/cli/src/scan-arguments.ts
@@ -30,4 +30,5 @@ export interface ScanArguments {
     httpHeaders?: string;
     adhereFilesystemPattern?: boolean;
     browserOptions?: string[];
+    keepUrlFragment?: boolean;
 }

--- a/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
@@ -70,12 +70,14 @@ describe(ApifyRequestQueueCreator, () => {
             const inputUrls = ['url1', 'url2'];
 
             setupBaseUrlAddRequestQueue();
-            queueMock.setup((o) =>
-                o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }),
-            );
-            queueMock.setup((o) =>
-                o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }),
-            );
+            queueMock
+                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
+                .returns(() => Promise.resolve(undefined))
+                .verifiable();
+            queueMock
+                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
+                .returns(() => Promise.resolve(undefined))
+                .verifiable();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: false, inputUrls: inputUrls });
             expect(queue).toBe(queueMock.object);

--- a/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
@@ -70,10 +70,12 @@ describe(ApifyRequestQueueCreator, () => {
             const inputUrls = ['url1', 'url2'];
 
             setupBaseUrlAddRequestQueue();
-            queueMock
-                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
-            queueMock
-                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
+            queueMock.setup((o) =>
+                o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }),
+            );
+            queueMock.setup((o) =>
+                o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }),
+            );
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: false, inputUrls: inputUrls });
             expect(queue).toBe(queueMock.object);

--- a/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.spec.ts
@@ -15,6 +15,7 @@ describe(ApifyRequestQueueCreator, () => {
     let fileSystemMock: IMock<typeof fs>;
     let queueMock: IMock<Crawlee.RequestQueue>;
     let apifyResourceCreator: ApifyRequestQueueCreator;
+    let userData: Crawlee.Dictionary;
 
     const baseUrl = 'url';
     const requestQueueName = 'scanRequests';
@@ -25,12 +26,12 @@ describe(ApifyRequestQueueCreator, () => {
         queueMock = getPromisableDynamicMock(Mock.ofType<Crawlee.RequestQueue>());
 
         Crawlee.RequestQueue.open = jest.fn().mockImplementation(() => Promise.resolve(queueMock.object));
-        queueMock
-            .setup((o) => o.addRequest({ url: baseUrl, skipNavigation: true }))
-            .returns(() => Promise.resolve(undefined))
-            .verifiable();
 
         apifyResourceCreator = new ApifyRequestQueueCreator(settingsHandlerMock.object, fileSystemMock.object);
+
+        userData = {
+            keepUrlFragment: false,
+        };
     });
 
     afterEach(() => {
@@ -43,6 +44,7 @@ describe(ApifyRequestQueueCreator, () => {
     describe('createRequestQueue', () => {
         it('create queue', async () => {
             fileSystemMock.setup((o) => o.rmSync(It.isAny(), It.isAny())).verifiable(Times.never());
+            setupBaseUrlAddRequestQueue();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl);
             expect(queue).toBe(queueMock.object);
@@ -50,6 +52,7 @@ describe(ApifyRequestQueueCreator, () => {
 
         it('delete local queue storage', async () => {
             setupClearRequestQueue(true);
+            setupBaseUrlAddRequestQueue();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: true });
             expect(queue).toBe(queueMock.object);
@@ -57,6 +60,7 @@ describe(ApifyRequestQueueCreator, () => {
 
         it('skip delete local queue storage', async () => {
             setupClearRequestQueue(false);
+            setupBaseUrlAddRequestQueue();
 
             const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: true });
             expect(queue).toBe(queueMock.object);
@@ -65,16 +69,35 @@ describe(ApifyRequestQueueCreator, () => {
         it('create queue with input urls"', async () => {
             const inputUrls = ['url1', 'url2'];
 
+            setupBaseUrlAddRequestQueue();
             queueMock
-                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true }, { forefront: true }))
+                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
+            queueMock
+                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: false, userData }, { forefront: true }))
+
+            const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: false, inputUrls: inputUrls });
+            expect(queue).toBe(queueMock.object);
+        });
+
+        it('create queue with input urls and keepUrlFragment true', async () => {
+            const inputUrls = ['url1', 'url2'];
+            userData.keepUrlFragment = true;
+
+            setupBaseUrlAddRequestQueue();
+            queueMock
+                .setup((o) => o.addRequest({ url: 'url1', skipNavigation: true, keepUrlFragment: true, userData }, { forefront: true }))
                 .returns(() => Promise.resolve(undefined))
                 .verifiable();
             queueMock
-                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true }, { forefront: true }))
+                .setup((o) => o.addRequest({ url: 'url2', skipNavigation: true, keepUrlFragment: true, userData }, { forefront: true }))
                 .returns(() => Promise.resolve(undefined))
                 .verifiable();
 
-            const queue = await apifyResourceCreator.createRequestQueue(baseUrl, { clear: false, inputUrls: inputUrls });
+            const queue = await apifyResourceCreator.createRequestQueue(baseUrl, {
+                clear: false,
+                inputUrls: inputUrls,
+                keepUrlFragment: true,
+            });
             expect(queue).toBe(queueMock.object);
         });
     });
@@ -88,5 +111,12 @@ describe(ApifyRequestQueueCreator, () => {
             });
         fileSystemMock.setup((o) => o.existsSync(localStorageDir)).returns(() => dirExists);
         fileSystemMock.setup((o) => o.rmSync(localStorageDir, { recursive: true })).verifiable(dirExists ? Times.once() : Times.never());
+    }
+
+    function setupBaseUrlAddRequestQueue(): void {
+        queueMock
+            .setup((o) => o.addRequest({ url: baseUrl, skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData }))
+            .returns(() => Promise.resolve(undefined))
+            .verifiable();
     }
 });

--- a/packages/crawler/src/apify/apify-request-queue-creator.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.ts
@@ -11,6 +11,7 @@ import { ApifySettingsHandler, apifySettingsHandler } from './apify-settings';
 export type RequestQueueOptions = {
     clear?: boolean;
     inputUrls?: string[];
+    keepUrlFragment?: boolean;
 };
 
 export type ApifyRequestQueueFactory = () => Promise<Crawlee.RequestQueue>;
@@ -34,21 +35,28 @@ export class ApifyRequestQueueCreator implements ResourceCreator {
         }
 
         const requestQueue = await Crawlee.RequestQueue.open(this.requestQueueName);
+        const keepUrlFragment = this.getKeepUrlFragment(options?.keepUrlFragment);
+        const userData = {
+            keepUrlFragment: keepUrlFragment,
+        } as Crawlee.Dictionary;
         if (baseUrl) {
-            await requestQueue.addRequest({ url: baseUrl.trim(), skipNavigation: true });
+            await requestQueue.addRequest({ url: baseUrl.trim(), skipNavigation: true, keepUrlFragment: keepUrlFragment, userData });
         }
-        await this.addUrlsFromList(requestQueue, options?.inputUrls);
+        await this.addUrlsFromList(requestQueue, userData, options?.inputUrls);
 
         return requestQueue;
     }
 
-    private async addUrlsFromList(requestQueue: Crawlee.RequestQueue, inputUrls?: string[]): Promise<void> {
+    private async addUrlsFromList(requestQueue: Crawlee.RequestQueue, userData: Crawlee.Dictionary, inputUrls?: string[]): Promise<void> {
         if (inputUrls === undefined) {
             return;
         }
 
         for (const url of inputUrls) {
-            await requestQueue.addRequest({ url: url.trim(), skipNavigation: true }, { forefront: true });
+            await requestQueue.addRequest(
+                { url: url.trim(), skipNavigation: true, keepUrlFragment: userData.keepUrlFragment, userData },
+                { forefront: true },
+            );
         }
     }
 
@@ -57,5 +65,9 @@ export class ApifyRequestQueueCreator implements ResourceCreator {
         if (this.fileSystem.existsSync(outputDir)) {
             this.fileSystem.rmSync(outputDir, { recursive: true });
         }
+    }
+
+    private getKeepUrlFragment(keepUrlFragment?: boolean): boolean {
+        return keepUrlFragment ?? false;
     }
 }

--- a/packages/crawler/src/common/url.spec.ts
+++ b/packages/crawler/src/common/url.spec.ts
@@ -14,6 +14,14 @@ describe('tryParseUrlString()', () => {
         url = Url.normalizeUrl('https://example.com/#top');
         expect(url).toEqual('https://example.com');
 
+        // remove hash
+        url = Url.normalizeUrl('https://example.com/#top', false);
+        expect(url).toEqual('https://example.com');
+
+        // do not remove hash
+        url = Url.normalizeUrl('https://example.com/#top', true);
+        expect(url).toEqual('https://example.com/#top');
+
         // keep and sort query parameters
         url = Url.normalizeUrl('https://example.com?b=two&a=one&c=three');
         expect(url).toEqual('https://example.com/?a=one&b=two&c=three');

--- a/packages/crawler/src/common/url.ts
+++ b/packages/crawler/src/common/url.ts
@@ -4,8 +4,10 @@
 import * as normalizeUrlExt from 'normalize-url';
 
 export namespace Url {
-    export function normalizeUrl(url: string): string {
-        return normalizeUrlExt.default(url, { stripHash: true, removeQueryParameters: false });
+    export function normalizeUrl(url: string, keepUrlFragment?: boolean): string {
+        const stripHash = keepUrlFragment !== null && keepUrlFragment !== undefined ? !keepUrlFragment : true;
+
+        return normalizeUrlExt.default(url, { stripHash: stripHash, removeQueryParameters: false });
     }
 
     export function hasQueryParameters(url: string): boolean {

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -62,22 +62,57 @@ describe(CrawlerConfiguration, () => {
         expect(crawlerConfiguration.simulate()).toEqual(simulate === true);
     });
 
-    it('requestQueueOptions', () => {
+    describe('requestQueueOptions', () => {
         const restartCrawl = true;
         const inputUrls = ['input url'];
         const baseCrawlPage = {} as Puppeteer.Page;
         const discoveryPatterns = ['discoveryPattern'];
-        const expectedOptions: RequestQueueOptions = {
-            clear: restartCrawl,
-            inputUrls: inputUrls,
-        };
+        
+        it('keepUrlFragment = undefined', () => {
+            const expectedOptions: RequestQueueOptions = {
+                clear: restartCrawl,
+                inputUrls: inputUrls,
+                keepUrlFragment: false,
+            };
 
-        crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
-        crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
-        crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
-        crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+            setupMockRequestQueueOptions();
+            crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => undefined);
 
-        expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+            expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+        });
+
+        it('keepUrlFragment = false', () => {
+            const expectedOptions: RequestQueueOptions = {
+                clear: restartCrawl,
+                inputUrls: inputUrls,
+                keepUrlFragment: false,
+            };
+
+            setupMockRequestQueueOptions();
+            crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => false);
+
+            expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+        });
+
+        it('keepUrlFragment = true', () => {
+            const expectedOptions: RequestQueueOptions = {
+                clear: restartCrawl,
+                inputUrls: inputUrls,
+                keepUrlFragment: true,
+            };
+
+            setupMockRequestQueueOptions();
+            crawlerRunOptionsMock.setup((o) => o.keepUrlFragment).returns(() => true);
+
+            expect(crawlerConfiguration.requestQueueOptions()).toEqual(expectedOptions);
+        });
+
+        function setupMockRequestQueueOptions(): void {
+            crawlerRunOptionsMock.setup((o) => o.restartCrawl).returns(() => restartCrawl);
+            crawlerRunOptionsMock.setup((o) => o.inputUrls).returns(() => inputUrls);
+            crawlerRunOptionsMock.setup((o) => o.baseCrawlPage).returns(() => baseCrawlPage);
+            crawlerRunOptionsMock.setup((o) => o.discoveryPatterns).returns(() => discoveryPatterns);
+        }
     });
 
     describe('getDiscoveryPattern', () => {

--- a/packages/crawler/src/crawler/crawler-configuration.spec.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.spec.ts
@@ -67,7 +67,7 @@ describe(CrawlerConfiguration, () => {
         const inputUrls = ['input url'];
         const baseCrawlPage = {} as Puppeteer.Page;
         const discoveryPatterns = ['discoveryPattern'];
-        
+
         it('keepUrlFragment = undefined', () => {
             const expectedOptions: RequestQueueOptions = {
                 clear: restartCrawl,

--- a/packages/crawler/src/crawler/crawler-configuration.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.ts
@@ -69,6 +69,7 @@ export class CrawlerConfiguration {
         return {
             clear: this.crawlerRunOptions.restartCrawl,
             inputUrls: this.crawlerRunOptions.inputUrls,
+            keepUrlFragment: this.crawlerRunOptions.keepUrlFragment ?? false,
         };
     }
 

--- a/packages/crawler/src/page-operations/enqueue-active-elements-operation.ts
+++ b/packages/crawler/src/page-operations/enqueue-active-elements-operation.ts
@@ -17,10 +17,11 @@ export class EnqueueActiveElementsOperation {
 
     public async enqueue(context: Crawlee.PuppeteerCrawlingContext, selectors: string[]): Promise<void> {
         const url = context.page.url();
+        const keepUrlFragment = context.request?.userData?.keepUrlFragment ?? false;
         const elements = await this.activeElementFinder.getActiveElements(context.page, selectors);
         await Promise.all(
             elements.map(async (e) => {
-                const uniqueKey = `${Url.normalizeUrl(url)}#${e.hash}`;
+                const uniqueKey = `${Url.normalizeUrl(url, keepUrlFragment)}#${e.hash}`;
                 const userData: Operation = {
                     operationType: 'click',
                     data: e,
@@ -31,6 +32,8 @@ export class EnqueueActiveElementsOperation {
                     userData,
                     transformRequestFunction: (request) => {
                         request.uniqueKey = uniqueKey;
+                        request.keepUrlFragment = keepUrlFragment;
+                        request.userData.keepUrlFragment = keepUrlFragment;
 
                         return request;
                     },

--- a/packages/crawler/src/page-processors/page-processor-base.spec.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.spec.ts
@@ -278,7 +278,7 @@ describe(PageProcessorBase, () => {
 
         const discoveryPatternsRegEx = discoveryPatterns.map((p) => new RegExp(p));
         await pageProcessorBase.enqueueLinks(context);
-        
+
         expect(context.enqueueLinks).toHaveBeenCalledWith({
             regexps: discoveryPatternsRegEx,
             transformRequestFunction: expect.any(Function),

--- a/packages/crawler/src/page-processors/page-processor-base.spec.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.spec.ts
@@ -243,11 +243,51 @@ describe(PageProcessorBase, () => {
                 loadedUrl: undefined,
             },
         } as Crawlee.PuppeteerCrawlingContext;
+        context.request.userData = {
+            keepUrlFragment: undefined,
+        };
         context.enqueueLinks = jest.fn().mockImplementation(() => Promise.resolve({ processedRequests: [{}] }));
         (pageProcessorBase as any).discoverLinks = true;
 
         const discoveryPatternsRegEx = discoveryPatterns.map((p) => new RegExp(p));
         await pageProcessorBase.enqueueLinks(context);
+        expect(context.enqueueLinks).toHaveBeenCalledWith({
+            regexps: discoveryPatternsRegEx,
+            transformRequestFunction: expect.any(Function),
+        });
+        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0];
+        // Assert the value of request.keepUrlFragment
+        expect(enqueueLinksArgs.transformRequestFunction({}).keepUrlFragment).toBe(false);
+        expect(context.request.loadedUrl).toEqual('url');
+    });
+
+    it('enqueueLinks to keep hash fragments', async () => {
+        const context = {
+            page: {
+                url: () => 'url',
+            },
+            request: {
+                loadedUrl: undefined,
+            },
+        } as Crawlee.PuppeteerCrawlingContext;
+        context.request.userData = {
+            keepUrlFragment: true,
+        };
+        context.enqueueLinks = jest.fn().mockImplementation(() => Promise.resolve({ processedRequests: [{}] }));
+        (pageProcessorBase as any).discoverLinks = true;
+
+        const discoveryPatternsRegEx = discoveryPatterns.map((p) => new RegExp(p));
+        await pageProcessorBase.enqueueLinks(context);
+        
+        expect(context.enqueueLinks).toHaveBeenCalledWith({
+            regexps: discoveryPatternsRegEx,
+            transformRequestFunction: expect.any(Function),
+        });
+
+        const enqueueLinksArgs = (context.enqueueLinks as any).mock?.calls[0][0];
+
+        // Assert the value of request.keepUrlFragment
+        expect(enqueueLinksArgs.transformRequestFunction({}).keepUrlFragment).toBe(true);
         expect(context.enqueueLinks).toHaveBeenCalledWith({ regexps: discoveryPatternsRegEx });
         expect(context.request.loadedUrl).toEqual('url');
     });

--- a/packages/crawler/src/page-processors/page-processor-base.spec.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.spec.ts
@@ -288,7 +288,6 @@ describe(PageProcessorBase, () => {
 
         // Assert the value of request.keepUrlFragment
         expect(enqueueLinksArgs.transformRequestFunction({}).keepUrlFragment).toBe(true);
-        expect(context.enqueueLinks).toHaveBeenCalledWith({ regexps: discoveryPatternsRegEx });
         expect(context.request.loadedUrl).toEqual('url');
     });
 

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -164,9 +164,23 @@ export abstract class PageProcessorBase implements PageProcessor {
         context.request.loadedUrl = context.page.url();
 
         try {
+            const userData = context.request.userData;
+            const keepUrlFragment = userData?.keepUrlFragment ?? false;
             const enqueued = await context.enqueueLinks({
                 // eslint-disable-next-line security/detect-non-literal-regexp
                 regexps: this.discoveryPatterns?.length > 0 ? this.discoveryPatterns.map((p) => new RegExp(p)) : undefined,
+                transformRequestFunction: (newRequest) => {
+                    newRequest.keepUrlFragment = keepUrlFragment;
+                    if (newRequest.userData) {
+                        newRequest.userData.keepUrlFragment = keepUrlFragment;
+                    } else {
+                        newRequest.userData = {
+                            keepUrlFragment: keepUrlFragment,
+                        };
+                    }
+
+                    return newRequest;
+                },
             });
             this.logger.logInfo(`Enqueued ${enqueued.processedRequests.length} new links.`, {
                 url: context.page.url(),

--- a/packages/crawler/src/types/crawler-run-options.ts
+++ b/packages/crawler/src/types/crawler-run-options.ts
@@ -27,4 +27,5 @@ export interface CrawlerRunOptions {
     httpHeaders?: Record<string, string>;
     adhereFilesystemPattern?: boolean;
     browserOptions?: string[];
+    keepUrlFragment?: boolean;
 }


### PR DESCRIPTION
#### Details

Added new optional parameter keepUrlFragment to enable crawling for URLs having hash fragments for ai-scan cli and crawler packages.
The default value of it is false so that existing scan work as is.

##### Motivation

[Feature 2114928](https://dev.azure.com/mseng/1ES/_workitems/edit/2114928): ADO Extension should be able to crawl hash-routing SPA apps

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] Validated in an Azure resource group
