### PR TITLE
Use az cli auth credentials for local app debugging 

### DIFF
--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -44,6 +44,7 @@
         "@azure/cosmos": "^4.0.0",
         "@azure/identity": "^3.1.3",
         "@azure/keyvault-secrets": "^4.6.0",
+        "@azure/ms-rest-js": "^2.7.0",
         "@azure/ms-rest-nodeauth": "^3.1.1",
         "@azure/storage-blob": "^12.12.0",
         "@azure/storage-queue": "^12.11.0",

--- a/packages/azure-services/src/credentials/credentials-provider.spec.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.spec.ts
@@ -4,7 +4,7 @@
 import 'reflect-metadata';
 
 import { IMock, Mock, Times } from 'typemoq';
-import { EnvironmentCredential } from '@azure/identity';
+import { AzureCliCredential } from '@azure/identity';
 import { CredentialsProvider } from './credentials-provider';
 import { MSICredentialsProvider, AuthenticationMethod } from './msi-credential-provider';
 import { ManagedIdentityCredentialCache } from './managed-identity-credential-cache';
@@ -47,13 +47,13 @@ describe(CredentialsProvider, () => {
         expect(credential).toBe(managedIdentityCredentialCacheMock.object);
     });
 
-    it('getAzureCredential creates EnvironmentCredential instance', () => {
+    it('getAzureCredential creates AzureCliCredential instance', () => {
         testSubject = new CredentialsProvider(
             msiCredProviderMock.object,
             managedIdentityCredentialCacheMock.object,
-            AuthenticationMethod.servicePrincipal,
+            AuthenticationMethod.azureCliCredentials,
         );
         const credential = testSubject.getAzureCredential();
-        expect(credential).toBeInstanceOf(EnvironmentCredential);
+        expect(credential).toBeInstanceOf(AzureCliCredential);
     });
 });

--- a/packages/azure-services/src/credentials/credentials-provider.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TokenCredential, EnvironmentCredential } from '@azure/identity';
+import { TokenCredential, AzureCliCredential } from '@azure/identity';
 import { inject, injectable } from 'inversify';
 import { iocTypeNames } from '../ioc-types';
 import { Credentials, MSICredentialsProvider, AuthenticationMethod } from './msi-credential-provider';
@@ -16,14 +16,12 @@ export class CredentialsProvider {
     ) {}
 
     public async getCredentialsForBatch(): Promise<Credentials> {
-        // eslint-disable-next-line max-len
-        // ref https://docs.microsoft.com/en-us/rest/api/batchservice/authenticate-requests-to-the-azure-batch-service#authentication-via-azure-ad
         return this.getCredentialsForResource('https://batch.core.windows.net/');
     }
 
     public getAzureCredential(): TokenCredential {
-        if (this.authenticationMethod === AuthenticationMethod.servicePrincipal) {
-            return new EnvironmentCredential();
+        if (this.authenticationMethod === AuthenticationMethod.azureCliCredentials) {
+            return new AzureCliCredential();
         } else {
             // must be object instance to reuse an internal cache
             return this.managedIdentityCredentialCache;

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -106,7 +106,7 @@ function createCosmosContainerClient(container: interfaces.Container, dbName: st
 }
 
 function setupAzureKeyVaultClientProvider(container: Container): void {
-    IoC.setupSingletonProvider<SecretClient>(iocTypeNames.AzureKeyVaultClientProvider, container, async (context) => {
+    IoC.setupSingletonProvider<SecretClient>(iocTypeNames.AzureKeyVaultClientProvider, container, async () => {
         const credentialProvider = container.get(CredentialsProvider);
         const credentials = credentialProvider.getAzureCredential();
 
@@ -223,7 +223,7 @@ function setupAuthenticationMethod(container: Container): void {
         .bind(iocTypeNames.AuthenticationMethod)
         .toConstantValue(
             System.isDebugEnabled() === true || process.env.LOCAL_AUTH === 'true'
-                ? AuthenticationMethod.servicePrincipal
+                ? AuthenticationMethod.azureCliCredentials
                 : AuthenticationMethod.managedIdentity,
         );
 }

--- a/packages/resource-deployment/scripts/create-env-file-for-debug.sh
+++ b/packages/resource-deployment/scripts/create-env-file-for-debug.sh
@@ -108,10 +108,6 @@ AZURE_STORAGE_NAME=$storageAccountName
 COSMOS_DB_URL=$cosmosDbUrl
 COSMOS_DB_KEY=$cosmosDbAccessKey
 
-AZURE_TENANT_ID=$tenant
-AZURE_CLIENT_ID=$clientId
-AZURE_CLIENT_SECRET=$password
-
 AZ_BATCH_POOL_ID=
 AZ_BATCH_JOB_ID=1-dev-test-job
 AZ_BATCH_TASK_ID=dev-test-task

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/ms-rest-js@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "@azure/ms-rest-js@npm:2.7.0"
+  dependencies:
+    "@azure/core-auth": ^1.1.4
+    abort-controller: ^3.0.0
+    form-data: ^2.5.0
+    node-fetch: ^2.6.7
+    tslib: ^1.10.0
+    tunnel: 0.0.6
+    uuid: ^8.3.2
+    xml2js: ^0.5.0
+  checksum: 38434010f3fc54a625f637a7758358d7ce0ad3e55ce9a6c7490bf05bbec8ea75ae95fe80041d2376beb3ef78ee6e55858bd0541477d7a88703246e368cfd59c1
+  languageName: node
+  linkType: hard
+
 "@azure/ms-rest-nodeauth@npm:^3.1.1":
   version: 3.1.1
   resolution: "@azure/ms-rest-nodeauth@npm:3.1.1"
@@ -5596,6 +5612,7 @@ __metadata:
     "@azure/cosmos": ^4.0.0
     "@azure/identity": ^3.1.3
     "@azure/keyvault-secrets": ^4.6.0
+    "@azure/ms-rest-js": ^2.7.0
     "@azure/ms-rest-nodeauth": ^3.1.1
     "@azure/storage-blob": ^12.12.0
     "@azure/storage-queue": ^12.11.0
@@ -16669,7 +16686,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xml2js@npm:^0.4.19":
+"xml2js@npm:^0.4.19, xml2js@npm:^0.5.0":
   version: 0.5.0
   resolution: "xml2js@npm:0.5.0"
   dependencies:


### PR DESCRIPTION
#### Details

Use az cli auth credentials for local app debugging instead of service principal.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
