### PR TITLE
Capture page state at the end of workflow

### DIFF
--- a/packages/privacy-scan-runner/src/processor/page-scan-processor.spec.ts
+++ b/packages/privacy-scan-runner/src/processor/page-scan-processor.spec.ts
@@ -44,14 +44,6 @@ describe(PageScanProcessor, () => {
             id: 'id',
             deepScan: undefined,
         };
-        pageMock
-            .setup((o) => o.getPageScreenshot())
-            .returns(() => Promise.resolve(pageScreenshot))
-            .verifiable();
-        pageMock
-            .setup((o) => o.getPageSnapshot())
-            .returns(() => Promise.resolve(pageSnapshot))
-            .verifiable();
         privacyScanResult = { scannedUrl: url } as PrivacyScanResult;
         websiteScanData = { id: 'websiteScanDataId' } as WebsiteScanData;
         pageMetadata = {
@@ -82,6 +74,7 @@ describe(PageScanProcessor, () => {
     });
 
     it('run successful scan', async () => {
+        setupCapturePageState();
         setupOpenPage();
         setupClosePage();
         privacyScannerMock
@@ -95,6 +88,7 @@ describe(PageScanProcessor, () => {
     });
 
     it('run successful scan with known pages list', async () => {
+        setupCapturePageState();
         setupOpenPage();
         setupClosePage();
         privacyScannerMock
@@ -175,5 +169,12 @@ describe(PageScanProcessor, () => {
 
     function setupClosePage(): void {
         pageMock.setup((p) => p.close()).verifiable();
+    }
+
+    function setupCapturePageState(): void {
+        pageMock
+            .setup((o) => o.capturePageState())
+            .returns(() => Promise.resolve({ pageScreenshot, pageSnapshot }))
+            .verifiable();
     }
 });

--- a/packages/privacy-scan-runner/src/processor/page-scan-processor.ts
+++ b/packages/privacy-scan-runner/src/processor/page-scan-processor.ts
@@ -38,10 +38,12 @@ export class PageScanProcessor {
                 return { error: this.page.browserError, pageResponseCode: this.page.browserError.statusCode };
             }
 
-            privacyScanResults = await this.runPrivacyScan(scanMetadata.url);
+            privacyScanResults = await this.privacyScanner.scan(scanMetadata.url, this.page);
             await this.deepScanner.runDeepScan(pageScanResult, websiteScanData, this.page);
 
             // Taking a screenshot of the page might break the page layout. Run at the end of the workflow.
+            // Perform hard page reload to show the page's state with the privacy banner displayed.
+            await this.page.reload({ hardReload: true });
             const pageState = await this.page.capturePageState();
             privacyScanResults = { ...privacyScanResults, ...pageState };
         } finally {
@@ -49,12 +51,6 @@ export class PageScanProcessor {
         }
 
         return privacyScanResults;
-    }
-
-    private async runPrivacyScan(url: string): Promise<PrivacyScanResult> {
-        const privacyScanResult = await this.privacyScanner.scan(url, this.page);
-
-        return privacyScanResult;
     }
 
     private getScannableState(pageMetadata: PageMetadata): PrivacyScanResult {

--- a/packages/privacy-scan-runner/src/processor/page-scan-processor.ts
+++ b/packages/privacy-scan-runner/src/processor/page-scan-processor.ts
@@ -38,27 +38,17 @@ export class PageScanProcessor {
                 return { error: this.page.browserError, pageResponseCode: this.page.browserError.statusCode };
             }
 
-            const pageState = await this.capturePageState();
-
             privacyScanResults = await this.runPrivacyScan(scanMetadata.url);
-            privacyScanResults = { ...privacyScanResults, ...pageState };
-
             await this.deepScanner.runDeepScan(pageScanResult, websiteScanData, this.page);
+
+            // Taking a screenshot of the page might break the page layout. Run at the end of the workflow.
+            const pageState = await this.page.capturePageState();
+            privacyScanResults = { ...privacyScanResults, ...pageState };
         } finally {
             await this.page.close();
         }
 
         return privacyScanResults;
-    }
-
-    private async capturePageState(): Promise<PrivacyScanResult> {
-        const pageSnapshot = await this.page.getPageSnapshot();
-        const pageScreenshot = await this.page.getPageScreenshot();
-
-        return {
-            pageSnapshot,
-            pageScreenshot,
-        };
     }
 
     private async runPrivacyScan(url: string): Promise<PrivacyScanResult> {

--- a/packages/service-library/src/website-builder/page-metadata-generator.spec.ts
+++ b/packages/service-library/src/website-builder/page-metadata-generator.spec.ts
@@ -90,7 +90,7 @@ describe(PageMetadataGenerator, () => {
         pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
         pageMock
             .setup((o) => o.analyze(url))
-            .returns(() => Promise.resolve())
+            .returns(() => Promise.resolve(undefined))
             .verifiable();
         const expectedPageMetadata = {
             url,
@@ -114,7 +114,7 @@ describe(PageMetadataGenerator, () => {
         pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
         pageMock
             .setup((o) => o.analyze(url))
-            .returns(() => Promise.resolve())
+            .returns(() => Promise.resolve(undefined))
             .verifiable();
         const expectedPageMetadata = {
             url,
@@ -136,7 +136,7 @@ describe(PageMetadataGenerator, () => {
         pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
         pageMock
             .setup((o) => o.analyze(url))
-            .returns(() => Promise.resolve())
+            .returns(() => Promise.resolve(undefined))
             .verifiable();
         const expectedPageMetadata = {
             url,
@@ -162,7 +162,7 @@ describe(PageMetadataGenerator, () => {
         pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
         pageMock
             .setup((o) => o.analyze(url))
-            .returns(() => Promise.resolve())
+            .returns(() => Promise.resolve(undefined))
             .verifiable();
         const expectedPageMetadata = {
             url,
@@ -187,7 +187,7 @@ describe(PageMetadataGenerator, () => {
         pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
         pageMock
             .setup((o) => o.analyze(url))
-            .returns(() => Promise.resolve())
+            .returns(() => Promise.resolve(undefined))
             .verifiable();
         const expectedPageMetadata = {
             url,
@@ -217,7 +217,7 @@ describe(PageMetadataGenerator, () => {
         pageMock.setup((o) => o.pageAnalysisResult).returns(() => pageAnalysisResult);
         pageMock
             .setup((o) => o.analyze(url))
-            .returns(() => Promise.resolve())
+            .returns(() => Promise.resolve(undefined))
             .verifiable();
         const expectedPageMetadata = {
             url,

--- a/packages/web-api-scan-runner/src/processor/page-scan-processor.spec.ts
+++ b/packages/web-api-scan-runner/src/processor/page-scan-processor.spec.ts
@@ -118,7 +118,7 @@ describe(PageScanProcessor, () => {
 
         setupReopenBrowser();
         setupNavigatePage(url, true);
-        setupGetPageState();
+        setupCapturePageState();
         setupClosePage();
         axeScannerMock
             .setup((s) => s.scan(pageMock.object))
@@ -163,7 +163,7 @@ describe(PageScanProcessor, () => {
 
         setupReopenBrowser();
         setupNavigatePage();
-        setupGetPageState();
+        setupCapturePageState();
         setupClosePage();
         axeScannerMock
             .setup((s) => s.scan(pageMock.object))
@@ -184,7 +184,6 @@ describe(PageScanProcessor, () => {
         const error = new Error('test error');
 
         setupNavigatePage();
-        setupGetPageState();
         setupClosePage();
         axeScannerMock.setup((s) => s.scan(pageMock.object)).throws(error);
         deepScannerMock.setup((o) => o.runDeepScan(It.isAny(), websiteScanData, It.isAny())).verifiable(Times.never());
@@ -228,7 +227,6 @@ describe(PageScanProcessor, () => {
         const error = new Error('test error');
 
         setupNavigatePage();
-        setupGetPageState();
         setupClosePage();
         axeScannerMock
             .setup((s) => s.scan(pageMock.object))
@@ -252,13 +250,9 @@ function setupClosePage(): void {
     pageMock.setup((p) => p.close()).verifiable();
 }
 
-function setupGetPageState(): void {
+function setupCapturePageState(): void {
     pageMock
-        .setup((o) => o.getPageScreenshot())
-        .returns(() => Promise.resolve(pageScreenshot))
-        .verifiable();
-    pageMock
-        .setup((o) => o.getPageSnapshot())
-        .returns(() => Promise.resolve(pageSnapshot))
+        .setup((o) => o.capturePageState())
+        .returns(() => Promise.resolve({ pageScreenshot, pageSnapshot }))
         .verifiable();
 }


### PR DESCRIPTION
#### Details

Capture page state at the end of workflow to prevent page layout break.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
