### PR TITLE
Fixed WebGL extended timeout rendering workflow

### DIFF
--- a/packages/scanner-global-library/src/authenticator/resource-authenticator.spec.ts
+++ b/packages/scanner-global-library/src/authenticator/resource-authenticator.spec.ts
@@ -9,7 +9,7 @@ import { GlobalLogger } from 'logger';
 import { System } from 'common';
 import { NavigationResponse } from '../page-navigator';
 import { PageResponseProcessor } from '../page-response-processor';
-import { puppeteerTimeoutConfig } from '../page-timeout-config';
+import { PuppeteerTimeoutConfig } from '../page-timeout-config';
 import { BrowserError } from '../browser-error';
 import { ResourceAuthenticator } from './resource-authenticator';
 import { LoginPageClientFactory } from './login-page-client-factory';
@@ -54,7 +54,7 @@ describe(ResourceAuthenticator, () => {
         const browserError = { statusCode: 404 } as BrowserError;
         const gotoError = new Error('404');
         puppeteerPageMock
-            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec }))
+            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec }))
             .returns(() => Promise.reject(gotoError))
             .verifiable(Times.atLeastOnce());
         pageResponseProcessorMock
@@ -84,7 +84,7 @@ describe(ResourceAuthenticator, () => {
         };
         puppeteerGotoResponse = { puppeteerResponse: 'goto', url: () => url } as unknown as Puppeteer.HTTPResponse;
         puppeteerPageMock
-            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec }))
+            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec }))
             .returns(() => Promise.resolve(puppeteerGotoResponse))
             .verifiable(Times.atLeastOnce());
         loginPageClientMock

--- a/packages/scanner-global-library/src/authenticator/resource-authenticator.ts
+++ b/packages/scanner-global-library/src/authenticator/resource-authenticator.ts
@@ -7,7 +7,7 @@ import { GlobalLogger } from 'logger';
 import { AuthenticationType } from 'storage-documents';
 import { System } from 'common';
 import { NavigationResponse, PageOperationResult } from '../page-navigator';
-import { PageNavigationTiming, puppeteerTimeoutConfig } from '../page-timeout-config';
+import { PageNavigationTiming, PuppeteerTimeoutConfig } from '../page-timeout-config';
 import { PageResponseProcessor } from '../page-response-processor';
 import { LoginPageClientFactory } from './login-page-client-factory';
 
@@ -71,7 +71,10 @@ export class ResourceAuthenticator {
         const timestamp = System.getTimestamp();
         try {
             this.logger?.logInfo('Navigate page to URL for authentication.');
-            const response = await page.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec });
+            const response = await page.goto(url, {
+                waitUntil: 'networkidle2',
+                timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec,
+            });
 
             return { response, navigationTiming: { goto: System.getElapsedTime(timestamp) } as PageNavigationTiming };
         } catch (error) {

--- a/packages/scanner-global-library/src/network/page-analyzer.spec.ts
+++ b/packages/scanner-global-library/src/network/page-analyzer.spec.ts
@@ -9,7 +9,7 @@ import { GlobalLogger } from 'logger';
 import { System } from 'common';
 import { PageResponseProcessor } from '../page-response-processor';
 import { LoginPageDetector } from '../authenticator/login-page-detector';
-import { PageNavigationTiming, puppeteerTimeoutConfig } from '../page-timeout-config';
+import { PageNavigationTiming, PuppeteerTimeoutConfig } from '../page-timeout-config';
 import { PageOperationResult } from '../page-navigator';
 import { BrowserError } from '../browser-error';
 import { PageAnalyzer } from './page-analyzer';
@@ -44,7 +44,7 @@ describe(PageAnalyzer, () => {
         puppeteerGotoResponse = { puppeteerResponse: 'goto', url: () => url, status: () => 200 } as unknown as Puppeteer.HTTPResponse;
         pageOperationResult = { response: puppeteerGotoResponse, navigationTiming: { goto: 100 } as PageNavigationTiming };
         puppeteerPageMock
-            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec }))
+            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec }))
             .returns(() => Promise.resolve(puppeteerGotoResponse))
             .verifiable(Times.atLeastOnce());
 
@@ -84,14 +84,14 @@ describe(PageAnalyzer, () => {
             .returns(() => ({ errorType: 'UrlNavigationTimeout' } as BrowserError));
         puppeteerPageMock.reset();
         puppeteerPageMock
-            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec }))
+            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec }))
             .returns(() => Promise.reject(error))
             .verifiable();
         pageRequestInterceptorMock.setup((o) => o.interceptedRequests).returns(() => interceptedRequests);
 
         let pageOperation: any;
         pageRequestInterceptorMock
-            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, puppeteerTimeoutConfig.redirectTimeoutMsec))
+            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, PuppeteerTimeoutConfig.redirectTimeoutMsec))
             .callback(async (fn) => (pageOperation = fn))
             .returns(async () => pageOperation(url, puppeteerPageMock.object))
             .verifiable();
@@ -116,7 +116,7 @@ describe(PageAnalyzer, () => {
     it('detect no page redirection', async () => {
         let pageOperation: any;
         pageRequestInterceptorMock
-            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, puppeteerTimeoutConfig.redirectTimeoutMsec))
+            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, PuppeteerTimeoutConfig.redirectTimeoutMsec))
             .callback(async (fn) => (pageOperation = fn))
             .returns(async () => pageOperation(url, puppeteerPageMock.object))
             .verifiable();
@@ -156,7 +156,7 @@ describe(PageAnalyzer, () => {
 
         let pageOperation: any;
         pageRequestInterceptorMock
-            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, puppeteerTimeoutConfig.redirectTimeoutMsec))
+            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, PuppeteerTimeoutConfig.redirectTimeoutMsec))
             .callback(async (fn) => (pageOperation = fn))
             .returns(async () => pageOperation(url, puppeteerPageMock.object))
             .verifiable();
@@ -212,7 +212,7 @@ describe(PageAnalyzer, () => {
         let pageOperation: any;
         const pageOnResponseHandler = (pageAnalyzer as any).getPageOnResponseHandler(url);
         pageRequestInterceptorMock
-            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, puppeteerTimeoutConfig.redirectTimeoutMsec))
+            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, PuppeteerTimeoutConfig.redirectTimeoutMsec))
             .callback(async (fn) => {
                 pageOperation = fn;
                 await Promise.all(

--- a/packages/scanner-global-library/src/network/page-analyzer.ts
+++ b/packages/scanner-global-library/src/network/page-analyzer.ts
@@ -10,7 +10,7 @@ import { AuthenticationType } from 'storage-documents';
 import { LoginPageDetector } from '../authenticator/login-page-detector';
 import { NavigationResponse, PageOperationResult } from '../page-navigator';
 import { PageResponseProcessor } from '../page-response-processor';
-import { puppeteerTimeoutConfig, PageNavigationTiming } from '../page-timeout-config';
+import { PuppeteerTimeoutConfig, PageNavigationTiming } from '../page-timeout-config';
 import { PageRequestInterceptor } from './page-request-interceptor';
 import { InterceptedRequest, PageEventHandler } from './page-event-handler';
 
@@ -193,7 +193,7 @@ export class PageAnalyzer {
         return this.pageRequestInterceptor.intercept(
             async () => this.navigatePage(url, page),
             page,
-            puppeteerTimeoutConfig.redirectTimeoutMsec,
+            PuppeteerTimeoutConfig.redirectTimeoutMsec,
         );
     }
 
@@ -201,7 +201,10 @@ export class PageAnalyzer {
         const timestamp = System.getTimestamp();
         try {
             this.logger?.logInfo('Navigate page to URL for analysis.');
-            const response = await page.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec });
+            const response = await page.goto(url, {
+                waitUntil: 'networkidle2',
+                timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec,
+            });
 
             return { response, navigationTiming: { goto: System.getElapsedTime(timestamp) } as PageNavigationTiming };
         } catch (error) {

--- a/packages/scanner-global-library/src/network/page-network-tracer.spec.ts
+++ b/packages/scanner-global-library/src/network/page-network-tracer.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, It, Mock } from 'typemoq';
 import * as Puppeteer from 'puppeteer';
 import { MockableLogger } from '../test-utilities/mockable-logger';
-import { puppeteerTimeoutConfig } from '../page-timeout-config';
+import { PuppeteerTimeoutConfig } from '../page-timeout-config';
 import { PageRequestInterceptor } from './page-request-interceptor';
 import { InterceptedRequest } from './page-event-handler';
 import { PageNetworkTracer } from './page-network-tracer';
@@ -43,13 +43,13 @@ describe(PageNetworkTracer, () => {
     it('trace', async () => {
         let pageOperation: any;
         pageRequestInterceptorMock
-            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, puppeteerTimeoutConfig.navigationTimeoutMsec, true))
+            .setup((o) => o.intercept(It.isAny(), puppeteerPageMock.object, PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec, true))
             .callback(async (fn) => (pageOperation = fn))
             .returns(async () => pageOperation(url, puppeteerPageMock.object))
             .verifiable();
         pageRequestInterceptorMock.setup((o) => o.interceptedRequests).returns(() => interceptedRequests);
         puppeteerPageMock
-            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec }))
+            .setup((o) => o.goto(url, { waitUntil: 'networkidle2', timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec }))
             .returns(() => Promise.resolve(puppeteerGotoResponse))
             .verifiable();
 

--- a/packages/scanner-global-library/src/network/page-network-tracer.ts
+++ b/packages/scanner-global-library/src/network/page-network-tracer.ts
@@ -5,7 +5,7 @@ import * as Puppeteer from 'puppeteer';
 import { injectable, inject, optional } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { System } from 'common';
-import { puppeteerTimeoutConfig } from '../page-timeout-config';
+import { PuppeteerTimeoutConfig } from '../page-timeout-config';
 import { PageRequestInterceptor } from './page-request-interceptor';
 
 @injectable()
@@ -20,7 +20,7 @@ export class PageNetworkTracer {
         await this.pageRequestInterceptor.intercept(
             async () => this.navigate(url, page),
             page,
-            puppeteerTimeoutConfig.navigationTimeoutMsec,
+            PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec,
             true,
         );
         this.logger?.logInfo(`[Network] Disable page network trace`);
@@ -28,7 +28,7 @@ export class PageNetworkTracer {
 
     private async navigate(url: string, page: Puppeteer.Page): Promise<void> {
         try {
-            await page.goto(url, { waitUntil: 'networkidle2', timeout: puppeteerTimeoutConfig.navigationTimeoutMsec });
+            await page.goto(url, { waitUntil: 'networkidle2', timeout: PuppeteerTimeoutConfig.defaultNavigationTimeoutMsec });
         } catch (error) {
             this.logger?.logError(`Page network trace navigation error.`, {
                 error: System.serializeError(error),

--- a/packages/scanner-global-library/src/network/page-operation-handler.ts
+++ b/packages/scanner-global-library/src/network/page-operation-handler.ts
@@ -7,7 +7,7 @@ import { GlobalLogger } from 'logger';
 import { System } from 'common';
 import { isNil } from 'lodash';
 import { PageOperationResult } from '../page-navigator';
-import { PageNavigationTiming, puppeteerTimeoutConfig } from '../page-timeout-config';
+import { PageNavigationTiming, PuppeteerTimeoutConfig } from '../page-timeout-config';
 import { PageResponseProcessor } from '../page-response-processor';
 import { PageRequestInterceptor } from './page-request-interceptor';
 
@@ -18,6 +18,7 @@ export class PageOperationHandler {
     constructor(
         @inject(PageRequestInterceptor) private readonly pageRequestInterceptor: PageRequestInterceptor,
         @inject(PageResponseProcessor) public readonly pageResponseProcessor: PageResponseProcessor,
+        @inject(PuppeteerTimeoutConfig) private readonly puppeteerTimeoutConfig: PuppeteerTimeoutConfig,
         @inject(GlobalLogger) @optional() private readonly logger: GlobalLogger,
     ) {}
 
@@ -30,7 +31,7 @@ export class PageOperationHandler {
         const opResult = await this.pageRequestInterceptor.intercept(
             async () => this.invokePageOperation(pageOperation),
             page,
-            puppeteerTimeoutConfig.navigationTimeoutMsec,
+            this.puppeteerTimeoutConfig.navigationTimeoutMsec,
         );
 
         // Handle indirect page redirection. Puppeteer will fail the initial URL navigation and

--- a/packages/scanner-global-library/src/page-handler.ts
+++ b/packages/scanner-global-library/src/page-handler.ts
@@ -5,7 +5,7 @@ import { inject, injectable, optional } from 'inversify';
 import { GlobalLogger } from 'logger';
 import * as Puppeteer from 'puppeteer';
 import { System } from 'common';
-import { puppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
+import { PuppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
 import { scrollToBottom } from './page-client-lib';
 
 @injectable()
@@ -13,7 +13,7 @@ export class PageHandler {
     constructor(
         @inject(GlobalLogger) @optional() private readonly logger: GlobalLogger,
         private readonly checkIntervalMsecs: number = 200,
-        private readonly pageDomStableTimeMsec: number = puppeteerTimeoutConfig.pageDomStableTimeMsec,
+        private readonly pageDomStableTimeMsec: number = PuppeteerTimeoutConfig.pageDomStableTimeMsec,
         private readonly scrollToPageBottom: typeof scrollToBottom = scrollToBottom,
     ) {}
 

--- a/packages/scanner-global-library/src/page-navigation-hooks.ts
+++ b/packages/scanner-global-library/src/page-navigation-hooks.ts
@@ -8,7 +8,7 @@ import { BrowserError } from './browser-error';
 import { PageConfigurator } from './page-configurator';
 import { PageHandler } from './page-handler';
 import { PageResponseProcessor } from './page-response-processor';
-import { puppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
+import { PuppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
 
 @injectable()
 export class PageNavigationHooks {
@@ -16,8 +16,8 @@ export class PageNavigationHooks {
         @inject(PageConfigurator) public readonly pageConfigurator: PageConfigurator,
         @inject(PageResponseProcessor) protected readonly pageResponseProcessor: PageResponseProcessor,
         @inject(PageHandler) protected readonly pageRenderingHandler: PageHandler,
-        private readonly scrollTimeoutMsec = puppeteerTimeoutConfig.scrollTimeoutMsec,
-        private readonly pageRenderingTimeoutMsec = puppeteerTimeoutConfig.pageRenderingTimeoutMsec,
+        private readonly scrollTimeoutMsec = PuppeteerTimeoutConfig.scrollTimeoutMsec,
+        private readonly pageRenderingTimeoutMsec = PuppeteerTimeoutConfig.pageRenderingTimeoutMsec,
     ) {}
 
     public async preNavigation(page: Puppeteer.Page): Promise<void> {

--- a/packages/scanner-global-library/src/page-navigator.ts
+++ b/packages/scanner-global-library/src/page-navigator.ts
@@ -8,7 +8,7 @@ import { GlobalLogger } from 'logger';
 import { BrowserError } from './browser-error';
 import { PageNavigationHooks } from './page-navigation-hooks';
 import { PageConfigurator } from './page-configurator';
-import { puppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
+import { PuppeteerTimeoutConfig, PageNavigationTiming } from './page-timeout-config';
 import { BrowserCache } from './browser-cache';
 import { PageOperation, PageOperationHandler } from './network/page-operation-handler';
 import { resetSessionHistory } from './page-client-lib';
@@ -33,24 +33,29 @@ export interface PageOperationResult {
 
 @injectable()
 export class PageNavigator {
-    private readonly waitForDefaultOptions: Puppeteer.WaitForOptions = {
-        waitUntil: 'networkidle2',
-        timeout: puppeteerTimeoutConfig.navigationTimeoutMsec,
-    };
+    private readonly waitForDefaultOptions: Puppeteer.WaitForOptions;
 
-    private readonly waitForCompleteOptions: Puppeteer.WaitForOptions = {
-        // The networkidle0 option is required to load page with WebGL enabled
-        waitUntil: 'networkidle0',
-        timeout: puppeteerTimeoutConfig.navigationTimeoutMsec,
-    };
+    private readonly waitForCompleteOptions: Puppeteer.WaitForOptions;
 
     constructor(
         @inject(PageNavigationHooks) private readonly pageNavigationHooks: PageNavigationHooks,
         @inject(BrowserCache) private readonly browserCache: BrowserCache,
         @inject(PageOperationHandler) private readonly pageOperationHandler: PageOperationHandler,
+        @inject(PuppeteerTimeoutConfig) private readonly puppeteerTimeoutConfig: PuppeteerTimeoutConfig,
         @inject(GlobalLogger) @optional() public readonly logger: GlobalLogger,
         private readonly resetSessionHistoryFn: typeof resetSessionHistory = resetSessionHistory,
-    ) {}
+    ) {
+        this.waitForDefaultOptions = {
+            waitUntil: 'networkidle2',
+            timeout: this.puppeteerTimeoutConfig.navigationTimeoutMsec,
+        };
+
+        this.waitForCompleteOptions = {
+            // The networkidle0 option is required to load page with WebGL enabled
+            waitUntil: 'networkidle0',
+            timeout: this.puppeteerTimeoutConfig.navigationTimeoutMsec,
+        };
+    }
 
     public get pageConfigurator(): PageConfigurator {
         return this.pageNavigationHooks.pageConfigurator;

--- a/packages/scanner-global-library/src/page.spec.ts
+++ b/packages/scanner-global-library/src/page.spec.ts
@@ -14,7 +14,7 @@ import { BrowserStartOptions, Page } from './page';
 import { getPromisableDynamicMock } from './test-utilities/promisable-mock';
 import { WebDriver } from './web-driver';
 import { PageNavigator, NavigationResponse } from './page-navigator';
-import { PageNavigationTiming } from './page-timeout-config';
+import { PageNavigationTiming, PuppeteerTimeoutConfig } from './page-timeout-config';
 import { scrollToTop } from './page-client-lib';
 import { PageNetworkTracer } from './network/page-network-tracer';
 import { ResourceAuthenticator, ResourceAuthenticationResult } from './authenticator/resource-authenticator';
@@ -54,6 +54,7 @@ let resourceAuthenticatorMock: IMock<ResourceAuthenticator>;
 let pageAnalyzerMock: IMock<PageAnalyzer>;
 let guidGeneratorMock: IMock<GuidGenerator>;
 let devToolsSessionMock: IMock<DevToolsSession>;
+let puppeteerTimeoutConfigMock: IMock<PuppeteerTimeoutConfig>;
 let browserStartOptions: BrowserStartOptions;
 
 describe(Page, () => {
@@ -67,7 +68,7 @@ describe(Page, () => {
         };
 
         webDriverMock = getPromisableDynamicMock(Mock.ofType<WebDriver>());
-        pageNavigatorMock = Mock.ofType(PageNavigator);
+        pageNavigatorMock = Mock.ofType<PageNavigator>();
         loggerMock = Mock.ofType<GlobalLogger>();
         browserMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Browser>());
         puppeteerPageMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Page>());
@@ -79,6 +80,7 @@ describe(Page, () => {
         pageAnalyzerMock = Mock.ofType<PageAnalyzer>();
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
         devToolsSessionMock = Mock.ofType<DevToolsSession>();
+        puppeteerTimeoutConfigMock = Mock.ofType<PuppeteerTimeoutConfig>();
         browserStartOptions = {} as BrowserStartOptions;
 
         scrollToTopMock = jest.fn().mockImplementation(() => Promise.resolve());
@@ -104,6 +106,7 @@ describe(Page, () => {
             resourceAuthenticatorMock.object,
             pageAnalyzerMock.object,
             devToolsSessionMock.object,
+            puppeteerTimeoutConfigMock.object,
             guidGeneratorMock.object,
             loggerMock.object,
             scrollToTopMock,
@@ -120,6 +123,7 @@ describe(Page, () => {
         pageNetworkTracerMock.verifyAll();
         resourceAuthenticatorMock.verifyAll();
         pageAnalyzerMock.verifyAll();
+        puppeteerTimeoutConfigMock.verifyAll();
     });
 
     describe('navigate()', () => {

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -10,7 +10,7 @@ import { isNumber, isEmpty } from 'lodash';
 import { WebDriver, WebDriverCapabilities } from './web-driver';
 import { PageNavigator, NavigationResponse } from './page-navigator';
 import { BrowserError } from './browser-error';
-import { PageNavigationTiming } from './page-timeout-config';
+import { PageNavigationTiming, PuppeteerTimeoutConfig } from './page-timeout-config';
 import { scrollToTop } from './page-client-lib';
 import { PageNetworkTracer } from './network/page-network-tracer';
 import { ResourceAuthenticator, ResourceAuthenticationResult } from './authenticator/resource-authenticator';
@@ -82,6 +82,7 @@ export class Page {
         @inject(ResourceAuthenticator) private readonly resourceAuthenticator: ResourceAuthenticator,
         @inject(PageAnalyzer) private readonly pageAnalyzer: PageAnalyzer,
         @inject(DevToolsSession) private readonly devToolsSession: DevToolsSession,
+        @inject(PuppeteerTimeoutConfig) private readonly puppeteerTimeoutConfig: PuppeteerTimeoutConfig,
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
         @inject(GlobalLogger) @optional() private readonly logger: GlobalLogger,
         private readonly scrollToPageTop: typeof scrollToTop = scrollToTop,
@@ -116,6 +117,7 @@ export class Page {
 
         this.userAgent = await this.browser.userAgent();
         this.page = await this.browser.newPage();
+        this.puppeteerTimeoutConfig.setOperationTimeout(options?.capabilities);
 
         const pageCreated = await this.webDriver.waitForPageCreation();
         if (pageCreated !== true) {

--- a/packages/scanner-global-library/src/puppeteer-options.ts
+++ b/packages/scanner-global-library/src/puppeteer-options.ts
@@ -3,7 +3,6 @@
 
 import * as Puppeteer from 'puppeteer';
 import { WebDriverCapabilities } from './web-driver';
-import { puppeteerTimeoutConfig } from './page-timeout-config';
 
 export const defaultBrowserOptions: Puppeteer.BrowserConnectOptions = {
     defaultViewport: null,
@@ -36,12 +35,8 @@ const defaultLaunchOptions: Puppeteer.PuppeteerNodeLaunchOptions = {
 
 export function launchOptions(capabilities?: WebDriverCapabilities): Puppeteer.PuppeteerNodeLaunchOptions {
     if (capabilities?.webgl === true) {
-        puppeteerTimeoutConfig.navigationTimeoutMsec = puppeteerTimeoutConfig.webglNavigationTimeoutMsec;
-
         return { ...defaultLaunchOptions, args: [...defaultArgs, ...webglArgs] };
     }
-
-    puppeteerTimeoutConfig.navigationTimeoutMsec = puppeteerTimeoutConfig.defaultNavigationTimeoutMsec;
 
     return { ...defaultLaunchOptions, args: [...defaultArgs, ...noWebglArgs] };
 }

--- a/packages/scanner-global-library/src/setup-scanner-container.spec.ts
+++ b/packages/scanner-global-library/src/setup-scanner-container.spec.ts
@@ -6,6 +6,7 @@ import 'reflect-metadata';
 import { Container } from 'inversify';
 import { AxePuppeteerFactory, axeScannerIocTypes } from 'axe-core-scanner';
 import { setupScannerContainer } from './setup-scanner-container';
+import { PuppeteerTimeoutConfig } from './page-timeout-config';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -27,6 +28,14 @@ describe(setupScannerContainer, () => {
 
     it('should use webAxeRunOptions', () => {
         expect(container.get(axeScannerIocTypes.AxeRunOptions)).toBeDefined();
+    });
+
+    it('PuppeteerTimeoutConfig should be singleton', () => {
+        const obj1 = container.get(PuppeteerTimeoutConfig);
+        const obj2 = container.get(PuppeteerTimeoutConfig);
+        expect(obj1).toBeDefined();
+        expect(obj2).toBeDefined();
+        expect(obj1).toEqual(obj2);
     });
 
     function verifySingletonResolution(key: any): void {

--- a/packages/scanner-global-library/src/setup-scanner-container.ts
+++ b/packages/scanner-global-library/src/setup-scanner-container.ts
@@ -3,9 +3,11 @@
 
 import * as inversify from 'inversify';
 import { registerAxeCoreScannerToContainer } from 'axe-core-scanner';
+import { PuppeteerTimeoutConfig } from './page-timeout-config';
 
 export function setupScannerContainer(container: inversify.Container): inversify.Container {
     container.options.skipBaseClassChecks = true;
+    container.bind(PuppeteerTimeoutConfig).toSelf().inSingletonScope();
     registerAxeCoreScannerToContainer(container);
 
     return container;


### PR DESCRIPTION
#### Details

Fixed webgl extended timeout workflow. The timeout was not assigned correctly for WebGL rendering workflow.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
