### PR TITLE
Capture a snapshot of the page using the browser CDP protocol

### DIFF
--- a/packages/scanner-global-library/src/dev-tools-session.spec.ts
+++ b/packages/scanner-global-library/src/dev-tools-session.spec.ts
@@ -64,12 +64,8 @@ function setupCDPSession(timeout: number = undefined): void {
         .setup((o) => o.detach())
         .returns(() => Promise.resolve())
         .verifiable();
-
-    const targetStub = {
-        createCDPSession: async () => cdpSessionMock.object,
-    } as Puppeteer.Target;
     puppeteerPageMock
-        .setup((o) => o.target())
-        .returns(() => targetStub)
+        .setup((o) => o.createCDPSession())
+        .returns(() => Promise.resolve(cdpSessionMock.object))
         .verifiable();
 }

--- a/packages/scanner-global-library/src/dev-tools-session.ts
+++ b/packages/scanner-global-library/src/dev-tools-session.ts
@@ -33,7 +33,7 @@ export class DevToolsSession {
         try {
             let timedOut;
 
-            client = await page.target().createCDPSession();
+            client = await page.createCDPSession();
             const wait = new Promise<void>((resolve) => {
                 timer = setTimeout(() => {
                     timedOut = true;


### PR DESCRIPTION
#### Details

Take a snapshot of the page using the browser CDP protocol to prevent Puppeteer's internal timeout error.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
