### PR TITLE
Override document readyState property

### DIFF
--- a/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.spec.ts
+++ b/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.spec.ts
@@ -232,6 +232,10 @@ function setupPageNavigation(response: Puppeteer.HTTPResponse, browserError?: Br
         .setup((o) => o.status())
         .returns(() => 200)
         .verifiable();
+    puppeteerPageMock
+        .setup((o) => o.evaluate(It.isAny()))
+        .returns(() => Promise.resolve())
+        .verifiable();
 }
 
 function setupPageLaunch(): void {

--- a/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.ts
+++ b/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.ts
@@ -35,6 +35,17 @@ export class AxePuppeteerScanner {
             browserResolution: `${browserResolution.width}x${browserResolution.height}`,
         };
 
+        // Before running axe scanner, we check that page has loaded. Sometimes, browser does not
+        // mark ready state as complete when opening page in a docker container. Hence, we can
+        // override ready state to make axe scanner validation work.
+        await page.puppeteerPage.evaluate(() => {
+            Object.defineProperty(document, 'readyState', {
+                get(): DocumentReadyState {
+                    return 'complete';
+                },
+            });
+        });
+
         let axePuppeteer = await this.axePuppeteerFactory.createAxePuppeteer(page.puppeteerPage, contentSourcePath);
         let axeRunResult = await this.runAxeAnalyze(page, axePuppeteer);
         if (axeRunResult.error !== undefined) {


### PR DESCRIPTION
#### Details

Override document readyState property to allow axe scanner complete validation.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
