### PR TITLE
Preload page metadata

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -224,8 +224,8 @@ exports[`ServiceConfiguration verifies custom config 1`] = `
       "format": "int",
     },
     "scanTimeoutInMin": {
-      "default": 5,
-      "doc": "Maximum allowed time for accessibility scanning a web page in minutes",
+      "default": 7,
+      "doc": "Maximum allowed time for accessibility scanning a web page, in minutes.",
       "format": "int",
     },
   },
@@ -468,8 +468,8 @@ exports[`ServiceConfiguration verifies dev config 1`] = `
       "format": "int",
     },
     "scanTimeoutInMin": {
-      "default": 5,
-      "doc": "Maximum allowed time for accessibility scanning a web page in minutes",
+      "default": 7,
+      "doc": "Maximum allowed time for accessibility scanning a web page, in minutes.",
       "format": "int",
     },
   },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -273,9 +273,9 @@ export class ServiceConfiguration {
                     doc: 'Maximum sliding window for a scan to complete.',
                 },
                 scanTimeoutInMin: {
-                    default: 5,
+                    default: 7,
                     format: 'int',
-                    doc: 'Maximum allowed time for accessibility scanning a web page in minutes',
+                    doc: 'Maximum allowed time for accessibility scanning a web page, in minutes.',
                 },
             },
             restApiConfig: {

--- a/packages/functional-tests/src/common-types.ts
+++ b/packages/functional-tests/src/common-types.ts
@@ -9,10 +9,11 @@ export declare type LogSource = 'TestContainer' | 'TestRun';
 
 export enum TestEnvironment {
     none = 0,
-    canary = 1,
-    insider = 2,
-    production = 4,
-    all = 7,
+    dev = 1,
+    canary = 2,
+    insider = 4,
+    production = 8,
+    all = 15,
 }
 
 export interface TestDefinition {

--- a/packages/privacy-scan-runner/docker-image-config/Dockerfile
+++ b/packages/privacy-scan-runner/docker-image-config/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
 
-ENV NODE_VERSION 18.20.3
+ENV NODE_VERSIO 20.15.0
 
 WORKDIR /app
 

--- a/packages/privacy-scan-runner/docker-image-config/Dockerfile
+++ b/packages/privacy-scan-runner/docker-image-config/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
 
-ENV NODE_VERSIO 20.15.0
+ENV NODE_VERSION 20.15.0
 
 WORKDIR /app
 

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -3,7 +3,7 @@
         "environmentDefinition": "dev"
     },
     "scanConfig": {
-        "failedScanRetryIntervalInMinutes": 5,
+        "failedScanRetryIntervalInMinutes": 15,
         "maxFailedScanRetryCount": 1
     },
     "taskConfig": {

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -7,7 +7,7 @@
         "maxQueueSize": 50
     },
     "scanConfig": {
-        "failedScanRetryIntervalInMinutes": 5,
+        "failedScanRetryIntervalInMinutes": 15,
         "maxFailedScanRetryCount": 1
     },
     "taskConfig": {

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -7,7 +7,7 @@
         "maxQueueSize": 50
     },
     "scanConfig": {
-        "failedScanRetryIntervalInMinutes": 15,
+        "failedScanRetryIntervalInMinutes": 5,
         "maxFailedScanRetryCount": 1
     },
     "taskConfig": {

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -2,10 +2,6 @@
     "availabilityTestConfig": {
         "environmentDefinition": "dev"
     },
-    "queueConfig": {
-        "messageVisibilityTimeoutInSeconds": 300,
-        "maxQueueSize": 50
-    },
     "scanConfig": {
         "failedScanRetryIntervalInMinutes": 5,
         "maxFailedScanRetryCount": 1

--- a/packages/resource-deployment/runtime-config/runtime-config.dev.json
+++ b/packages/resource-deployment/runtime-config/runtime-config.dev.json
@@ -3,8 +3,7 @@
         "environmentDefinition": "dev"
     },
     "scanConfig": {
-        "failedScanRetryIntervalInMinutes": 15,
-        "maxFailedScanRetryCount": 1
+        "maxFailedScanRetryCount": 0
     },
     "taskConfig": {
         "taskTimeoutInMinutes": 15

--- a/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.spec.ts
+++ b/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.spec.ts
@@ -29,7 +29,6 @@ let scanResults: AxeScanResults;
 let pageMock: IMock<Page>;
 let axePuppeteerFactoryMock: IMock<AxePuppeteerFactory>;
 let loggerMock: IMock<GlobalLogger>;
-let browserMock: IMock<Puppeteer.Browser>;
 let puppeteerPageMock: IMock<Puppeteer.Page>;
 let puppeteerResponseMock: IMock<Puppeteer.HTTPResponse>;
 let puppeteerRequestMock: IMock<Puppeteer.HTTPRequest>;
@@ -40,16 +39,11 @@ describe(AxePuppeteerScanner, () => {
         pageMock = Mock.ofType<Page>();
         axePuppeteerFactoryMock = Mock.ofType(AxePuppeteerFactory);
         loggerMock = Mock.ofType<GlobalLogger>();
-        browserMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Browser>());
         puppeteerPageMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.Page>());
         puppeteerResponseMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.HTTPResponse>());
         puppeteerRequestMock = getPromisableDynamicMock(Mock.ofType<Puppeteer.HTTPRequest>());
         axePuppeteerMock = getPromisableDynamicMock(Mock.ofType<AxePuppeteer>());
 
-        browserMock
-            .setup(async (o) => o.version())
-            .returns(() => Promise.resolve(scanResults.browserSpec))
-            .verifiable();
         axeResults = { url } as AxeResults;
         scanResults = {
             pageTitle: 'pageTitle',
@@ -224,10 +218,6 @@ function setupPageNavigation(response: Puppeteer.HTTPResponse, browserError?: Br
         .setup((o) => o.url)
         .returns(() => url)
         .verifiable();
-    puppeteerPageMock
-        .setup(async (o) => o.title())
-        .returns(() => Promise.resolve(scanResults.pageTitle))
-        .verifiable();
     puppeteerResponseMock
         .setup((o) => o.status())
         .returns(() => 200)
@@ -240,8 +230,12 @@ function setupPageNavigation(response: Puppeteer.HTTPResponse, browserError?: Br
 
 function setupPageLaunch(): void {
     pageMock
-        .setup((o) => o.browser)
-        .returns(() => browserMock.object)
+        .setup((o) => o.title)
+        .returns(() => scanResults.pageTitle)
+        .verifiable();
+    pageMock
+        .setup((o) => o.browserVersion)
+        .returns(() => scanResults.browserSpec)
         .verifiable();
     pageMock
         .setup((o) => o.userAgent)

--- a/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.ts
+++ b/packages/scanner-global-library/src/axe-scanner/axe-puppeteer-scanner.ts
@@ -27,8 +27,8 @@ export class AxePuppeteerScanner {
         // any further puppeteer API calls fail to respond. So run the axe scanner only after
         // we have collected all the browser metadata.
         const scanResults: AxeScanResults = {
-            pageTitle: await page.puppeteerPage.title(),
-            browserSpec: await page.browser.version(),
+            pageTitle: page.title,
+            browserSpec: page.browserVersion,
             pageResponseCode: page.navigationResponse.status(),
             userAgent: page.userAgent,
             browserResolution: `${page.browserResolution.width}x${page.browserResolution.height}`,

--- a/packages/scanner-global-library/src/page.ts
+++ b/packages/scanner-global-library/src/page.ts
@@ -47,35 +47,39 @@ type Operation = 'load' | 'reload' | 'analysis' | 'auth';
 
 @injectable()
 export class Page {
-    public browser: Puppeteer.Browser;
+    private page: Puppeteer.Page;
 
-    public navigationResponse: Puppeteer.HTTPResponse;
+    private readonly browserWSEndpoint: string;
 
-    public browserError: BrowserError;
-
-    public browserStartOptions: BrowserStartOptions;
-
-    public pageOptions: PageOptions;
+    private readonly enableAuthenticationGlobalFlag: boolean;
 
     public authenticationResult: ResourceAuthenticationResult;
 
-    public pageNavigationTiming: PageNavigationTiming;
+    public browser: Puppeteer.Browser;
+
+    public browserError: BrowserError;
+
+    public browserResolution: Viewport;
+
+    public browserStartOptions: BrowserStartOptions;
+
+    public browserVersion: string;
+
+    public navigationResponse: Puppeteer.HTTPResponse;
 
     public pageAnalysisResult: PageAnalysisResult;
+
+    public pageNavigationTiming: PageNavigationTiming;
+
+    public pageOptions: PageOptions;
 
     public pageState: PageState;
 
     public requestUrl: string;
 
+    public title: string;
+
     public userAgent: string;
-
-    public browserResolution: Viewport;
-
-    private page: Puppeteer.Page;
-
-    private readonly enableAuthenticationGlobalFlag: boolean;
-
-    private readonly browserWSEndpoint: string;
 
     constructor(
         @inject(WebDriver) private readonly webDriver: WebDriver,
@@ -121,6 +125,7 @@ export class Page {
         this.page = await this.browser.newPage();
         this.puppeteerTimeoutConfig.setOperationTimeout(options?.capabilities);
         this.browserResolution = await this.getBrowserResolution();
+        this.browserVersion = await this.browser.version();
 
         const pageCreated = await this.webDriver.waitForPageCreation();
         if (pageCreated !== true) {
@@ -302,6 +307,7 @@ export class Page {
         if (this.pageAnalysisResult.navigationResponse?.browserError !== undefined) {
             this.setLastNavigationState('analysis', this.pageAnalysisResult.navigationResponse);
         } else {
+            this.title = await this.page.title();
             await this.reopenBrowserImpl({ hardReload: true });
         }
     }

--- a/packages/service-library/src/combined-report-provider/combined-results-blob-provider.ts
+++ b/packages/service-library/src/combined-report-provider/combined-results-blob-provider.ts
@@ -25,7 +25,7 @@ export class CombinedResultsBlobProvider {
 
         if (existingCombinedResultsBlobId === undefined) {
             actualBlobId = this.guidGenerator.createGuid();
-            this.logger.logInfo('Combined axe scan results not found in a blob storage. Creating a new blob.');
+            this.logger.logInfo('Combined axe scan results blob id was not provided. Creating a new blob.', { blobId: actualBlobId });
             blobReadResponse = this.combinedScanResultsProvider.getEmptyResponse();
         } else {
             blobReadResponse = await this.getCombinedResultsBlob(actualBlobId);
@@ -41,12 +41,15 @@ export class CombinedResultsBlobProvider {
         const response = await this.combinedScanResultsProvider.readCombinedResults(combinedResultsBlobId);
         if (response.error) {
             if (response.error.errorCode === 'blobNotFound') {
-                this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.');
+                this.logger.logWarn('Combined axe scan results not found in a blob storage. Creating a new blob.', {
+                    blobId: combinedResultsBlobId,
+                });
 
                 return this.combinedScanResultsProvider.getEmptyResponse();
             }
 
             this.logger.logError('Failed to read combined axe results blob.', {
+                blobId: combinedResultsBlobId,
                 error: JSON.stringify(response.error),
             });
 

--- a/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
+++ b/packages/service-library/src/combined-report-provider/combined-scan-result-processor.ts
@@ -6,6 +6,7 @@ import { GlobalLogger } from 'logger';
 import { RetryHelper, System } from 'common';
 import { AxeScanResults } from 'scanner-global-library';
 import { OnDemandPageScanResult, WebsiteScanData } from 'storage-documents';
+import { cloneDeep } from 'lodash';
 import { ReportWriter } from '../data-providers/report-writer';
 import { WebsiteScanDataProvider } from '../data-providers/website-scan-data-provider';
 import { CombinedAxeResultBuilder } from './combined-axe-result-builder';
@@ -66,7 +67,13 @@ export class CombinedScanResultProcessor {
             return;
         }
 
-        const combinedAxeResults = await this.combinedAxeResultBuilder.mergeAxeResults(axeScanResults.results, combinedResultsBlob);
+        // Make the consolidated report smaller by deleting unnecessary data.
+        const axeScanResultsReduced = cloneDeep(axeScanResults.results);
+        axeScanResultsReduced.inapplicable = [];
+        axeScanResultsReduced.incomplete = [];
+        axeScanResultsReduced.passes = [];
+
+        const combinedAxeResults = await this.combinedAxeResultBuilder.mergeAxeResults(axeScanResultsReduced, combinedResultsBlob);
         const generatedReport = this.combinedReportGenerator.generate(
             combinedResultsBlobId,
             combinedAxeResults,

--- a/packages/service-library/src/web-api/api-contracts/health-report.ts
+++ b/packages/service-library/src/web-api/api-contracts/health-report.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export declare type TestEnvironment = 'canary' | 'insider' | 'production';
+export declare type TestEnvironment = 'dev' | 'canary' | 'insider' | 'production';
 export declare type TestRunResult = 'pass' | 'fail' | 'warn';
 
 export interface TestRun {

--- a/packages/web-api-scan-runner/docker-image-config/Dockerfile
+++ b/packages/web-api-scan-runner/docker-image-config/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
 
-ENV NODE_VERSION 18.20.3
+ENV NODE_VERSION 20.15.0
 
 WORKDIR /app
 

--- a/packages/web-api-scan-runner/run-in-docker-container.cmd
+++ b/packages/web-api-scan-runner/run-in-docker-container.cmd
@@ -19,4 +19,4 @@ docker build --tag web-api-scan-runner:prescanner -f Dockerfile.debug . &&^
 cd ..\..\resource-deployment\scripts\docker-scanner-image &&^
 powershell .\build-scanner-image.ps1 -InstallHostFonts &&^
 cd ..\..\..\web-api-scan-runner &&^
-docker run --init --shm-size=2gb --ipc=host -p 9229:9229 --env-file .env web-api-scan-runner
+docker run --cpus=2 --init --shm-size=2gb --ipc=host -p 9229:9229 --env-file .env web-api-scan-runner

--- a/packages/web-workers/src/orchestration/orchestration-steps.spec.ts
+++ b/packages/web-workers/src/orchestration/orchestration-steps.spec.ts
@@ -207,7 +207,7 @@ describe(OrchestrationSteps, () => {
                             scenarioName,
                         },
                         testContextData,
-                        environment: 1,
+                        environment: 2,
                         releaseId: webApiConfig.releaseId,
                     } as RunFunctionalTestGroupData,
                 };


### PR DESCRIPTION
#### Details

Fetch page metadata in advance to prevent dev-tool protocol from timing out on pages with high activity.
Fixed bugs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
