### PR TITLE
fix: handle service account password authentication preference

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.ts
@@ -32,13 +32,18 @@ export class AzureActiveDirectoryAuthentication implements AuthenticationMethod 
 
         try {
             await page.waitForSelector('#FormsAuthentication');
+            await page.click('#FormsAuthentication');
         } catch (error) {
-            throw new Error(
-                `Authentication failed. Authentication requires a non-people service account. To learn how to set up a service account, visit: https://aka.ms/AI-action-auth. ${error}`,
-            );
+            try {
+                await page.waitForSelector('input[type="password"]');
+                await page.click('input[type="password"]');
+            } catch (errorPassword) {
+                throw new Error(
+                    `Authentication failed. Authentication requires a non-people service account. To learn how to set up a service account, visit: https://aka.ms/AI-action-auth. ${errorPassword}`,
+                );
+            }
         }
 
-        await page.click('#FormsAuthentication');
         await page.type('input[type="password"]', this.accountPassword);
         await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.keyboard.press('Enter')]);
 


### PR DESCRIPTION
#### Details

Service accounts having password authentication preference set by default will skip the Forms Authentication Page (page which gives option to select authentication type Password or Sign in with PIN). This pull request handle the scenario to checks for password page load if forms authentication page load timeout. 

##### Motivation

addresses issue #2569 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: Fixes #2569 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
