### PR TITLE
Create RBAC role per resource group

### DIFF
--- a/packages/resource-deployment/scripts/enable-batch-node-identity.sh
+++ b/packages/resource-deployment/scripts/enable-batch-node-identity.sh
@@ -26,8 +26,8 @@ function enableBatchAccount() {
     roleDefinitionGeneratedFileName="batch-account-custom-role.generated.json"
 
     # The role is assigned under a tenant in the subscription scope. Creating it under another subscription
-    # may fail due to lack of access to the original scope, so a unique role is created per subscription scope.
-    roleNameSuffix=${subscription:24:12}
+    # may fail due to lack of access to the original scope, so a unique role is created per resource group scope.
+    roleNameSuffix=$(echo "${resourceGroupName}" | tr '[:upper:]' '[:lower:]')
     roleName="BatchAccountJobSubmitter_${roleNameSuffix}"
 
     sed -e "s@%NAME_TOKEN%@${roleName}@" -e "s@%SUBSCRIPTION_TOKEN%@${subscription}@" "${roleDefinitionFileName}" >"${roleDefinitionGeneratedFileName}"


### PR DESCRIPTION
#### Details

Create RBAC role per resource group to avoid name collision.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
