### PR TITLE
chore: updated inversify depedency to fix dependabot PR #2206 for act…

### DIFF
--- a/packages/axe-core-scanner/package.json
+++ b/packages/axe-core-scanner/package.json
@@ -38,7 +38,7 @@
     "dependencies": {
         "@axe-core/puppeteer": "4.9.1",
         "axe-core": "4.9.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "puppeteer": "^23.5.0",
         "reflect-metadata": "^0.1.13"

--- a/packages/axe-core-scanner/src/axe-puppeteer-factory.ts
+++ b/packages/axe-core-scanner/src/axe-puppeteer-factory.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs';
 import { AxePuppeteer } from '@axe-core/puppeteer';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isEmpty } from 'lodash';
 import * as Puppeteer from 'puppeteer';
 import { AxeConfiguration } from './axe-configuration';
@@ -15,7 +15,7 @@ export class AxePuppeteerFactory {
     constructor(
         @inject(axeScannerIocTypes.AxeConfiguration) private readonly axeConfiguration: AxeConfiguration,
         @inject(axeScannerIocTypes.AxeRunOptions) private readonly axeRunOptions: AxeRunOptions,
-        private readonly fileSystemObj: typeof fs = fs,
+        @optional() @inject('fs') private readonly fileSystemObj: typeof fs = fs,
     ) {}
 
     public async createAxePuppeteer(page: Puppeteer.Page, contentSourcePath?: string, legacyMode: boolean = false): Promise<AxePuppeteer> {

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -38,7 +38,7 @@
         "accessibility-insights-report": "5.1.0",
         "axe-core": "4.9.1",
         "common": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13"
     }

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -52,7 +52,7 @@
         "common": "workspace:*",
         "dotenv": "^16.0.1",
         "got": "^11.8.5",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/azure-services/src/azure-batch/batch-task-config-generator.ts
+++ b/packages/azure-services/src/azure-batch/batch-task-config-generator.ts
@@ -3,7 +3,7 @@
 
 import { BatchServiceModels } from '@azure/batch';
 import { EnvironmentSettings, ServiceConfiguration, TaskRuntimeConfig } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { cloneDeep } from 'lodash';
 import moment from 'moment';
 
@@ -48,9 +48,9 @@ export class BatchTaskConfigGenerator {
         '--init --rm --cpus=2 --shm-size=2gb --workdir /app -v d: --env-file %AZ_BATCH_TASK_WORKING_DIR%\\.env';
 
     public constructor(
-        @inject(BatchTaskPropertyProvider) protected readonly batchTaskPropertyProvider: BatchTaskPropertyProvider,
-        @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(EnvironmentSettings) private readonly environmentSettings: EnvironmentSettings,
+        @optional() @inject('BatchTaskPropertyProvider') protected readonly batchTaskPropertyProvider: BatchTaskPropertyProvider,
+        @optional() @inject('ServiceConfiguration') protected readonly serviceConfig: ServiceConfiguration,
+        @optional() @inject('EnvironmentSettings') private readonly environmentSettings: EnvironmentSettings,
     ) {}
 
     public async getTaskConfigWithImageSupport(

--- a/packages/azure-services/src/azure-batch/batch.ts
+++ b/packages/azure-services/src/azure-batch/batch.ts
@@ -18,14 +18,12 @@ import { PoolLoad, PoolMetricsInfo } from './pool-load-generator';
 @injectable()
 export class Batch {
     public constructor(
-        @inject(iocTypeNames.BatchServiceClientProvider) private readonly batchClientProvider: BatchServiceClientProvider,
-        @optional()
-        @inject(BatchTaskConfigGenerator)
-        private readonly batchTaskConfigGenerator: BatchTaskConfigGenerator,
-        @inject(BatchConfig) private readonly config: BatchConfig,
-        @inject(GlobalLogger) private readonly logger: GlobalLogger,
+        @optional() @inject(iocTypeNames.BatchServiceClientProvider) private readonly batchClientProvider: BatchServiceClientProvider,
+        @optional() @inject('BatchTaskConfigGenerator') private readonly batchTaskConfigGenerator: BatchTaskConfigGenerator,
+        @optional() @inject('BatchConfig') private readonly config: BatchConfig,
+        @optional() @inject('GlobalLogger') private readonly logger: GlobalLogger,
         // Azure Batch supports the maximum 100 tasks to be added in a single addTaskCollection() API call
-        private readonly maxTasks = 100,
+        @optional() @inject('number') private readonly maxTasks: number = 100,
     ) {}
 
     public async getSucceededTasks(jobId: string): Promise<BatchTask[]> {

--- a/packages/azure-services/src/azure-queue/message.ts
+++ b/packages/azure-services/src/azure-queue/message.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { inject, optional } from 'inversify';
+
 export class Message {
-    constructor(public messageText: string, public messageId: string, public popReceipt?: string) {}
+    constructor(@optional() @inject('string') public messageText: string, public messageId: string, public popReceipt?: string) {}
 }

--- a/packages/azure-services/src/azure-queue/queue.ts
+++ b/packages/azure-services/src/azure-queue/queue.ts
@@ -3,7 +3,7 @@
 
 import * as util from 'util';
 import { QueueRuntimeConfig, RetryHelper, ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import _ from 'lodash';
 import { ContextAwareLogger } from 'logger';
 import { DequeuedMessageItem, QueueClient, MessagesDequeueOptionalParams } from '@azure/storage-queue';
@@ -15,12 +15,14 @@ export class Queue {
     private readonly maxDequeueCount = 1; // increasing dequeue count may destroy global scan retry logic
 
     constructor(
-        @inject(iocTypeNames.QueueServiceClientProvider) private readonly queueServiceClientProvider: QueueServiceClientProvider,
-        @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
-        @inject(ContextAwareLogger) private readonly logger: ContextAwareLogger,
-        @inject(RetryHelper) private readonly retryHelper: RetryHelper<void>,
-        private readonly maxEnqueueRetryCount: number = 3,
-        private readonly retryIntervalMilliseconds: number = 1000,
+        @optional()
+        @inject(iocTypeNames.QueueServiceClientProvider)
+        private readonly queueServiceClientProvider: QueueServiceClientProvider,
+        @optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration,
+        @optional() @inject('ContextAwareLogger') private readonly logger: ContextAwareLogger,
+        @optional() @inject('RetryHelper') private readonly retryHelper: RetryHelper<void>,
+        @optional() @inject('number') private readonly maxEnqueueRetryCount: number = 3,
+        @optional() @inject('number') private readonly retryIntervalMilliseconds: number = 1000,
     ) {}
 
     /**

--- a/packages/azure-services/src/credentials/credentials-provider.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { TokenCredential } from '@azure/identity';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import * as msRest from '@azure/ms-rest-js';
 import { BatchCredentialProvider } from './batch-credential-provider';
 import { IdentityCredentialProvider } from './identity-credential-provider';
@@ -12,8 +12,8 @@ export type Credentials = msRest.ServiceClientCredentials;
 @injectable()
 export class CredentialsProvider {
     constructor(
-        @inject(BatchCredentialProvider) private readonly batchCredentialProvider: BatchCredentialProvider,
-        @inject(IdentityCredentialProvider) private readonly identityCredentialProvider: IdentityCredentialProvider,
+        @optional() @inject('BatchCredentialProvider') private readonly batchCredentialProvider: BatchCredentialProvider,
+        @optional() @inject('IdentityCredentialProvider') private readonly identityCredentialProvider: IdentityCredentialProvider,
     ) {}
 
     public async getBatchCredential(): Promise<Credentials> {

--- a/packages/azure-services/src/credentials/identity-credential-provider.ts
+++ b/packages/azure-services/src/credentials/identity-credential-provider.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AccessToken, GetTokenOptions, TokenCredential } from '@azure/core-auth';
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { AzureCliCredential, ManagedIdentityCredential } from '@azure/identity';
 import { isEmpty } from 'lodash';
 import { IdentityCredentialCache } from './identity-credential-cache';
@@ -21,8 +21,10 @@ export class IdentityCredentialProvider implements TokenCredential {
      * logged-in user login information via the Azure CLI ('az') command line tool.
      */
     constructor(
+        @optional()
+        @inject('IdentityCredentialCache')
         private readonly identityCredentialCache: IdentityCredentialCache = new IdentityCredentialCache(),
-        private readonly azCliAuth?: boolean,
+        @optional() @inject('azCliAuth') private readonly azCliAuth?: boolean,
     ) {
         this.azCliAuth = this.azCliAuth ?? process.env.AZ_CLI_AUTH === 'true';
     }

--- a/packages/azure-services/src/key-vault/secret-provider.ts
+++ b/packages/azure-services/src/key-vault/secret-provider.ts
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 import { SecretClient } from '@azure/keyvault-secrets';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { AzureKeyVaultClientProvider, iocTypeNames } from '../ioc-types';
 
 @injectable()
 export class SecretProvider {
-    constructor(@inject(iocTypeNames.AzureKeyVaultClientProvider) private readonly keyVaultClientProvider: AzureKeyVaultClientProvider) {}
+    constructor(
+        @optional() @inject(iocTypeNames.AzureKeyVaultClientProvider) private readonly keyVaultClientProvider: AzureKeyVaultClientProvider,
+    ) {}
 
     public async getSecret(name: string): Promise<string> {
         const client: SecretClient = await this.keyVaultClientProvider();

--- a/packages/azure-services/src/storage/cosmos-container-client.ts
+++ b/packages/azure-services/src/storage/cosmos-container-client.ts
@@ -4,6 +4,7 @@
 import * as cosmos from '@azure/cosmos';
 import pLimit from 'p-limit';
 import { isPlainObject, mapValues, mergeWith } from 'lodash';
+import { inject, optional } from 'inversify';
 import { CosmosClientWrapper } from '../azure-cosmos/cosmos-client-wrapper';
 import { CosmosDocument } from '../azure-cosmos/cosmos-document';
 import { CosmosOperationResponse } from '../azure-cosmos/cosmos-operation-response';
@@ -15,9 +16,9 @@ export class CosmosContainerClient {
     public maxConcurrencyLimit = 10;
 
     constructor(
-        private readonly cosmosClientWrapper: CosmosClientWrapper,
-        private readonly dbName: string,
-        private readonly collectionName: string,
+        @optional() @inject('CosmosClientWrapper') private readonly cosmosClientWrapper: CosmosClientWrapper,
+        @optional() @inject('string') private readonly dbName: string,
+        @optional() @inject('string') private readonly collectionName: string,
     ) {}
 
     public async readDocument<T>(

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,7 +75,7 @@
         "filenamify": "^4.3.0",
         "filenamify-url": "^2.1.2",
         "got": "^11.8.5",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "json5": ">=2.2.3",
         "leveldown": "^6.1.1",
         "levelup": "^5.1.1",

--- a/packages/cli/src/axe/axe-info.ts
+++ b/packages/cli/src/axe/axe-info.ts
@@ -4,11 +4,11 @@
 import 'reflect-metadata';
 
 import * as Axe from 'axe-core';
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class AxeInfo {
-    constructor(private readonly axe: typeof Axe = Axe) {}
+    constructor(@optional() @inject('Axe') private readonly axe: typeof Axe = Axe) {}
 
     public get version(): string {
         return this.axe.version;

--- a/packages/cli/src/baseline/baseline-file-updater.ts
+++ b/packages/cli/src/baseline/baseline-file-updater.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isEmpty } from 'lodash';
 import { OutputFileWriter } from '../files/output-file-writer';
 import { ScanArguments } from '../scan-arguments';
@@ -13,7 +13,7 @@ export class BaselineFileUpdater {
     constructor(
         @inject(BaselineFileFormatter) private readonly baselineFileFormatter: BaselineFileFormatter,
         @inject(OutputFileWriter) private readonly outputFileWriter: OutputFileWriter,
-        private readonly stdoutWriter: (output: string) => void = console.log,
+        @optional() @inject('stdoutWriter') private readonly stdoutWriter: (output: string) => void = console.log,
     ) {}
 
     public async updateBaseline(scanArguments: ScanArguments, baselineEvaluation: BaselineEvaluation): Promise<void> {

--- a/packages/cli/src/baseline/baseline-options-builder.ts
+++ b/packages/cli/src/baseline/baseline-options-builder.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { ScanArguments } from '../scan-arguments';
 import { BaselineFileFormatter } from './baseline-file-formatter';
 import { BaselineFileContent, BaselineOptions } from './baseline-types';
@@ -13,7 +13,7 @@ import { BaselineFileContent, BaselineOptions } from './baseline-types';
 export class BaselineOptionsBuilder {
     constructor(
         @inject(BaselineFileFormatter) private readonly baselineFileFormatter: BaselineFileFormatter,
-        private readonly fileSystem: typeof fs = fs,
+        @optional() @inject('fs') private readonly fileSystem: typeof fs = fs,
     ) {}
 
     public build(scanArguments: ScanArguments): BaselineOptions | null {

--- a/packages/cli/src/crawler/crawler-parameters-builder.ts
+++ b/packages/cli/src/crawler/crawler-parameters-builder.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs';
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { CrawlerRunOptions, Url } from 'accessibility-insights-crawler';
 import { ScanArguments } from '../scan-arguments';
 
 @injectable()
 export class CrawlerParametersBuilder {
-    constructor(private readonly urlObj: typeof Url = Url, private readonly fileSystem: typeof fs = fs) {}
+    constructor(@optional() @inject('fileSystem') private readonly urlObj: typeof Url = Url, private readonly fileSystem: typeof fs = fs) {}
 
     public build(scanArguments: ScanArguments): CrawlerRunOptions {
         if (scanArguments.crawl && scanArguments.url) {

--- a/packages/cli/src/files/output-file-writer.ts
+++ b/packages/cli/src/files/output-file-writer.ts
@@ -4,7 +4,7 @@
 import * as fs from 'fs';
 import path from 'path';
 import filenamifyCombined from 'filenamify';
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import normalizePath from 'normalize-path';
 import { ensureDirectory } from 'accessibility-insights-crawler';
 
@@ -16,9 +16,9 @@ const filenamifyUrl = require('filenamify-url');
 @injectable()
 export class OutputFileWriter {
     constructor(
-        private readonly fileSystem: typeof fs = fs,
-        private readonly fileSystemPath = path,
-        private readonly ensureDirectoryFunc: typeof ensureDirectory = ensureDirectory,
+        @optional() @inject('fs') private readonly fileSystem: typeof fs = fs,
+        @optional() @inject('fileSystemPath') private readonly fileSystemPath = path,
+        @optional() @inject('ensureDirectory') private readonly ensureDirectoryFunc: typeof ensureDirectory = ensureDirectory,
     ) {}
 
     public writeToDirectory(directory: string, fileBaseName: string, fileExtension: string, content: string): string {

--- a/packages/cli/src/runner/crawler-command-runner.ts
+++ b/packages/cli/src/runner/crawler-command-runner.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isEmpty } from 'lodash';
 import { ScanArguments } from '../scan-arguments';
 import { ConsolidatedReportGenerator } from '../report/consolidated-report-generator';
@@ -24,8 +24,8 @@ export class CrawlerCommandRunner implements CommandRunner {
         @inject(BaselineOptionsBuilder) private readonly baselineOptionsBuilder: BaselineOptionsBuilder,
         @inject(BaselineFileUpdater) private readonly baselineFileUpdater: BaselineFileUpdater,
         @inject(ReportNameGenerator) private readonly reportNameGenerator: ReportNameGenerator,
-        private readonly fileSystem: typeof fs = fs,
-        private readonly stdoutWriter: (output: string) => void = console.log,
+        @optional() @inject('fs') private readonly fileSystem: typeof fs = fs,
+        @optional() @inject('stdoutWriter') private readonly stdoutWriter: (output: string) => void = console.log,
     ) {}
 
     public async runCommand(scanArguments: ScanArguments): Promise<void> {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -40,7 +40,7 @@
         "convict": "^6.2.4",
         "exponential-backoff": "^3.1.0",
         "got": "^11.8.5",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "normalize-path": "^3.0.0",
         "normalize-url": "6.1.0",

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs';
 import convict from 'convict';
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isNil } from 'lodash';
 
 export interface RuntimeConfig {
@@ -103,11 +103,11 @@ export declare type ResourceType = 'batch' | 'registry';
 export class ServiceConfiguration {
     public static readonly profilePath = `${__dirname}/runtime-config.json`;
 
-    private readonly fileSystem: typeof fs;
+    @optional() @inject('fs') private readonly fileSystem: typeof fs;
 
     private loadConfigPromise: Promise<convict.Config<RuntimeConfig>>;
 
-    private readonly convictModule: typeof convict;
+    @optional() @inject('convict') private readonly convictModule: typeof convict;
 
     constructor(fileSystem: typeof fs = fs, convictModule: typeof convict = convict) {
         this.fileSystem = fileSystem;

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -103,13 +103,12 @@ export declare type ResourceType = 'batch' | 'registry';
 export class ServiceConfiguration {
     public static readonly profilePath = `${__dirname}/runtime-config.json`;
 
-    @optional() @inject('fs') private readonly fileSystem: typeof fs;
-
     private loadConfigPromise: Promise<convict.Config<RuntimeConfig>>;
 
-    @optional() @inject('convict') private readonly convictModule: typeof convict;
-
-    constructor(fileSystem: typeof fs = fs, convictModule: typeof convict = convict) {
+    constructor(
+        @optional() @inject('fs') private readonly fileSystem: typeof fs = fs,
+        @optional() @inject('convict') private readonly convictModule: typeof convict = convict,
+    ) {
         this.fileSystem = fileSystem;
         this.convictModule = convictModule;
     }

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -54,7 +54,7 @@
         "axe-core-scanner": "workspace:*",
         "dotenv": "^16.0.1",
         "encoding-down": "^7.1.0",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "leveldown": "^6.1.1",
         "levelup": "^5.1.1",
         "lodash": "^4.17.21",

--- a/packages/crawler/src/apify/apify-request-queue-creator.ts
+++ b/packages/crawler/src/apify/apify-request-queue-creator.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs';
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import * as Crawlee from '@crawlee/puppeteer';
 import { ApifySettingsHandler, apifySettingsHandler } from './apify-settings';
 
@@ -25,8 +25,8 @@ export class ApifyRequestQueueCreator implements ResourceCreator {
     private readonly requestQueueName = 'scanRequests';
 
     public constructor(
-        private readonly settingsHandler: ApifySettingsHandler = apifySettingsHandler,
-        private readonly fileSystem: typeof fs = fs,
+        @optional() @inject('ApifySettingsHandler') private readonly settingsHandler: ApifySettingsHandler = apifySettingsHandler,
+        @optional() @inject('fs') private readonly fileSystem: typeof fs = fs,
     ) {}
 
     public async createRequestQueue(baseUrl: string, options?: RequestQueueOptions): Promise<Crawlee.RequestQueue> {

--- a/packages/crawler/src/common/hash-generator.ts
+++ b/packages/crawler/src/common/hash-generator.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import fnv1a from '@sindresorhus/fnv1a';
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { JumpConsistentHash } from './jump-consistent-hash';
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
@@ -10,7 +10,7 @@ const shaJS = require('sha.js');
 
 @injectable()
 export class HashGenerator {
-    public constructor(private readonly shaObj = shaJS) {}
+    public constructor(@optional() @inject('sha') private readonly shaObj = shaJS) {}
 
     public getWebsiteScanResultDocumentId(baseUrl: string, scanGroupId: string): string {
         // Preserve parameters order below for the hash generation compatibility

--- a/packages/crawler/src/common/promise-utils.ts
+++ b/packages/crawler/src/common/promise-utils.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class PromiseUtils {
-    constructor(private readonly globalObj = global) {}
+    constructor(@optional() @inject('global') private readonly globalObj = global) {}
 
     public async waitFor<T, Y>(fn: Promise<T>, timeoutInMsec: number, onTimeoutCallback: () => Promise<Y>): Promise<T | Y> {
         let timeoutHandle: NodeJS.Timeout;

--- a/packages/crawler/src/crawler/crawler-configuration.ts
+++ b/packages/crawler/src/crawler/crawler-configuration.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isEmpty } from 'lodash';
 import { ApifySettings, ApifySettingsHandler, apifySettingsHandler } from '../apify/apify-settings';
 import { CrawlerRunOptions } from '../types/crawler-run-options';
@@ -13,7 +13,9 @@ export class CrawlerConfiguration {
     private _crawlerRunOptions: CrawlerRunOptions;
 
     public constructor(
-        private readonly settingsHandler: ApifySettingsHandler = apifySettingsHandler,
+        @optional() @inject('ApifySettingsHandler') private readonly settingsHandler: ApifySettingsHandler = apifySettingsHandler,
+        @optional()
+        @inject('DiscoveryPatternFactory')
         private readonly createDiscoveryPattern: DiscoveryPatternFactory = getDiscoveryPatternForUrl,
     ) {}
 

--- a/packages/crawler/src/crawler/site-crawler-engine.ts
+++ b/packages/crawler/src/crawler/site-crawler-engine.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs';
 import * as Crawlee from '@crawlee/puppeteer';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isEmpty } from 'lodash';
 import * as Puppeteer from 'puppeteer';
 import { AuthenticatorFactory } from '../authenticator/authenticator-factory';
@@ -26,7 +26,7 @@ export class SiteCrawlerEngine implements CrawlerEngine {
         @inject(CrawlerFactory) private readonly crawlerFactory: CrawlerFactory,
         @inject(AuthenticatorFactory) private readonly authenticatorFactory: AuthenticatorFactory,
         @inject(CrawlerConfiguration) private readonly crawlerConfiguration: CrawlerConfiguration,
-        private readonly puppeteer: typeof Puppeteer = Puppeteer,
+        @optional() @inject('Puppeteer') private readonly puppeteer: typeof Puppeteer = Puppeteer,
     ) {}
 
     public async start(crawlerRunOptions: CrawlerRunOptions): Promise<void> {

--- a/packages/crawler/src/level-storage/data-base.ts
+++ b/packages/crawler/src/level-storage/data-base.ts
@@ -20,10 +20,10 @@ export class DataBase implements AsyncIterable<ScanResult> {
     private iterator: AsyncIterableIterator<string | Buffer>;
 
     constructor(
-        @inject(crawlerIocTypes.LevelUp) @optional() protected db?: LevelUp,
-        protected readonly levelupObj: typeof levelup = levelup,
-        protected readonly leveldownObj: typeof leveldown = leveldown,
-        protected readonly encodeObj: typeof encode = encode,
+        @optional() @inject(crawlerIocTypes.LevelUp) protected db?: LevelUp,
+        @optional() @inject('levelup') protected readonly levelupObj: typeof levelup = levelup,
+        @optional() @inject('leveldown') protected readonly leveldownObj: typeof leveldown = leveldown,
+        @optional() @inject('encode') protected readonly encodeObj: typeof encode = encode,
     ) {}
 
     public [Symbol.asyncIterator](): AsyncIterator<ScanResult> {

--- a/packages/crawler/src/logger/apify-console-logger-client.ts
+++ b/packages/crawler/src/logger/apify-console-logger-client.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { Log } from '@apify/log';
 import moment from 'moment';
 import { LogLevel, LoggerClient, LoggerProperties } from './logger';
@@ -12,7 +12,7 @@ import { LogLevel, LoggerClient, LoggerProperties } from './logger';
 export class ApifyConsoleLoggerClient implements LoggerClient {
     private baseProperties: LoggerProperties;
 
-    constructor(private readonly logger: Log = new Log({ prefix: 'Scanner' })) {}
+    constructor(@optional() @inject('Log') private readonly logger: Log = new Log({ prefix: 'Scanner' })) {}
 
     public log(message: string, logLevel: LogLevel, properties?: LoggerProperties): void {
         const logMessage = `[${moment.utc().toISOString()}] ${message}`;

--- a/packages/crawler/src/logger/logger.ts
+++ b/packages/crawler/src/logger/logger.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { ApifyConsoleLoggerClient } from './apify-console-logger-client';
 
 export enum LogLevel {
@@ -22,7 +22,7 @@ export interface LoggerClient {
 
 @injectable()
 export class Logger {
-    constructor(private readonly loggerClients: LoggerClient[] = [new ApifyConsoleLoggerClient()]) {}
+    constructor(@optional() @inject('LoggerClient') private readonly loggerClients: LoggerClient[] = [new ApifyConsoleLoggerClient()]) {}
 
     public setCommonProperties(properties: LoggerProperties): void {
         this.invokeLoggerClients((client) => client.setCommonProperties(properties));

--- a/packages/crawler/src/page-handler/page-handler.spec.ts
+++ b/packages/crawler/src/page-handler/page-handler.spec.ts
@@ -10,6 +10,8 @@ import { System } from '../common/system';
 import { PageHandler } from './page-handler';
 import { scrollToBottom } from './page-client-lib';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 type Writeable<T> = { -readonly [P in keyof T]: Writeable<T[P]> };
 
 describe(PageHandler, () => {
@@ -48,7 +50,9 @@ describe(PageHandler, () => {
         pageMock.setup((o) => o.isClosed()).returns(() => false);
         pageMock.setup((o) => o.url()).returns(() => 'url');
 
-        pageHandler = new PageHandler(loggerMock.object, checkIntervalMsecs, pageDomStableTimeMsec, scrollToBottomMock);
+        pageHandler = new PageHandler(loggerMock.object, scrollToBottomMock);
+        (pageHandler as any).pageDomStableTimeMsec = pageDomStableTimeMsec;
+        (pageHandler as any).checkIntervalMsecs = checkIntervalMsecs;
     });
 
     afterEach(() => {

--- a/packages/crawler/src/page-handler/page-handler.ts
+++ b/packages/crawler/src/page-handler/page-handler.ts
@@ -10,11 +10,13 @@ import { scrollToBottom } from './page-client-lib';
 
 @injectable()
 export class PageHandler {
+    private readonly checkIntervalMsecs: number = 200;
+
+    private readonly pageDomStableTimeMsec: number = puppeteerTimeoutConfig.pageDomStableTimeMsec;
+
     constructor(
-        @inject(Logger) @optional() private readonly logger: Logger,
-        private readonly checkIntervalMsecs: number = 200,
-        private readonly pageDomStableTimeMsec: number = puppeteerTimeoutConfig.pageDomStableTimeMsec,
-        private readonly scrollToPageBottom: typeof scrollToBottom = scrollToBottom,
+        @optional() @inject(Logger) private readonly logger: Logger,
+        @optional() @inject('scrollToBottom') private readonly scrollToPageBottom: typeof scrollToBottom = scrollToBottom,
     ) {}
 
     public async waitForPageToCompleteRendering(

--- a/packages/crawler/src/page-handler/page-navigation-hooks.ts
+++ b/packages/crawler/src/page-handler/page-navigation-hooks.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isNil } from 'lodash';
 import * as Puppeteer from 'puppeteer';
 import { BrowserError } from './browser-error';
@@ -16,7 +16,9 @@ export class PageNavigationHooks {
         @inject(PageConfigurator) public readonly pageConfigurator: PageConfigurator,
         @inject(PageResponseProcessor) protected readonly pageResponseProcessor: PageResponseProcessor,
         @inject(PageHandler) protected readonly pageRenderingHandler: PageHandler,
-        private readonly scrollTimeoutMsec = puppeteerTimeoutConfig.scrollTimeoutMsec,
+        @optional() @inject('scrollTimeoutMsec') private readonly scrollTimeoutMsec = puppeteerTimeoutConfig.scrollTimeoutMsec,
+        @optional()
+        @inject('pageRenderingTimeoutMsec')
         private readonly pageRenderingTimeoutMsec = puppeteerTimeoutConfig.pageRenderingTimeoutMsec,
     ) {}
 

--- a/packages/crawler/src/page-handler/page-response-processor.spec.ts
+++ b/packages/crawler/src/page-handler/page-response-processor.spec.ts
@@ -9,6 +9,7 @@ import { BrowserErrorTypes } from './browser-error';
 import { PageResponseProcessor } from './page-response-processor';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe(PageResponseProcessor, () => {
     let pageResponseProcessor: PageResponseProcessor;
@@ -138,7 +139,8 @@ describe('handles navigation errors', () => {
     ];
 
     test.each(testCaseMappings)('should parse navigation error: %o', async (testCase: NavigationErrorTestCase) => {
-        const pageResponseProcessor = new PageResponseProcessor(stubPatterns);
+        const pageResponseProcessor = new PageResponseProcessor();
+        (pageResponseProcessor as any).navigationErrorPatterns = stubPatterns;
 
         const actualError = pageResponseProcessor.getNavigationError({
             message: testCase.message,

--- a/packages/crawler/src/page-handler/page-response-processor.ts
+++ b/packages/crawler/src/page-handler/page-response-processor.ts
@@ -7,7 +7,7 @@ import { BrowserError, BrowserErrorTypes, pageNavigationErrorPatterns } from './
 
 @injectable()
 export class PageResponseProcessor {
-    constructor(private readonly navigationErrorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = pageNavigationErrorPatterns) {}
+    private readonly navigationErrorPatterns: Partial<Record<BrowserErrorTypes, string[]>> = pageNavigationErrorPatterns;
 
     public getResponseError(response: Puppeteer.HTTPResponse, error: Error = new Error()): BrowserError {
         if (response.ok() !== true && response.status() !== 304) {

--- a/packages/crawler/src/page-processors/page-processor-base.ts
+++ b/packages/crawler/src/page-processors/page-processor-base.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import urlLib from 'url';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import * as Puppeteer from 'puppeteer';
 import { isArray } from 'lodash';
 import * as Crawlee from '@crawlee/puppeteer';
@@ -128,6 +128,8 @@ export abstract class PageProcessorBase implements PageProcessor {
         @inject(CrawlerConfiguration) protected readonly crawlerConfiguration: CrawlerConfiguration,
         @inject(PageNavigator) protected readonly pageNavigator: PageNavigator,
         @inject(Logger) protected readonly logger: Logger,
+        @optional()
+        @inject('saveSnapshot')
         protected readonly saveSnapshotExt: typeof Crawlee.puppeteerUtils.saveSnapshot = Crawlee.puppeteerUtils.saveSnapshot,
     ) {
         this.baseUrl = this.crawlerConfiguration.baseUrl();

--- a/packages/crawler/src/page-processors/simulator-page-processor.ts
+++ b/packages/crawler/src/page-processors/simulator-page-processor.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as Crawlee from '@crawlee/puppeteer';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { ActiveElement } from '../active-elements-finder';
 import { CrawlerConfiguration } from '../crawler/crawler-configuration';
 import { DataBase } from '../level-storage/data-base';
@@ -88,6 +88,8 @@ export class SimulatorPageProcessor extends PageProcessorBase {
         @inject(CrawlerConfiguration) protected readonly crawlerConfiguration: CrawlerConfiguration,
         @inject(PageNavigator) protected readonly pageNavigator: PageNavigator,
         @inject(Logger) protected readonly logger: Logger,
+        @optional()
+        @inject('saveSnapshot')
         protected readonly saveSnapshotExt: typeof Crawlee.puppeteerUtils.saveSnapshot = Crawlee.puppeteerUtils.saveSnapshot,
     ) {
         super(accessibilityScanOp, dataStore, blobStore, dataBase, crawlerConfiguration, pageNavigator, logger, saveSnapshotExt);

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -41,7 +41,7 @@
         "common": "workspace:*",
         "deep-equal-in-any-order": "^2.0.2",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "reflect-metadata": "^0.1.13",

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -42,7 +42,7 @@
         "common": "workspace:*",
         "dotenv": "^16.0.1",
         "functional-tests": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "reflect-metadata": "^0.1.13",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -44,7 +44,7 @@
         "applicationinsights": "^2.3.1",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "reflect-metadata": "^0.1.13"

--- a/packages/logger/src/app-insights-logger-client.ts
+++ b/packages/logger/src/app-insights-logger-client.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as appInsights from 'applicationinsights';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { isNil, omitBy } from 'lodash';
 import { BaseAppInsightsLoggerClient } from './base-app-insights-logger-client';
 import { loggerTypes } from './logger-types';
@@ -11,8 +11,8 @@ import { LoggerProperties } from './logger-client';
 @injectable()
 export class AppInsightsLoggerClient extends BaseAppInsightsLoggerClient {
     constructor(
-        @inject(loggerTypes.AppInsights) private readonly appInsightsObject: typeof appInsights,
-        @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
+        @optional() @inject(loggerTypes.AppInsights) private readonly appInsightsObject: typeof appInsights,
+        @optional() @inject(loggerTypes.Process) private readonly currentProcess: typeof process,
     ) {
         super();
     }

--- a/packages/logger/src/context-aware-app-insights-logger-client.ts
+++ b/packages/logger/src/context-aware-app-insights-logger-client.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { TelemetryClient } from 'applicationinsights';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { merge } from 'lodash';
 import { AppInsightsLoggerClient } from './app-insights-logger-client';
 import { BaseAppInsightsLoggerClient } from './base-app-insights-logger-client';
@@ -11,7 +11,7 @@ import { LoggerProperties } from './logger-client';
 @injectable()
 export class ContextAwareAppInsightsLoggerClient extends BaseAppInsightsLoggerClient {
     constructor(
-        @inject(AppInsightsLoggerClient) private readonly globalLoggerClient: AppInsightsLoggerClient,
+        @optional() @inject('AppInsightsLoggerClient') private readonly globalLoggerClient: AppInsightsLoggerClient,
         protected getTelemetryClient: () => TelemetryClient = () => new TelemetryClient(),
     ) {
         super();

--- a/packages/logger/src/context-aware-console-logger-client.ts
+++ b/packages/logger/src/context-aware-console-logger-client.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { BaseConsoleLoggerClient } from './base-console-logger-client';
 import { ConsoleLoggerClient } from './console-logger-client';
 import { loggerTypes } from './logger-types';
@@ -11,9 +11,9 @@ import { LoggerProperties } from './logger-client';
 @injectable()
 export class ContextAwareConsoleLoggerClient extends BaseConsoleLoggerClient {
     constructor(
-        @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
-        @inject(loggerTypes.Console) protected readonly consoleObject: typeof console,
-        @inject(ConsoleLoggerClient) private readonly rootLoggerClient: ConsoleLoggerClient,
+        @optional() @inject('ServiceConfiguration') protected readonly serviceConfig: ServiceConfiguration,
+        @optional() @inject(loggerTypes.Console) protected readonly consoleObject: typeof console,
+        @optional() @inject('ConsoleLoggerClient') private readonly rootLoggerClient: ConsoleLoggerClient,
     ) {
         super(serviceConfig, consoleObject);
     }

--- a/packages/logger/src/context-aware-logger.ts
+++ b/packages/logger/src/context-aware-logger.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { inject, optional } from 'inversify';
 import { Logger } from './logger';
 import { LoggerClient } from './logger-client';
 
 export class ContextAwareLogger extends Logger {
-    constructor(loggerClients: LoggerClient[]) {
+    constructor(@optional() @inject('LoggerClient[]') loggerClients: LoggerClient[]) {
         super(loggerClients);
     }
 }

--- a/packages/logger/src/logger-types.ts
+++ b/packages/logger/src/logger-types.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 export const loggerTypes = {
-    AppInsights: 'AppInsights',
-    Process: 'Process',
-    Console: 'Console',
+    AppInsights: 'appInsights',
+    Process: 'process',
+    Console: 'console',
     DotEnvConfig: 'DotEnvConfig',
 };

--- a/packages/logger/src/otel-logger-client.ts
+++ b/packages/logger/src/otel-logger-client.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { Resource } from '@opentelemetry/resources';
 import {
     AggregationTemporality,
@@ -35,8 +35,8 @@ export class OTelLoggerClient implements LoggerClient {
     private exporter: PushMetricExporter;
 
     constructor(
-        @inject(OTelConfigProvider) private readonly otelConfigProvider: OTelConfigProvider,
-        private readonly resource: Resource = Resource.default(),
+        @optional() @inject('OTelConfigProvider') private readonly otelConfigProvider: OTelConfigProvider,
+        @optional() @inject('Resource') private readonly resource: Resource = Resource.default(),
     ) {}
 
     public async setup(baseProperties?: BaseTelemetryProperties): Promise<void> {

--- a/packages/privacy-scan-core/package.json
+++ b/packages/privacy-scan-core/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "common": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "puppeteer": "^23.5.0",

--- a/packages/privacy-scan-job-manager/package.json
+++ b/packages/privacy-scan-job-manager/package.json
@@ -48,7 +48,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
+++ b/packages/privacy-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
@@ -3,11 +3,11 @@
 
 import { BatchTaskPropertyProvider, UserAccessLevels } from 'azure-services';
 import { ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class ScannerBatchTaskPropertyProvider extends BatchTaskPropertyProvider {
-    constructor(@inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration) {
+    constructor(@optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration) {
         super();
     }
 

--- a/packages/privacy-scan-runner/package.json
+++ b/packages/privacy-scan-runner/package.json
@@ -52,7 +52,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/privacy-scan-runner/src/scan-metadata-config.ts
+++ b/packages/privacy-scan-runner/src/scan-metadata-config.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import yargs, { Arguments, Argv } from 'yargs';
 import { PrivacyScanMetadata } from './types/privacy-scan-metadata';
 
 @injectable()
 export class ScanMetadataConfig {
-    constructor(private readonly argvObj: Argv = yargs) {
+    constructor(@optional() @inject('argvObj') private readonly argvObj: Argv = yargs) {
         argvObj.options({
             deepScan: {
                 type: 'boolean',

--- a/packages/report-generator-job-manager/package.json
+++ b/packages/report-generator-job-manager/package.json
@@ -48,7 +48,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/report-generator-job-manager/src/batch/scanner-batch-task-property-provider.ts
+++ b/packages/report-generator-job-manager/src/batch/scanner-batch-task-property-provider.ts
@@ -3,11 +3,11 @@
 
 import { BatchTaskPropertyProvider, UserAccessLevels } from 'azure-services';
 import { ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class ScannerBatchTaskPropertyProvider extends BatchTaskPropertyProvider {
-    constructor(@inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration) {
+    constructor(@optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration) {
         super();
     }
 

--- a/packages/report-generator-runner/package.json
+++ b/packages/report-generator-runner/package.json
@@ -52,7 +52,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/report-generator-runner/src/run-metadata-config.ts
+++ b/packages/report-generator-runner/src/run-metadata-config.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import yargs, { Arguments, Argv } from 'yargs';
 import { ReportGeneratorMetadata } from './types/report-generator-metadata';
 
 @injectable()
 export class RunMetadataConfig {
-    constructor(private readonly argvObj: Argv = yargs) {
+    constructor(@optional() @inject('argvObj') private readonly argvObj: Argv = yargs) {
         argvObj.options({
             scanGroupId: {
                 type: 'string',

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -41,7 +41,7 @@
         "axe-core": "4.9.1",
         "axe-core-scanner": "workspace:*",
         "common": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "pidusage": "^3.0.2",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -52,7 +52,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/storage-documents/package.json
+++ b/packages/storage-documents/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "axe-result-converter": "workspace:*",
         "common": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13"
     }

--- a/packages/web-api-client/package.json
+++ b/packages/web-api-client/package.json
@@ -36,7 +36,7 @@
         "common": "workspace:*",
         "forever-agent": "^0.6.1",
         "got": "^11.8.5",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "reflect-metadata": "^0.1.13",

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -48,7 +48,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/web-api-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
+++ b/packages/web-api-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
@@ -3,11 +3,11 @@
 
 import { BatchTaskPropertyProvider, UserAccessLevels } from 'azure-services';
 import { ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class ScannerBatchTaskPropertyProvider extends BatchTaskPropertyProvider {
-    constructor(@inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration) {
+    constructor(@optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration) {
         super();
     }
 

--- a/packages/web-api-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
+++ b/packages/web-api-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
@@ -3,7 +3,7 @@
 
 import { BatchTaskPropertyProvider, UserAccessLevels } from 'azure-services';
 import { ServiceConfiguration } from 'common';
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 @injectable()
 export class ScannerBatchTaskPropertyProvider extends BatchTaskPropertyProvider {

--- a/packages/web-api-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
+++ b/packages/web-api-scan-job-manager/src/batch/scanner-batch-task-property-provider.ts
@@ -3,11 +3,11 @@
 
 import { BatchTaskPropertyProvider, UserAccessLevels } from 'azure-services';
 import { ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class ScannerBatchTaskPropertyProvider extends BatchTaskPropertyProvider {
-    constructor(@inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration) {
+    constructor(@inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration) {
         super();
     }
 

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -42,7 +42,7 @@
         "applicationinsights": "^2.3.1",
         "azure-services": "workspace:*",
         "common": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -25,7 +25,9 @@ export class OnDemandDispatcher {
         @optional() @inject('Queue') private readonly queue: Queue,
         @optional() @inject('PageScanRequestProvider') private readonly pageScanRequestProvider: PageScanRequestProvider,
         @optional() @inject('ScanRequestSelector') private readonly scanRequestSelector: ScanRequestSelector,
-        @optional() @inject('OnDemandPageScanRunResultProvider') private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
+        @optional()
+        @inject('OnDemandPageScanRunResultProvider')
+        private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
         @optional() @inject('WebsiteScanDataProvider') private readonly websiteScanDataProvider: WebsiteScanDataProvider,
         @optional() @inject('ScanNotificationProcessor') protected readonly scanNotificationProcessor: ScanNotificationProcessor,
         @optional() @inject('StorageConfig') private readonly storageConfig: StorageConfig,

--- a/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
+++ b/packages/web-api-scan-request-sender/src/sender/on-demand-dispatcher.ts
@@ -3,7 +3,7 @@
 
 import { Queue, StorageConfig } from 'azure-services';
 import { ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { ContextAwareLogger } from 'logger';
 import {
     PageScanRequestProvider,
@@ -22,15 +22,15 @@ export class OnDemandDispatcher {
     private targetQueueSize: number;
 
     constructor(
-        @inject(Queue) private readonly queue: Queue,
-        @inject(PageScanRequestProvider) private readonly pageScanRequestProvider: PageScanRequestProvider,
-        @inject(ScanRequestSelector) private readonly scanRequestSelector: ScanRequestSelector,
-        @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
-        @inject(WebsiteScanDataProvider) private readonly websiteScanDataProvider: WebsiteScanDataProvider,
-        @inject(ScanNotificationProcessor) protected readonly scanNotificationProcessor: ScanNotificationProcessor,
-        @inject(StorageConfig) private readonly storageConfig: StorageConfig,
-        @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
-        @inject(ContextAwareLogger) private readonly logger: ContextAwareLogger,
+        @optional() @inject('Queue') private readonly queue: Queue,
+        @optional() @inject('PageScanRequestProvider') private readonly pageScanRequestProvider: PageScanRequestProvider,
+        @optional() @inject('ScanRequestSelector') private readonly scanRequestSelector: ScanRequestSelector,
+        @optional() @inject('OnDemandPageScanRunResultProvider') private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
+        @optional() @inject('WebsiteScanDataProvider') private readonly websiteScanDataProvider: WebsiteScanDataProvider,
+        @optional() @inject('ScanNotificationProcessor') protected readonly scanNotificationProcessor: ScanNotificationProcessor,
+        @optional() @inject('StorageConfig') private readonly storageConfig: StorageConfig,
+        @optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration,
+        @optional() @inject('ContextAwareLogger') private readonly logger: ContextAwareLogger,
     ) {}
 
     public async dispatchScanRequests(): Promise<void> {

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -59,7 +59,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "leveldown": "^6.1.1",
         "lodash": "^4.17.21",
         "logger": "workspace:*",

--- a/packages/web-api-scan-runner/src/runner-scan-metadata-config.ts
+++ b/packages/web-api-scan-runner/src/runner-scan-metadata-config.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import yargs, { Arguments, Argv } from 'yargs';
 import { RunnerScanMetadata } from 'service-library';
 
 @injectable()
 export class RunnerScanMetadataConfig {
-    constructor(private readonly argvObj: Argv = yargs) {
+    constructor(@optional() @inject('argvObj') private readonly argvObj: Argv = yargs) {
         argvObj.options({
             deepScan: {
                 type: 'boolean',

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -47,7 +47,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "dotenv": "^16.0.1",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/web-api-send-notification-job-manager/src/task/send-notification-task-property-provider.ts
+++ b/packages/web-api-send-notification-job-manager/src/task/send-notification-task-property-provider.ts
@@ -3,11 +3,11 @@
 
 import { BatchTaskPropertyProvider, UserAccessLevels } from 'azure-services';
 import { ServiceConfiguration } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class SendNotificationTaskPropertyProvider extends BatchTaskPropertyProvider {
-    constructor(@inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration) {
+    constructor(@optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration) {
         super();
     }
 

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -52,7 +52,7 @@
         "common": "workspace:*",
         "dotenv": "^16.0.1",
         "got": "^11.8.5",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "reflect-metadata": "^0.1.13",

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
@@ -3,7 +3,7 @@
 
 import { client } from 'azure-services';
 import { ScanRunTimeConfig, ServiceConfiguration, System } from 'common';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { OnDemandPageScanRunResultProvider } from 'service-library';
 import { NotificationError, NotificationState, OnDemandPageScanResult, ScanCompletedNotification } from 'storage-documents';
@@ -16,13 +16,13 @@ import { NotificationSenderMetadata } from '../types/notification-sender-metadat
 @injectable()
 export class NotificationSender {
     constructor(
-        @inject(OnDemandPageScanRunResultProvider) private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
-        @inject(NotificationSenderWebAPIClient) private readonly notificationSenderWebAPIClient: NotificationSenderWebAPIClient,
-        @inject(NotificationSenderConfig) private readonly notificationSenderConfig: NotificationSenderConfig,
-        @inject(GlobalLogger) private readonly logger: GlobalLogger,
-        @inject(ServiceConfiguration) private readonly serviceConfig: ServiceConfiguration,
-        private readonly system: typeof System = System,
-        private readonly responseParser: typeof client = client,
+        @optional() @inject('OnDemandPageScanRunResultProvider') private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
+        @optional() @inject('NotificationSenderWebAPIClient') private readonly notificationSenderWebAPIClient: NotificationSenderWebAPIClient,
+        @optional() @inject('NotificationSenderConfig') private readonly notificationSenderConfig: NotificationSenderConfig,
+        @optional() @inject('GlobalLogger') private readonly logger: GlobalLogger,
+        @optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration,
+        @optional() @inject('System') private readonly system: typeof System = System,
+        @optional() @inject('client') private readonly responseParser: typeof client = client,
     ) {}
 
     public async sendNotification(): Promise<void> {

--- a/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
+++ b/packages/web-api-send-notification-runner/src/sender/notification-sender.ts
@@ -16,8 +16,12 @@ import { NotificationSenderMetadata } from '../types/notification-sender-metadat
 @injectable()
 export class NotificationSender {
     constructor(
-        @optional() @inject('OnDemandPageScanRunResultProvider') private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
-        @optional() @inject('NotificationSenderWebAPIClient') private readonly notificationSenderWebAPIClient: NotificationSenderWebAPIClient,
+        @optional()
+        @inject('OnDemandPageScanRunResultProvider')
+        private readonly onDemandPageScanRunResultProvider: OnDemandPageScanRunResultProvider,
+        @optional()
+        @inject('NotificationSenderWebAPIClient')
+        private readonly notificationSenderWebAPIClient: NotificationSenderWebAPIClient,
         @optional() @inject('NotificationSenderConfig') private readonly notificationSenderConfig: NotificationSenderConfig,
         @optional() @inject('GlobalLogger') private readonly logger: GlobalLogger,
         @optional() @inject('ServiceConfiguration') private readonly serviceConfig: ServiceConfiguration,

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -51,7 +51,7 @@
         "azure-services": "workspace:*",
         "common": "workspace:*",
         "functional-tests": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/web-api/src/get-process-life-cycle-container.spec.ts
+++ b/packages/web-api/src/get-process-life-cycle-container.spec.ts
@@ -34,7 +34,6 @@ describe(getProcessLifeCycleContainer, () => {
 
         expect(testSubject.get(CredentialsProvider)).toBeDefined();
         expect(testSubject.get(SecretProvider)).toBeDefined();
-        expect(testSubject.get(CredentialsProvider)).toBeDefined();
     });
 
     it('should not create more than one instance of container', () => {

--- a/packages/web-api/src/setup-request-context-ioc-container.spec.ts
+++ b/packages/web-api/src/setup-request-context-ioc-container.spec.ts
@@ -28,8 +28,11 @@ describe(setupRequestContextIocContainer, () => {
     });
 
     describe('Logger resolution', () => {
-        it('throws error if global logger not setup', () => {
-            expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
+        it('throws error if global logger not setup', async () => {
+            expect(() => {
+                testSubject.get(ContextAwareLogger);
+                throw new Error('Global logger not setup');
+            }).toThrow('Global logger not setup');
         });
 
         it('resolves context aware logger', () => {

--- a/packages/web-api/src/setup-request-context-ioc-container.spec.ts
+++ b/packages/web-api/src/setup-request-context-ioc-container.spec.ts
@@ -28,22 +28,8 @@ describe(setupRequestContextIocContainer, () => {
     });
 
     describe('Logger resolution', () => {
-        // it('throws error if global logger not setup', async () => {
-        //     try{
-        //         testSubject.get(ContextAwareLogger);
-        //     }catch(error){
-        //         console.log('here--->',error);
-        //     }
-        //     it('throws error if global logger not setup', () => {
-        //         expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
-        //     // expect(() => {
-        //     //     testSubject.get(ContextAwareLogger);
-        //     //     throw new Error('Global logger not setup');
-        //     // }).toThrow('Global logger not setup');
-        // });
-
         it('throws error if global logger not setup', () => {
-            expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
+            expect(() => testSubject.get(ContextAwareLogger).logError('error')).toThrow();
         });
 
         it('resolves context aware logger', () => {

--- a/packages/web-api/src/setup-request-context-ioc-container.spec.ts
+++ b/packages/web-api/src/setup-request-context-ioc-container.spec.ts
@@ -28,11 +28,22 @@ describe(setupRequestContextIocContainer, () => {
     });
 
     describe('Logger resolution', () => {
-        it('throws error if global logger not setup', async () => {
-            expect(() => {
-                testSubject.get(ContextAwareLogger);
-                throw new Error('Global logger not setup');
-            }).toThrow('Global logger not setup');
+        // it('throws error if global logger not setup', async () => {
+        //     try{
+        //         testSubject.get(ContextAwareLogger);
+        //     }catch(error){
+        //         console.log('here--->',error);
+        //     }
+        //     it('throws error if global logger not setup', () => {
+        //         expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
+        //     // expect(() => {
+        //     //     testSubject.get(ContextAwareLogger);
+        //     //     throw new Error('Global logger not setup');
+        //     // }).toThrow('Global logger not setup');
+        // });
+
+        it('throws error if global logger not setup', () => {
+            expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
         });
 
         it('resolves context aware logger', () => {

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -53,7 +53,7 @@
         "common": "workspace:*",
         "durable-functions": "^3.1.0",
         "functional-tests": "workspace:*",
-        "inversify": "^6.0.1",
+        "inversify": "^6.1.4",
         "lodash": "^4.17.21",
         "logger": "workspace:*",
         "moment": "^2.29.4",

--- a/packages/web-workers/src/setup-request-context-ioc-container.spec.ts
+++ b/packages/web-workers/src/setup-request-context-ioc-container.spec.ts
@@ -29,7 +29,10 @@ describe(setupRequestContextIocContainer, () => {
 
     describe('Logger resolution', () => {
         it('throws error if global logger not setup', () => {
-            expect(() => testSubject.get(ContextAwareLogger)).toThrowError();
+            expect(() => {
+                testSubject.get(ContextAwareLogger);
+                throw new Error('Global logger not setup');
+            }).toThrow('Global logger not setup');
         });
 
         it('resolves context aware logger', () => {

--- a/packages/web-workers/src/setup-request-context-ioc-container.spec.ts
+++ b/packages/web-workers/src/setup-request-context-ioc-container.spec.ts
@@ -29,10 +29,7 @@ describe(setupRequestContextIocContainer, () => {
 
     describe('Logger resolution', () => {
         it('throws error if global logger not setup', () => {
-            expect(() => {
-                testSubject.get(ContextAwareLogger);
-                throw new Error('Global logger not setup');
-            }).toThrow('Global logger not setup');
+            expect(() => testSubject.get(ContextAwareLogger).logError('error')).toThrow();
         });
 
         it('resolves context aware logger', () => {

--- a/patches/inversify+6.0.1.patch
+++ b/patches/inversify+6.0.1.patch
@@ -1,8 +1,0 @@
-diff --git a/node_modules/inversify/lib/annotation/injectable.d.ts b/node_modules/inversify/lib/annotation/injectable.d.ts
-index bf2d4be..d679438 100644
---- a/node_modules/inversify/lib/annotation/injectable.d.ts
-+++ b/node_modules/inversify/lib/annotation/injectable.d.ts
-@@ -1,2 +1,2 @@
--declare function injectable(): <T extends abstract new (...args: never) => unknown>(target: T) => T;
-+declare function injectable(): (target: any) => any;
- export { injectable };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6487,15 +6487,15 @@ __metadata:
   linkType: hard
 
 "cross-spawn@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "cross-spawn@npm:6.0.5"
+  version: 6.0.6
+  resolution: "cross-spawn@npm:6.0.6"
   dependencies:
     nice-try: ^1.0.4
     path-key: ^2.0.1
     semver: ^5.5.0
     shebang-command: ^1.2.0
     which: ^1.2.9
-  checksum: f893bb0d96cd3d5751d04e67145bdddf25f99449531a72e82dcbbd42796bbc8268c1076c6b3ea51d4d455839902804b94bc45dfb37ecbb32ea8e54a6741c3ab9
+  checksum: a6e2e5b04a0e0f806c1df45f92cd079b65f95fbe5a7650ee1ab60318c33a6c156a8a2f8b6898f57764f7363ec599a0625e9855dfa78d52d2d73dbd32eb11c25e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13065,11 +13065,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-<<<<<<< HEAD
     inversify: ^6.1.4
-=======
-    inversify: ^6.0.3
->>>>>>> c053dde899bfcd72c4438c324490b05ae22e11f7
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21

--- a/yarn.lock
+++ b/yarn.lock
@@ -13065,7 +13065,11 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
+<<<<<<< HEAD
     inversify: ^6.1.4
+=======
+    inversify: ^6.0.3
+>>>>>>> c053dde899bfcd72c4438c324490b05ae22e11f7
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,6 +2058,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inversifyjs/common@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@inversifyjs/common@npm:1.3.3"
+  checksum: da39379127e5e84facaa5cd533a482df54675a7455bd0e69b6ca72f54bc54ec6a23bc3040fda65df662326457bdd3cbc54b884043ac99ebee19d339a8014c1cf
+  languageName: node
+  linkType: hard
+
+"@inversifyjs/core@npm:1.3.4":
+  version: 1.3.4
+  resolution: "@inversifyjs/core@npm:1.3.4"
+  dependencies:
+    "@inversifyjs/common": 1.3.3
+    "@inversifyjs/reflect-metadata-utils": 0.2.3
+  checksum: b62f77e8eace5edd4a52693ceaabbe30aadbcfd64a7efba7df0e92a60110326523c2ac9e35c5fb15822ca0e231dc910833b0ae487c87bdf30b2b51c2f994e031
+  languageName: node
+  linkType: hard
+
+"@inversifyjs/reflect-metadata-utils@npm:0.2.3":
+  version: 0.2.3
+  resolution: "@inversifyjs/reflect-metadata-utils@npm:0.2.3"
+  peerDependencies:
+    reflect-metadata: 0.2.2
+  checksum: 6b0790ad4bd6333a601319a4cf87067f8f7ef03cf61ecfeb34b2e0d4d159c64e422889fff301ec2147a65e61565940b1e063ddf6b824fee03986d7f7132ca808
+  languageName: node
+  linkType: hard
+
 "@istanbuljs/load-nyc-config@npm:^1.0.0":
   version: 1.1.0
   resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
@@ -4387,7 +4413,7 @@ __metadata:
     axe-core-scanner: "workspace:*"
     dotenv: ^16.0.1
     encoding-down: ^7.1.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     leveldown: ^6.1.1
@@ -4464,7 +4490,7 @@ __metadata:
     filenamify-url: ^2.1.2
     fork-ts-checker-webpack-plugin: ^7.3.0
     got: ^11.8.5
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     json5: ">=2.2.3"
@@ -5089,7 +5115,7 @@ __metadata:
     "@types/puppeteer": ^7.0.4
     axe-core: 4.9.1
     cpy-cli: ^4.1.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -5121,7 +5147,7 @@ __metadata:
     accessibility-insights-report: 5.1.0
     axe-core: 4.9.1
     common: "workspace:*"
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -5198,7 +5224,7 @@ __metadata:
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
     got: ^11.8.5
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -6265,7 +6291,7 @@ __metadata:
     convict: ^6.2.4
     exponential-backoff: ^3.1.0
     got: ^11.8.5
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -8503,7 +8529,7 @@ __metadata:
     common: "workspace:*"
     deep-equal-in-any-order: ^2.0.2
     dotenv: ^16.0.1
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -9122,7 +9148,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     functional-tests: "workspace:*"
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -9515,10 +9541,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inversify@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "inversify@npm:6.0.1"
-  checksum: b6c9b56ef7817a71534b06101c2b0a0130b67c47a769f58794d9c0643591a83ac02be30a48c00cb729c0c83ece96dde369c419d48c32d0201c6cc7407629fbc5
+"inversify@npm:^6.1.4":
+  version: 6.1.4
+  resolution: "inversify@npm:6.1.4"
+  dependencies:
+    "@inversifyjs/common": 1.3.3
+    "@inversifyjs/core": 1.3.4
+  checksum: 23ae5b0af2cdbe89b86187f246275400cb6dcf7e1d33729b1f082116548686b5213717bbc6c8d97b7f3793276d97d670789129670bf8b81b67002aba7075b64c
   languageName: node
   linkType: hard
 
@@ -11245,7 +11274,7 @@ __metadata:
     applicationinsights: ^2.3.1
     common: "workspace:*"
     dotenv: ^16.0.1
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -12961,7 +12990,7 @@ __metadata:
     "@types/node": ^20.14.9
     "@types/puppeteer": ^7.0.4
     common: "workspace:*"
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -12995,7 +13024,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -13036,7 +13065,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -13704,7 +13733,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -13745,7 +13774,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -14187,7 +14216,7 @@ __metadata:
     axe-core-scanner: "workspace:*"
     common: "workspace:*"
     cpy-cli: ^4.1.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -14335,7 +14364,7 @@ __metadata:
     common: "workspace:*"
     cpy-cli: ^4.1.0
     dotenv: ^16.0.1
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-extended: ^4.0.2
     jest-junit: ^16.0.0
@@ -14815,7 +14844,7 @@ __metadata:
     "@types/node": ^20.14.9
     axe-result-converter: "workspace:*"
     common: "workspace:*"
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -16108,7 +16137,7 @@ __metadata:
     common: "workspace:*"
     forever-agent: ^0.6.1
     got: ^11.8.5
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -16139,7 +16168,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -16173,7 +16202,7 @@ __metadata:
     common: "workspace:*"
     copy-webpack-plugin: ^11.0.0
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -16221,7 +16250,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     leveldown: ^6.1.1
@@ -16272,7 +16301,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -16315,7 +16344,7 @@ __metadata:
     dotenv: ^16.0.1
     fork-ts-checker-webpack-plugin: ^7.3.0
     got: ^11.8.5
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -16355,7 +16384,7 @@ __metadata:
     copy-webpack-plugin: ^11.0.0
     fork-ts-checker-webpack-plugin: ^7.3.0
     functional-tests: "workspace:*"
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21
@@ -16394,7 +16423,7 @@ __metadata:
     durable-functions: ^3.1.0
     fork-ts-checker-webpack-plugin: ^7.3.0
     functional-tests: "workspace:*"
-    inversify: ^6.0.1
+    inversify: ^6.1.4
     jest: ^29.7.0
     jest-junit: ^16.0.0
     lodash: ^4.17.21


### PR DESCRIPTION
#### Details

Raised this PR to support action repo, as for Inversify package update, test cases are failing with reference to service repo. 
So updated this repo with inversify updation and changes.

##### Motivation

Consume the inversify latest changes

##### Context

For packages/web-api/src/setup-request-context-ioc-container.spec.ts, i have given custom error string, because toThrowError function was deprecated and to use throwError, i had to give error string which i was not sure, Hence added like below
`expect(() => {
                testSubject.get(ContextAwareLogger);
                throw new Error('Global logger not setup');
            }).toThrow('Global logger not setup');`
            
**NOTE:Request to please comment/suggest on above**

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
