### PR TITLE
fix: update timeout for authentication in accessibility insights scan package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",

--- a/packages/crawler/src/authenticator/azure-active-directory-authenticator.spec.ts
+++ b/packages/crawler/src/authenticator/azure-active-directory-authenticator.spec.ts
@@ -31,12 +31,13 @@ function setupAADAuthenticationFlow(
     if (passwordAuthenticationPreference) {
         pageMock.setup((p) => p.waitForSelector('input[name="loginfmt"]')).verifiable(Times.exactly(1));
         pageMock
-            .setup((p) => p.waitForSelector('#FormsAuthentication'))
-            .returns(() => Promise.reject('TimeoutError: waiting for selector `#FormsAuthentication` failed: timeout 30000ms exceeded'));
-        pageMock.setup((p) => p.waitForSelector('input[type="password"]')).verifiable(Times.exactly(1));
+            .setup((p) => p.waitForSelector('#FormsAuthentication', { timeout: 10000 }))
+            .returns(() => Promise.reject('TimeoutError: waiting for selector `#FormsAuthentication` failed: timeout 10000ms exceeded'));
+        pageMock.setup((p) => p.waitForSelector('input[type="password"]', { timeout: 10000 })).verifiable(Times.exactly(1));
         pageMock.setup((p) => p.click('input[type="password"]')).verifiable(Times.exactly(1));
     } else {
-        pageMock.setup((p) => p.waitForSelector(It.isAnyString())).verifiable(Times.exactly(2));
+        pageMock.setup((p) => p.waitForSelector('#FormsAuthentication', { timeout: 10000 })).verifiable(Times.exactly(1));
+        pageMock.setup((p) => p.waitForSelector('input[type="password"]', { timeout: 10000 })).verifiable(Times.exactly(1));
         pageMock.setup((p) => p.click('#FormsAuthentication')).verifiable(Times.exactly(1));
     }
     if (success) {
@@ -142,11 +143,11 @@ describe(AzureActiveDirectoryAuthentication, () => {
         pageMock.setup((p) => p.type(It.isAnyString(), accountName)).verifiable(Times.exactly(1));
         pageMock.setup((o) => o.waitForNavigation()).verifiable(Times.exactly(1));
         pageMock
-            .setup((p) => p.waitForSelector('#FormsAuthentication'))
-            .returns(() => Promise.reject('TimeoutError: waiting for selector `#FormsAuthentication` failed: timeout 30000ms exceeded'));
+            .setup((p) => p.waitForSelector('#FormsAuthentication', { timeout: 10000 }))
+            .returns(() => Promise.reject('TimeoutError: waiting for selector `#FormsAuthentication` failed: timeout 10000ms exceeded'));
         pageMock
-            .setup((p) => p.waitForSelector('input[type="password"]'))
-            .returns(() => Promise.reject('TimeoutError: waiting for selector `input[type="password"]` failed: timeout 30000ms exceeded'));
+            .setup((p) => p.waitForSelector('input[type="password"]', { timeout: 10000 }))
+            .returns(() => Promise.reject('TimeoutError: waiting for selector `input[type="password"]` failed: timeout 10000ms exceeded'));
         pageMock
             .setup((p) => p.url())
             .returns(() => 'https://login.microsoftonline.com')
@@ -154,7 +155,7 @@ describe(AzureActiveDirectoryAuthentication, () => {
 
         expect.assertions(1);
         const expectedErrorMessage = new Error(
-            'Authentication failed. Authentication requires a non-people service account. To learn how to set up a service account, visit: https://aka.ms/AI-action-auth. TimeoutError: waiting for selector `input[type="password"]` failed: timeout 30000ms exceeded',
+            'Authentication failed. Authentication requires a non-people service account. To learn how to set up a service account, visit: https://aka.ms/AI-action-auth. TimeoutError: waiting for selector `input[type="password"]` failed: timeout 10000ms exceeded',
         );
 
         try {


### PR DESCRIPTION
#### Details

scan is failing with below error due to waiting for 30 sec on #FormsAuthentication selector. Reduced the timeout to 10 seconds. 

```Authentication failed. Authentication requires a non-people service account. To learn how to set up a service account, visit: https://aka.ms/AI-action-auth. Error: Waiting for selector `input[type="password"]` failed: waitForFunction failed: frame got detached.```

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
