### PR TITLE
refactor: remove workaround for Playwright and extend scan reporting

### DIFF
--- a/packages/api-contracts/openapi.json
+++ b/packages/api-contracts/openapi.json
@@ -459,9 +459,7 @@
                                     "example": "accessibility-agent"
                                 },
                                 "state": {
-                                    "type": "string",
-                                    "enum": ["pending", "pass", "fail", "error", "completed"],
-                                    "example": "completed"
+                                    "$ref": "#/components/schemas/RunState"
                                 },
                                 "timestamp": {
                                     "description": "Full date and time string format as defined by ISO 8601",
@@ -673,7 +671,7 @@
             "ScanState": {
                 "type": "string",
                 "default": "pending",
-                "enum": ["pending", "pass", "fail"],
+                "enum": ["pending", "pass", "fail", "error"],
                 "example": "fail"
             },
             "RunState": {

--- a/packages/resource-deployment/scripts/docker-scanner-image/install-font-packages.ps1
+++ b/packages/resource-deployment/scripts/docker-scanner-image/install-font-packages.ps1
@@ -1,24 +1,29 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+Import-Module DISM
+
 $gateway = (Get-NetRoute '0.0.0.0/0').NextHop
-net use S: \\$gateway\WinSxS /user:DockerBuild "${env:BUILD_KEY}" | Out-Null
-Write-Host "Windows font source contains:" ( Get-ChildItem S: | Measure-Object ).Count "files"
+net use W: \\$gateway\WinSxS /user:DockerBuild "${env:BUILD_KEY}" | Out-Null
+net use F: \\$gateway\Fonts /user:DockerBuild "${env:BUILD_KEY}" | Out-Null
+Write-Host "Windows font source contains:" ( Get-ChildItem F: | Measure-Object ).Count "files"
+
+Write-Host "Enabling Windows ServerMediaFoundation feature..."
+Enable-WindowsOptionalFeature -FeatureName "ServerMediaFoundation" -Online -LimitAccess -Source W:\
 
 if ("${env:INSTALLATION_TYPE}" -eq "Server") {
     Write-Host "Enabling Windows fonts feature..."
 
-    Import-Module DISM
     Enable-WindowsOptionalFeature -FeatureName `
         "ServerCoreFonts-NonCritical-Fonts-MinConsoleFonts", `
         "ServerCoreFonts-NonCritical-Fonts-Support", `
         "ServerCoreFonts-NonCritical-Fonts-BitmapFonts", `
         "ServerCoreFonts-NonCritical-Fonts-TrueType", `
         "ServerCoreFonts-NonCritical-Fonts-UAPFonts" `
-        -Online -LimitAccess -Source S:\ | Out-Null
+        -Online -LimitAccess -Source W:\ | Out-Null
 }
 else {
     Write-Host "Copying Windows fonts from the host machine..."
 
-    Copy-Item -Path "S:\*" -Destination "${env:windir}\Fonts" -Include "*.fon", "*.ttf", "*.ttc" -Force
+    Copy-Item -Path "F:\*" -Destination "${env:windir}\Fonts" -Include "*.fon", "*.ttf", "*.ttc" -Force
 }

--- a/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
+++ b/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ReportSource } from 'storage-documents';
 import { ScanNotificationErrorCodeName } from '../scan-notification-error-codes';
 import { ScanRunErrorCodeName } from '../scan-run-error-codes';
 import { WebApiError } from '../web-api-error-codes';
@@ -32,7 +31,7 @@ export declare type AuthenticationType = (typeof authenticationTypes)[number];
 // Construct to support type guard
 export const browserValidationTypes = ['highContrastProperties'] as const;
 export declare type BrowserValidationTypes = (typeof browserValidationTypes)[number];
-
+export declare type ReportSource = 'accessibility-agent' | 'accessibility-scan' | 'accessibility-combined' | 'privacy-scan';
 export declare type ReportFormat =
     | 'axe'
     | 'sarif'

--- a/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
+++ b/packages/service-library/src/web-api/api-contracts/scan-result-response.ts
@@ -8,8 +8,7 @@ import { WebApiError } from '../web-api-error-codes';
 import { ScanDefinitionType } from './scan-run-request';
 
 export declare type LinkType = 'self';
-export declare type ScanState = 'pending' | 'pass' | 'fail';
-export declare type ScanStateExt = ScanState | 'error' | 'completed';
+export declare type ScanState = 'pending' | 'pass' | 'fail' | 'error';
 export declare type RunState =
     | 'pending'
     | 'accepted'
@@ -107,7 +106,7 @@ export interface ScanRun {
 
 export interface ScanRunDetail {
     name: ScanDefinitionType;
-    state: ScanStateExt;
+    state: RunState;
     timestamp?: string;
     error?: string;
     details?: unknown;
@@ -131,5 +130,5 @@ export interface AuthenticationResult {
 }
 
 export interface BrowserValidationResult {
-    highContrastProperties?: ScanStateExt;
+    highContrastProperties?: ScanState;
 }

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -25,7 +25,7 @@ export declare type CookieBannerType = 'standard';
 export declare type AuthenticationType = 'undetermined' | 'entraId';
 export declare type ScanType = 'accessibility' | 'privacy';
 export declare type ScanDefinitionType = 'accessibility-agent';
-export declare type ReportSource = 'accessibility-agent' | 'accessibility-scan' | 'privacy-scan';
+export declare type ReportSource = 'accessibility-agent' | 'accessibility-scan' | 'accessibility-combined' | 'privacy-scan';
 export declare type ReportFormat =
     | 'axe'
     | 'sarif'

--- a/packages/storage-documents/src/on-demand-page-scan-result.ts
+++ b/packages/storage-documents/src/on-demand-page-scan-result.ts
@@ -17,8 +17,7 @@ export declare type OnDemandPageScanRunState =
     | 'completed'
     | 'failed'
     | 'unscannable';
-export declare type ScanState = 'pending' | 'pass' | 'fail';
-export declare type ScanStateExt = ScanState | 'error' | 'completed';
+export declare type ScanState = 'pending' | 'pass' | 'fail' | 'error';
 export declare type NotificationState = 'pending' | 'queued' | 'queueFailed' | 'sending' | 'sent' | 'sendFailed';
 export declare type NotificationErrorTypes = 'InternalError' | 'HttpErrorCode';
 export declare type AuthenticationState = 'succeeded' | 'failed' | 'unauthenticated';
@@ -86,7 +85,7 @@ export interface OnDemandPageScanResult extends StorageDocument {
 }
 
 export interface BrowserValidationResult {
-    highContrastProperties?: ScanStateExt;
+    highContrastProperties?: ScanState;
 }
 
 export interface AuthenticationResult {
@@ -131,7 +130,7 @@ export interface OnDemandPageScanRunResult {
 
 export interface ScanRunDetail {
     name: ScanDefinitionType;
-    state: ScanStateExt;
+    state: OnDemandPageScanRunState;
     timestamp?: string;
     error?: string | null;
     details?: unknown;

--- a/packages/web-api-scan-runner/docker-image-config/Dockerfile
+++ b/packages/web-api-scan-runner/docker-image-config/Dockerfile
@@ -24,18 +24,4 @@ RUN npm install
 RUN npx patch-package
 RUN npx playwright install msedge
 
-# TODO: Remove the following workaround once the Playwright CLI supports installing specific versions of Playwright.
-#
-# Temporary workaround for installing Playwright versions that are not yet available in the Playwright CLI.
-# This workaround will be removed once the Playwright CLI supports installing specific versions of Playwright.
-# To install a specific version of Playwright, set the PLAYWRIGHT_VERSION environment variable to the desired version
-# and rebuild the Docker image.
-ENV PLAYWRIGHT_VERSION 1155
-RUN powershell -Command \
-    Invoke-WebRequest $('https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/{0}/chromium-win64.zip' -f $env:PLAYWRIGHT_VERSION) -OutFile 'chromium-win64.zip' -UseBasicParsing ; \
-    Expand-Archive 'chromium-win64.zip' -DestinationPath $('C:\Users\ContainerAdministrator\AppData\Local\ms-playwright\chromium-{0}' -f $env:PLAYWRIGHT_VERSION) -Force
-RUN powershell -Command \
-    Invoke-WebRequest $('https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/{0}/chromium-headless-shell-win64.zip' -f $env:PLAYWRIGHT_VERSION) -OutFile 'chromium-headless-shell-win64.zip' -UseBasicParsing ; \
-    Expand-Archive 'chromium-headless-shell-win64.zip' -DestinationPath $('C:\Users\ContainerAdministrator\AppData\Local\ms-playwright\chromium_headless_shell-{0}' -f $env:PLAYWRIGHT_VERSION) -Force
-
 CMD ["powershell", "./web-api-scan-runner.ps1"]

--- a/packages/web-api-scan-runner/run-in-docker-container.cmd
+++ b/packages/web-api-scan-runner/run-in-docker-container.cmd
@@ -9,7 +9,7 @@ SET DOCKER_CLI_HINTS=false
 
 copy ..\resource-deployment\runtime-config\runtime-config.dev.json .\dist\runtime-config.json &&^
 copy /y .\docker-image-config\Dockerfile.debug .\dist\Dockerfile.debug &&^
-xcopy ..\a11y_agent .\dist\a11y_agent\ /s /e &&^
+xcopy ..\a11y_agent .\dist\a11y_agent\ /s /e /y &&^
 cd ..\scanner-global-library &&^
 yarn build &&^
 cd ..\web-api-scan-runner &&^

--- a/packages/web-api-scan-runner/src/agent/agent-report-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/agent/agent-report-generator.spec.ts
@@ -17,7 +17,7 @@ describe(AgentReportGenerator, () => {
     let agentReportGenerator: AgentReportGenerator;
 
     const agentResultsStub: AgentResults = {
-        result: 'pass',
+        result: 'completed',
         scannedUrl: 'https://example.com',
     } as AgentResults;
 

--- a/packages/web-api-scan-runner/src/agent/axe-result-converter.spec.ts
+++ b/packages/web-api-scan-runner/src/agent/axe-result-converter.spec.ts
@@ -20,7 +20,7 @@ describe(AxeResultConverter, () => {
     } as AxeResults;
 
     const agentResultsStub: AgentResults = {
-        result: 'pass',
+        result: 'completed',
         scannedUrl: 'https://example.com',
         axeResults: axeResultsStub,
     };

--- a/packages/web-api-scan-runner/src/agent/html-result-converter.spec.ts
+++ b/packages/web-api-scan-runner/src/agent/html-result-converter.spec.ts
@@ -24,7 +24,7 @@ describe(HtmlResultConverter, () => {
     } as AxeResults;
 
     const agentResultsStub: AgentResults = {
-        result: 'pass',
+        result: 'completed',
         scannedUrl: 'https://example.com',
         axeResults: axeResultsStub,
     };

--- a/packages/web-api-scan-runner/src/agent/sarif-result-converter.spec.ts
+++ b/packages/web-api-scan-runner/src/agent/sarif-result-converter.spec.ts
@@ -38,7 +38,7 @@ describe(SarifResultConverter, () => {
     };
 
     const agentResultsStub: AgentResults = {
-        result: 'pass',
+        result: 'completed',
         scannedUrl: 'https://example.com',
         axeResults: axeResultsStub,
     };

--- a/packages/web-api-scan-runner/src/report-generator/report-generator.spec.ts
+++ b/packages/web-api-scan-runner/src/report-generator/report-generator.spec.ts
@@ -15,6 +15,7 @@ describe(ReportGenerator, () => {
     let axeResultConverterMock1: IMock<AxeResultConverter>;
     let axeResultConverterMock2: IMock<AxeResultConverter>;
     let reportGenerator: ReportGenerator;
+    let guidId: number;
 
     const axeScanResults1: AxeScanResults = {
         pageTitle: 'test page 1',
@@ -46,8 +47,7 @@ describe(ReportGenerator, () => {
         },
     } as AxeScanResults;
 
-    const generatedGuid1 = 'guid-1';
-    const generatedGuid2 = 'guid-2';
+    const generatedGuids: string[] = ['guid-1', 'guid-2', 'guid-3', 'guid-4'];
 
     beforeEach(() => {
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
@@ -60,14 +60,8 @@ describe(ReportGenerator, () => {
         axeResultConverterMock2.setup((converter) => converter.convert(It.isAny())).returns(() => 'converted-content-2');
         axeResultConverterMock2.setup((converter) => converter.targetReportFormat).returns(() => 'html');
 
-        guidGeneratorMock
-            .setup((g) => g.createGuid())
-            .returns(() => generatedGuid1)
-            .verifiable(Times.once());
-        guidGeneratorMock
-            .setup((g) => g.createGuid())
-            .returns(() => generatedGuid2)
-            .verifiable(Times.once());
+        guidId = 0;
+        guidGeneratorMock.setup((g) => g.createGuid()).returns(() => generatedGuids[guidId++]);
 
         reportGenerator = new ReportGenerator(guidGeneratorMock.object, [axeResultConverterMock1.object, axeResultConverterMock2.object]);
     });
@@ -78,13 +72,13 @@ describe(ReportGenerator, () => {
         const expectedReports: GeneratedReport[] = [
             {
                 content: 'converted-content-1',
-                id: generatedGuid1,
+                id: generatedGuids[0],
                 format: 'axe',
                 source: 'accessibility-scan',
             },
             {
                 content: 'converted-content-2',
-                id: generatedGuid2,
+                id: generatedGuids[1],
                 format: 'html',
                 source: 'accessibility-scan',
             },
@@ -103,15 +97,27 @@ describe(ReportGenerator, () => {
         const expectedReports: GeneratedReport[] = [
             {
                 content: 'converted-content-1',
-                id: generatedGuid1,
+                id: generatedGuids[0],
                 format: 'axe',
                 source: 'accessibility-scan',
             },
             {
                 content: 'converted-content-2',
-                id: generatedGuid2,
+                id: generatedGuids[1],
                 format: 'html',
                 source: 'accessibility-scan',
+            },
+            {
+                content: 'converted-content-1',
+                id: generatedGuids[2],
+                format: 'axe',
+                source: 'accessibility-combined',
+            },
+            {
+                content: 'converted-content-2',
+                id: generatedGuids[3],
+                format: 'html',
+                source: 'accessibility-combined',
             },
         ];
 
@@ -119,22 +125,22 @@ describe(ReportGenerator, () => {
 
         axeResultConverterMock1.verify((converter) => converter.convert(mergedAxeScanResults), Times.once());
         axeResultConverterMock2.verify((converter) => converter.convert(mergedAxeScanResults), Times.once());
-        guidGeneratorMock.verify((g) => g.createGuid(), Times.exactly(2));
+        guidGeneratorMock.verify((g) => g.createGuid(), Times.exactly(4));
     });
 
     it('should handle empty AxeScanResults objects gracefully', () => {
-        const reports = reportGenerator.generateReports(axeScanResults1, {} as AxeScanResults);
+        const reports = reportGenerator.generateReports(axeScanResults1);
 
         const expectedReports: GeneratedReport[] = [
             {
                 content: 'converted-content-1',
-                id: generatedGuid1,
+                id: generatedGuids[0],
                 format: 'axe',
                 source: 'accessibility-scan',
             },
             {
                 content: 'converted-content-2',
-                id: generatedGuid2,
+                id: generatedGuids[1],
                 format: 'html',
                 source: 'accessibility-scan',
             },

--- a/packages/web-api-scan-runner/src/report-generator/report-generator.ts
+++ b/packages/web-api-scan-runner/src/report-generator/report-generator.ts
@@ -21,17 +21,17 @@ export class ReportGenerator {
      * The first parameter is used as the base to merge the results of the other parameters.
      */
     public generateReports(...axeScanResults: AxeScanResults[]): GeneratedReport[] {
-        const accessibilityReport = this.generateAccessibilityReport(axeScanResults[0]);
+        const accessibilityReports = this.generateAccessibilityReports(axeScanResults[0]);
 
         if (axeScanResults.length > 1) {
-            const accessibilityCombinedReport = this.generateAccessibilityCombinedReport(axeScanResults);
-            accessibilityReport.push(...accessibilityCombinedReport);
+            const accessibilityCombinedReport = this.generateAccessibilityCombinedReports(axeScanResults);
+            accessibilityReports.push(...accessibilityCombinedReport);
         }
 
-        return accessibilityReport;
+        return accessibilityReports;
     }
 
-    private generateAccessibilityReport(axeScanResults: AxeScanResults): GeneratedReport[] {
+    private generateAccessibilityReports(axeScanResults: AxeScanResults): GeneratedReport[] {
         return this.axeResultConverters.map<GeneratedReport>((axeResultConverter) => {
             return {
                 content: axeResultConverter.convert(axeScanResults),
@@ -42,7 +42,7 @@ export class ReportGenerator {
         });
     }
 
-    private generateAccessibilityCombinedReport(axeScanResults: AxeScanResults[]): GeneratedReport[] {
+    private generateAccessibilityCombinedReports(axeScanResults: AxeScanResults[]): GeneratedReport[] {
         const baseAxeScanResult = axeScanResults[0];
         const mergedAxeResults = this.mergeAxeScanResults(axeScanResults.filter((r) => isEmpty(r) === false).map((r) => r.results));
         baseAxeScanResult.results.violations = mergedAxeResults.violations;

--- a/packages/web-api-scan-runner/src/report-generator/report-generator.ts
+++ b/packages/web-api-scan-runner/src/report-generator/report-generator.ts
@@ -21,21 +21,41 @@ export class ReportGenerator {
      * The first parameter is used as the base to merge the results of the other parameters.
      */
     public generateReports(...axeScanResults: AxeScanResults[]): GeneratedReport[] {
-        const baseAxeScanResult = axeScanResults[0];
+        const accessibilityReport = this.generateAccessibilityReport(axeScanResults[0]);
+
         if (axeScanResults.length > 1) {
-            const mergedAxeResults = this.mergeAxeScanResults(axeScanResults.filter((r) => isEmpty(r) === false).map((r) => r.results));
-            baseAxeScanResult.results.violations = mergedAxeResults.violations;
-            baseAxeScanResult.results.passes = mergedAxeResults.passes;
-            baseAxeScanResult.results.inapplicable = mergedAxeResults.inapplicable;
-            baseAxeScanResult.results.incomplete = mergedAxeResults.incomplete;
+            const accessibilityCombinedReport = this.generateAccessibilityCombinedReport(axeScanResults);
+            accessibilityReport.push(...accessibilityCombinedReport);
         }
+
+        return accessibilityReport;
+    }
+
+    private generateAccessibilityReport(axeScanResults: AxeScanResults): GeneratedReport[] {
+        return this.axeResultConverters.map<GeneratedReport>((axeResultConverter) => {
+            return {
+                content: axeResultConverter.convert(axeScanResults),
+                id: this.guidGenerator.createGuid(),
+                format: axeResultConverter.targetReportFormat,
+                source: 'accessibility-scan',
+            };
+        });
+    }
+
+    private generateAccessibilityCombinedReport(axeScanResults: AxeScanResults[]): GeneratedReport[] {
+        const baseAxeScanResult = axeScanResults[0];
+        const mergedAxeResults = this.mergeAxeScanResults(axeScanResults.filter((r) => isEmpty(r) === false).map((r) => r.results));
+        baseAxeScanResult.results.violations = mergedAxeResults.violations;
+        baseAxeScanResult.results.passes = mergedAxeResults.passes;
+        baseAxeScanResult.results.inapplicable = mergedAxeResults.inapplicable;
+        baseAxeScanResult.results.incomplete = mergedAxeResults.incomplete;
 
         return this.axeResultConverters.map<GeneratedReport>((axeResultConverter) => {
             return {
                 content: axeResultConverter.convert(baseAxeScanResult),
                 id: this.guidGenerator.createGuid(),
                 format: axeResultConverter.targetReportFormat,
-                source: 'accessibility-scan',
+                source: 'accessibility-combined',
             };
         });
     }

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -238,7 +238,7 @@ export class Runner {
             results: scanProcessorResult.agentResults?.axeResults,
         });
 
-        // Generate and save reports for accessibility scan results
+        // Save reports for accessibility scan results
         const availableReports = reports.filter((r) => !isEmpty(r.content));
         const accessibilityReportRefs = await this.reportWriter.writeBatch(availableReports);
 

--- a/packages/web-api-scan-runner/src/runner/runner.ts
+++ b/packages/web-api-scan-runner/src/runner/runner.ts
@@ -73,7 +73,7 @@ export class Runner {
             if (axeScanResults?.unscannable === true) {
                 // unscannable URL
                 this.setRunResult(pageScanResult, 'unscannable', axeScanResults.scannedUrl, axeScanResults.error);
-            } else if (axeScanResults.error === undefined && scanProcessorResult.agentResults?.result !== 'error') {
+            } else if (axeScanResults.error === undefined && scanProcessorResult.agentResults?.result !== 'failed') {
                 // scan completed successfully
                 await this.onCompletedScan(scanProcessorResult, pageScanResult);
             } else {

--- a/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
@@ -143,15 +143,18 @@ export class AgentScanner {
                 result: 'completed',
             };
         } catch (error) {
+            let message;
             if (error.killed) {
-                this.logger.logError('Agent process was terminated due to timeout.', { timeout: timeoutMsec.toString() });
+                message = 'Agent process was terminated due to timeout.';
+                this.logger.logError(message, { timeout: timeoutMsec.toString() });
             } else {
+                message = `Error while executing agent. ${System.serializeError(error)}`;
                 this.logger.logError('Error while executing agent.', { error: System.serializeError(error) });
             }
 
             return {
                 result: 'failed',
-                error: System.serializeError(error),
+                error: message,
             };
         }
     }

--- a/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
@@ -125,15 +125,16 @@ export class AgentScanner {
             const { stdout, stderr } = await execAsync(`${this.agentExeCommand} ${encodeURI(url)}`, {
                 timeout: timeoutMsec,
                 cwd: this.agentFolder,
+                env: { ...process.env, VSCODE_INSPECTOR_OPTIONS: '' }, // Disable VSCode inspector to prevent dotnet debugger attachment
             });
 
             if (stderr) {
                 this.logger.logError('Agent exited with error code.', { error: stderr });
 
-                // return {
-                //     result: 'error',
-                //     error: stderr,
-                // };
+                return {
+                    result: 'error',
+                    error: stderr,
+                };
             }
 
             this.logger.logInfo('Agent console output.', { stdout });

--- a/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import fs from 'fs';
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
-import { OnDemandPageScanReport, ScanStateExt } from 'storage-documents';
+import { OnDemandPageScanReport, OnDemandPageScanRunState } from 'storage-documents';
 import { System } from 'common';
 import { AxeResults } from 'axe-core';
 import { isEmpty } from 'lodash';
@@ -17,7 +17,7 @@ import { AgentReportGenerator } from '../agent/agent-report-generator';
 /* eslint-disable security/detect-non-literal-fs-filename */
 
 export interface AgentResults {
-    result?: ScanStateExt;
+    result?: OnDemandPageScanRunState;
     scannedUrl?: string;
     error?: string;
     axeResults?: AxeResults;
@@ -57,12 +57,12 @@ export class AgentScanner {
         this.logger.logInfo('Starting accessibility agent scan.');
         try {
             response = await this.executeAgent(url);
-            if (response.result === 'error') {
+            if (response.result === 'failed') {
                 return { ...response, scannedUrl: url };
             }
 
             response = await this.processAxeResults();
-            if (response.result === 'error') {
+            if (response.result === 'failed') {
                 return { ...response, scannedUrl: url };
             }
 
@@ -71,7 +71,7 @@ export class AgentScanner {
                 this.logger.logError('No reports were generated from accessibility agent scan.', { scannedUrl: url });
 
                 return {
-                    result: 'error',
+                    result: 'failed',
                     scannedUrl: url,
                     error: 'No reports were generated from accessibility agent scan.',
                 };
@@ -82,7 +82,7 @@ export class AgentScanner {
             this.logger.logError('Error while running accessibility agent scan.', { error: System.serializeError(error) });
 
             return {
-                result: 'error',
+                result: 'failed',
                 scannedUrl: url,
                 error: System.serializeError(error),
             };
@@ -104,7 +104,7 @@ export class AgentScanner {
             this.logger.logError('Agent did not produce axe results file.', { path: this.agentAxeResultPath });
 
             return {
-                result: 'error',
+                result: 'failed',
                 error: 'Agent did not produce axe results file.',
             };
         }
@@ -133,7 +133,7 @@ export class AgentScanner {
                 this.logger.logError('Agent exited with error code.', { error: stderr });
 
                 return {
-                    result: 'error',
+                    result: 'failed',
                     error: stderr,
                 };
             }
@@ -151,7 +151,7 @@ export class AgentScanner {
             }
 
             return {
-                result: 'error',
+                result: 'failed',
                 error: System.serializeError(error),
             };
         }

--- a/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
@@ -122,11 +122,10 @@ export class AgentScanner {
         const timeoutMsec: number = 120000;
 
         try {
-            const { stdout, stderr } = await execAsync(`start cmd /C "${this.agentExeCommand} ${encodeURI(url)}"`, {
+            const { stdout, stderr } = await execAsync(`${this.agentExeCommand} ${encodeURI(url)}`, {
                 timeout: timeoutMsec,
                 cwd: this.agentFolder,
                 env: { ...process.env, VSCODE_INSPECTOR_OPTIONS: '' }, // Disable VSCode inspector to prevent dotnet debugger attachment
-                windowsHide: false,
             });
 
             if (stderr) {

--- a/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
@@ -122,10 +122,11 @@ export class AgentScanner {
         const timeoutMsec: number = 120000;
 
         try {
-            const { stdout, stderr } = await execAsync(`${this.agentExeCommand} ${encodeURI(url)}`, {
+            const { stdout, stderr } = await execAsync(`start cmd /C "${this.agentExeCommand} ${encodeURI(url)}"`, {
                 timeout: timeoutMsec,
                 cwd: this.agentFolder,
                 env: { ...process.env, VSCODE_INSPECTOR_OPTIONS: '' }, // Disable VSCode inspector to prevent dotnet debugger attachment
+                windowsHide: false,
             });
 
             if (stderr) {

--- a/packages/web-api-scan-runner/src/scanner/high-contrast-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/high-contrast-scanner.ts
@@ -4,13 +4,13 @@
 import { inject, injectable } from 'inversify';
 import { GlobalLogger } from 'logger';
 import { BrowserError, PageResponseProcessor, SecretVault } from 'scanner-global-library';
-import { ScanStateExt } from 'storage-documents';
+import { ScanState } from 'storage-documents';
 import { chromium, Browser, BrowserContext } from '@playwright/test';
 import { System } from 'common';
 import { iocTypeNames } from '../ioc-types';
 
 export interface HighContrastResults {
-    result?: ScanStateExt;
+    result?: ScanState;
     error?: string | BrowserError;
     scannedUrl?: string;
 }
@@ -28,7 +28,7 @@ export class HighContrastScanner {
 
     public async scan(url: string): Promise<HighContrastResults> {
         const warnings = new Set<string>();
-        let result: ScanStateExt = 'pass';
+        let result: ScanState = 'pass';
         let browser;
         let response;
 

--- a/packages/web-api-scan-runner/src/scanner/scanner-dispatcher.spec.ts
+++ b/packages/web-api-scan-runner/src/scanner/scanner-dispatcher.spec.ts
@@ -75,7 +75,7 @@ describe(ScannerDispatcher, () => {
     it('should dispatch all scanners and return results', async () => {
         const axeScanResultsStub = { violations: [] } as AxeScanResults;
         const highContrastResultsStub: HighContrastResults = { result: 'pass' };
-        const agentResultsStub: AgentResults = { result: 'pass' };
+        const agentResultsStub: AgentResults = { result: 'completed' };
 
         axeScannerMock
             .setup((a) => a.scan(pageMock.object))


### PR DESCRIPTION
#### Details

This pull request includes several changes to the codebase, focusing on updating enums, modifying scripts for Docker image building, and enhancing test cases. The most important changes are summarized below:

### Enum Updates:
* Updated the `state` property in `openapi.json` to reference `RunState` instead of a string enum.
* Added `error` to the `ScanState` enum in `openapi.json`.
* Updated `ScanState` and `RunState` enums in `scan-result-response.ts` and `on-demand-page-scan-result.ts` to include `error` and `completed` states. [[1]](diffhunk://#diff-b98d83874f9b69c1e3a373bf295d7aeac697c7e43f365180c2de478fac031a3fL4-R10) [[2]](diffhunk://#diff-5955e953841a00eb4c2746a3cc280db3d05a3b0e2ebd6bfc4d695d71bc351515L20-R28)

### Script Modifications:
* Refactored `build-scanner-image.ps1` to handle separate shares for `WinSxS` and `Fonts`. [[1]](diffhunk://#diff-252b3fea7772ab3f7154a506098f23bc011765a4d85b2b356179adc7b45da4e7L6-R9) [[2]](diffhunk://#diff-252b3fea7772ab3f7154a506098f23bc011765a4d85b2b356179adc7b45da4e7L18-R25) [[3]](diffhunk://#diff-252b3fea7772ab3f7154a506098f23bc011765a4d85b2b356179adc7b45da4e7L37-R44)
* Updated `install-font-packages.ps1` to use separate drive mappings for `WinSxS` and `Fonts` and enabled the `ServerMediaFoundation` feature.

### Test Enhancements:
* Modified test cases in `agent-report-generator.spec.ts`, `axe-result-converter.spec.ts`, `html-result-converter.spec.ts`, and `sarif-result-converter.spec.ts` to use `completed` instead of `pass` for the `result` field. [[1]](diffhunk://#diff-9efc6a59114e3498a49d601e9ed15e76ce2c180efbf50133538b4f7c47837b37L20-R20) [[2]](diffhunk://#diff-f5c6667d1effe6a94a52a5d09a38733a457d20f5ce225d4135344da536727d1cL23-R23) [[3]](diffhunk://#diff-a6d927f3a369adf8bf4e56932fe23c3092f6cb266ca726cec5c885262b3e1059L27-R27) [[4]](diffhunk://#diff-5542fb72930391100e9032e9b562774ec9325742df0dbe9f617debb4e39a86efL41-R41)
* Enhanced `report-generator.spec.ts` to generate multiple GUIDs and verify the correct number of GUIDs created. [[1]](diffhunk://#diff-257cb8a97050128951bf2d31ecbeb75389533d29c4629070770c9234f148026aR18) [[2]](diffhunk://#diff-257cb8a97050128951bf2d31ecbeb75389533d29c4629070770c9234f148026aL49-R50) [[3]](diffhunk://#diff-257cb8a97050128951bf2d31ecbeb75389533d29c4629070770c9234f148026aL63-R64) [[4]](diffhunk://#diff-257cb8a97050128951bf2d31ecbeb75389533d29c4629070770c9234f148026aL81-R81) [[5]](diffhunk://#diff-257cb8a97050128951bf2d31ecbeb75389533d29c4629070770c9234f148026aL106-R143)

### Docker and Build Configuration:
* Removed the workaround for installing specific Playwright versions from the Dockerfile.
* Added the `/y` flag to the `xcopy` command in `run-in-docker-container.cmd` to suppress prompts.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
