### PR TITLE
fix: update job manager and task timeouts

### DIFF
--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -90,7 +90,7 @@ exports[`ServiceConfiguration verifies custom config 1`] = `
       "format": "int",
     },
     "maxWallClockTimeInMinutes": {
-      "default": 30,
+      "default": 40,
       "doc": "The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
@@ -175,7 +175,7 @@ exports[`ServiceConfiguration verifies custom config 1`] = `
       "format": "int",
     },
     "messageVisibilityTimeoutInSeconds": {
-      "default": 2700,
+      "default": 3600,
       "doc": "Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes config value.",
       "format": "int",
     },
@@ -236,7 +236,7 @@ exports[`ServiceConfiguration verifies custom config 1`] = `
       "format": "int",
     },
     "taskTimeoutInMinutes": {
-      "default": 20,
+      "default": 30,
       "doc": "Timeout value after which the task has to be terminated. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
@@ -334,7 +334,7 @@ exports[`ServiceConfiguration verifies dev config 1`] = `
       "format": "int",
     },
     "maxWallClockTimeInMinutes": {
-      "default": 30,
+      "default": 40,
       "doc": "The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },
@@ -419,7 +419,7 @@ exports[`ServiceConfiguration verifies dev config 1`] = `
       "format": "int",
     },
     "messageVisibilityTimeoutInSeconds": {
-      "default": 2700,
+      "default": 3600,
       "doc": "Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes config value.",
       "format": "int",
     },
@@ -480,7 +480,7 @@ exports[`ServiceConfiguration verifies dev config 1`] = `
       "format": "int",
     },
     "taskTimeoutInMinutes": {
-      "default": 20,
+      "default": 30,
       "doc": "Timeout value after which the task has to be terminated. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.",
       "format": "int",
     },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -173,14 +173,14 @@ export class ServiceConfiguration {
                 },
                 messageVisibilityTimeoutInSeconds: {
                     format: 'int',
-                    default: 30 * 1.5 * 60, // maxWallClockTimeInMinutes * delta termination wait time
+                    default: 40 * 1.5 * 60, // maxWallClockTimeInMinutes * delta termination wait time
                     doc: 'Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes config value.',
                 },
             },
             taskConfig: {
                 taskTimeoutInMinutes: {
                     format: 'int',
-                    default: 20,
+                    default: 30,
                     doc: 'Timeout value after which the task has to be terminated. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.',
                 },
                 retentionTimeInDays: {
@@ -202,7 +202,7 @@ export class ServiceConfiguration {
                 },
                 maxWallClockTimeInMinutes: {
                     format: 'int',
-                    default: 30,
+                    default: 40,
                     doc: 'The amount of time the job manager instance will run continuously. Must correlate with queueConfig.messageVisibilityTimeoutInSeconds config value.',
                 },
                 sendNotificationTasksCount: {
@@ -269,7 +269,7 @@ export class ServiceConfiguration {
                 },
                 maxScanStaleTimeoutInMinutes: {
                     format: 'int',
-                    default: 4320,
+                    default: 4320, // 3 days
                     doc: 'Maximum sliding window for a scan to complete.',
                 },
                 scanTimeoutInMin: {

--- a/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
+++ b/packages/web-api-scan-runner/src/scanner/agent-scanner.ts
@@ -92,7 +92,7 @@ export class AgentScanner {
 
     private async executeAgent(url: string): Promise<AgentResults> {
         const execAsync = promisify(exec);
-        const timeoutMsec: number = 120000;
+        const timeoutMsec: number = 1200000; // 20 minutes
 
         try {
             const { stdout, stderr } = await execAsync(`${this.agentExeCommand} ${encodeURI(url)}`, {


### PR DESCRIPTION
This pull request updates several default configuration values to align with updated system requirements and increases the timeout for the agent scanner execution. Below is a breakdown of the most important changes:

### Configuration Updates

* Increased `maxWallClockTimeInMinutes` default value from 30 to 40, affecting both custom and dev configurations, as well as the main `ServiceConfiguration` class. This change ensures longer job manager runtime. [[1]](diffhunk://#diff-58a67e3e14fd8c5f493d38665e28c714ecf0924e537f323c2ef28d9b6f4b5de6L93-R93) [[2]](diffhunk://#diff-58a67e3e14fd8c5f493d38665e28c714ecf0924e537f323c2ef28d9b6f4b5de6L337-R337) [[3]](diffhunk://#diff-3a867985537464e1b21cbbcb23906735642ee64a2e8db8242c9b8252a3835644L205-R205)
* Updated `messageVisibilityTimeoutInSeconds` default value from 2700 to 3600 across custom and dev configurations, as well as in the main `ServiceConfiguration` class, to align with the new `maxWallClockTimeInMinutes`. [[1]](diffhunk://#diff-58a67e3e14fd8c5f493d38665e28c714ecf0924e537f323c2ef28d9b6f4b5de6L178-R178) [[2]](diffhunk://#diff-58a67e3e14fd8c5f493d38665e28c714ecf0924e537f323c2ef28d9b6f4b5de6L422-R422) [[3]](diffhunk://#diff-3a867985537464e1b21cbbcb23906735642ee64a2e8db8242c9b8252a3835644L176-R183)
* Increased `taskTimeoutInMinutes` default value from 20 to 30 in custom and dev configurations, and in the main `ServiceConfiguration` class, to provide more time for task completion. [[1]](diffhunk://#diff-58a67e3e14fd8c5f493d38665e28c714ecf0924e537f323c2ef28d9b6f4b5de6L239-R239) [[2]](diffhunk://#diff-58a67e3e14fd8c5f493d38665e28c714ecf0924e537f323c2ef28d9b6f4b5de6L483-R483) [[3]](diffhunk://#diff-3a867985537464e1b21cbbcb23906735642ee64a2e8db8242c9b8252a3835644L176-R183)

### Code Comment Improvements

* Added a clarifying comment for `maxScanStaleTimeoutInMinutes` in `ServiceConfiguration` to indicate it represents 3 days.

### Agent Scanner Timeout Update

* Increased the `timeoutMsec` value for the `AgentScanner` execution from 120,000 milliseconds (2 minutes) to 1,200,000 milliseconds (20 minutes) to accommodate longer-running tasks.