### PR TITLE
chore: update accessibility-insights-report dependency to version 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "socks": ">=2.7.4"
     },
     "dependencies": {
-        "accessibility-insights-report": "5.2.0"
+        "accessibility-insights-report": "7.0.0"
     },
     "packageManager": "yarn@3.2.2"
 }

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -35,7 +35,7 @@
         "typescript": "^5.5.3"
     },
     "dependencies": {
-        "accessibility-insights-report": "5.2.0",
+        "accessibility-insights-report": "7.0.0",
         "axe-core": "4.10.2",
         "common": "workspace:*",
         "inversify": "^6.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
         "@opentelemetry/sdk-metrics": "^1.28.0",
         "@opentelemetry/semantic-conventions": "^1.15.0",
         "@sindresorhus/fnv1a": "^2.0.1",
-        "accessibility-insights-report": "5.2.0",
+        "accessibility-insights-report": "7.0.0",
         "ajv": "^8.17.1",
         "applicationinsights": "^3.6.0",
         "axe-core": "4.10.2",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -49,7 +49,7 @@
         "@crawlee/puppeteer": "^3.12.2",
         "@medv/finder": "^2.1.0",
         "@sindresorhus/fnv1a": "^2.0.1",
-        "accessibility-insights-report": "5.2.0",
+        "accessibility-insights-report": "7.0.0",
         "axe-core": "4.10.2",
         "axe-core-scanner": "workspace:*",
         "dotenv": "^16.4.7",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -46,7 +46,7 @@
         "@azure/identity": "^4.5.0",
         "@azure/storage-blob": "^12.12.0",
         "@crawlee/puppeteer": "^3.12.2",
-        "accessibility-insights-report": "5.2.0",
+        "accessibility-insights-report": "7.0.0",
         "async-mutex": "^0.5.0",
         "axe-core": "4.10.2",
         "axe-result-converter": "workspace:*",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -51,7 +51,7 @@
         "@axe-core/puppeteer": "4.10.1",
         "@azure/cosmos": "^4.0.0",
         "@playwright/test": "^1.51.1",
-        "accessibility-insights-report": "5.2.0",
+        "accessibility-insights-report": "7.0.0",
         "applicationinsights": "^3.6.0",
         "axe-core": "4.10.2",
         "axe-result-converter": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,7 +5301,7 @@ __metadata:
     "@types/node": ^20.14.9
     "@types/normalize-path": ^3.0.2
     "@types/puppeteer": ^7.0.4
-    accessibility-insights-report: 5.2.0
+    accessibility-insights-report: 7.0.0
     axe-core: 4.10.2
     axe-core-scanner: "workspace:*"
     dotenv: ^16.4.7
@@ -5329,9 +5329,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"accessibility-insights-report@npm:5.2.0":
-  version: 5.2.0
-  resolution: "accessibility-insights-report@npm:5.2.0"
+"accessibility-insights-report@npm:7.0.0":
+  version: 7.0.0
+  resolution: "accessibility-insights-report@npm:7.0.0"
   dependencies:
     "@fluentui/react": ^8.118.1
     axe-core: 4.10.2
@@ -5342,7 +5342,7 @@ __metadata:
     react-dom: ^18.3.1
     react-helmet-async: ^2.0.5
     uuid: ^9.0.1
-  checksum: 94d1892e9b1941480775588e6555076e8c50d8589bfa23662e50fdf06a0d94d07abd3aa529ac4b6bfcb15cb3aeccd0dacd4fb5459611f3cb11e4f3bc0cb7de80
+  checksum: f9f056fae2588287ba520e4ba359927352405013348c454936f449b551712fb448e28087e4a59aea26450630fc57b41f72ad57f5fbbd5215ffed8a7ba7195a8a
   languageName: node
   linkType: hard
 
@@ -5369,7 +5369,7 @@ __metadata:
     "@types/puppeteer": ^7.0.4
     "@types/table": ^6.3.2
     accessibility-insights-crawler: "workspace:*"
-    accessibility-insights-report: 5.2.0
+    accessibility-insights-report: 7.0.0
     ajv: ^8.17.1
     applicationinsights: ^3.6.0
     axe-core: 4.10.2
@@ -5423,7 +5423,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^7.15.0
     "@typescript-eslint/eslint-plugin-tslint": ^7.0.2
     "@typescript-eslint/parser": ^8.16.0
-    accessibility-insights-report: 5.2.0
+    accessibility-insights-report: 7.0.0
     combine-dependabot-prs: ^1.0.5
     commander: ^13.1.0
     eslint: ^8.57.0
@@ -6033,7 +6033,7 @@ __metadata:
     "@types/jest": ^29.5.12
     "@types/lodash": ^4.17.6
     "@types/node": ^20.14.9
-    accessibility-insights-report: 5.2.0
+    accessibility-insights-report: 7.0.0
     axe-core: 4.10.2
     common: "workspace:*"
     inversify: ^6.0.1
@@ -15757,7 +15757,7 @@ __metadata:
     "@types/puppeteer": ^7.0.4
     "@types/sha.js": ^2.4.4
     "@types/yargs": ^17.0.22
-    accessibility-insights-report: 5.2.0
+    accessibility-insights-report: 7.0.0
     async-mutex: ^0.5.0
     axe-core: 4.10.2
     axe-result-converter: "workspace:*"
@@ -17656,7 +17656,7 @@ __metadata:
     "@types/puppeteer": ^7.0.4
     "@types/sha.js": ^2.4.4
     "@types/yargs": ^17.0.22
-    accessibility-insights-report: 5.2.0
+    accessibility-insights-report: 7.0.0
     applicationinsights: ^3.6.0
     axe-core: 4.10.2
     axe-result-converter: "workspace:*"


### PR DESCRIPTION
This pull request updates the `accessibility-insights-report` dependency across multiple packages in the repository from version `5.2.0` to `7.0.0`. This ensures all packages use the latest version of the library, likely to incorporate new features, bug fixes, or performance improvements.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L95-R95): Updated `accessibility-insights-report` dependency to version `7.0.0` in the root package file.
* [`packages/axe-result-converter/package.json`](diffhunk://#diff-5d02697f92ec66562e8de45c75ab37913364f2f0eab90e9129861e8411d20d79L38-R38): Updated `accessibility-insights-report` dependency to version `7.0.0`.
* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L67-R67): Updated `accessibility-insights-report` dependency to version `7.0.0`.
* [`packages/crawler/package.json`](diffhunk://#diff-7b1fe15227f7a23db2c9debdc2b6160e9dec7dcdfe591b9271f92dc28a21daa5L52-R52): Updated `accessibility-insights-report` dependency to version `7.0.0`.
* [`packages/service-library/package.json`](diffhunk://#diff-aafa950f00fa95cf7664306d04050a3d8b13f887e8cabbad7ae6fc109bc6b318L49-R49): Updated `accessibility-insights-report` dependency to version `7.0.0`.
* [`packages/web-api-scan-runner/package.json`](diffhunk://#diff-ae195a3b3fd77f7b897ef6d679b6abfe946b2b2eba5778980f9c9c6fee2451b3L54-R54): Updated `accessibility-insights-report` dependency to version `7.0.0`.