### PR TITLE
feat: add CodeQL configuration

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 path_classifiers:
     tests:
         - '.yarn/releases/*.cjs'


### PR DESCRIPTION
This pull request adds a new path classifier to the `CodeQL.yml` configuration file to improve the categorization of test files.

* [`CodeQL.yml`](diffhunk://#diff-11f91616bc3eaa1f32316ccc77220574192619700debb1f9500e9cd208f6366cR1-R3): Added a `path_classifiers` section to classify files under `.yarn/releases/*.cjs` as tests.