### PR TITLE
CG Issue fix: Bump convict from 6.2.4 to 6.2.5 

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
         "ajv": "^8.18.0",
         "applicationinsights": "^3.12.1",
         "axe-core": "4.10.2",
-        "convict": "^6.2.4",
+        "convict": "^6.2.5",
         "dotenv": "^17.2.1",
         "encoding-down": "^7.1.0",
         "exponential-backoff": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6221,7 +6221,7 @@ __metadata:
     ajv: "npm:^8.18.0"
     applicationinsights: "npm:^3.12.1"
     axe-core: "npm:4.10.2"
-    convict: "npm:^6.2.4"
+    convict: "npm:^6.2.5"
     copy-webpack-plugin: "npm:^13.0.1"
     dotenv: "npm:^17.2.1"
     dts-bundle-generator: "npm:^7.2.0"
@@ -8218,6 +8218,16 @@ __metadata:
     lodash.clonedeep: "npm:^4.5.0"
     yargs-parser: "npm:^20.2.7"
   checksum: 10/d4b9c50dcddf4b5da7a80c1d99d1cfae8a47d78d291f0cc11637ab25b6b4515f5f0e9029abd45bcc30cc3e33032aa8814ead22142b4563c4e4959d2e56bdf1ae
+  languageName: node
+  linkType: hard
+
+"convict@npm:^6.2.5":
+  version: 6.2.5
+  resolution: "convict@npm:6.2.5"
+  dependencies:
+    lodash.clonedeep: "npm:^4.5.0"
+    yargs-parser: "npm:^20.2.7"
+  checksum: 10/998fce29b699aa07eb6128b9f2b0833af3d3f5df96b6d775d5c44ae5d56f07d9a87b1cacc79e04db3ebd47037463218698fec30331cfa63e44e0c4e7f331c863
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

This PR fix the CG issue using updating convict version 6.2.4 to 6.2.5. 
convict: Updated "convict@^6.2.4": "^6.2.5" in \packages\cli\package.json. Lockfile updated via yarn install.

Resolves [CVE-2026-33864](https://dev.azure.com/mseng/1ES/_componentGovernance/1010/alert/413025?typeId=286936) in convict 6.2.4 — [#2371860](https://dev.azure.com/mseng/1ES/_workitems/edit/2371860/?view=edit)
Resolves [CVE-2026-33863](https://dev.azure.com/mseng/1ES/_componentGovernance/1010/alert/413026?typeId=286936&pipelinesTrackingFilter=0) in convict 6.2.4 — [#2371861](https://dev.azure.com/mseng/1ES/_workitems/edit/2371861/?view=edit)