### PR TITLE
Combined PR for Dependabot PRs and CG alerts fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "shellcheck": "^4.1.0",
         "simple-git": "^3.36.0",
         "syncpack": "^8.4.11",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "tslint": "^6.1.3",
         "typescript": "^5.5.3"
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@types/node": "^20.14.9",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
         "@typescript-eslint/eslint-plugin-tslint": "^7.0.2",
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.60.1",
         "combine-dependabot-prs": "^1.0.5",
         "commander": "^14.0.3",
         "eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
         "brace-expansion@^5.0.2": "^5.0.5",
         "file-type@^20.0.0": "^21.3.2",
         "file-type@^20.5.0": "^21.3.2",
-        "@azure/core-rest-pipeline": "^1.22.0"
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "tmp": "^0.2.6"
     },
     "dependencies": {
         "accessibility-insights-report": "7.6.0"

--- a/packages/axe-core-scanner/package.json
+++ b/packages/axe-core-scanner/package.json
@@ -31,7 +31,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/axe-result-converter/package.json
+++ b/packages/axe-result-converter/package.json
@@ -30,7 +30,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -31,7 +31,7 @@
         "mockdate": "^3.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -32,7 +32,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -43,7 +43,7 @@
         "@azure/core-auth": "^1.10.1",
         "@azure/cosmos": "^4.0.0",
         "@azure/identity": "^4.13.0",
-        "@azure/keyvault-secrets": "^4.11.1",
+        "@azure/keyvault-secrets": "^4.11.2",
         "@azure/ms-rest-js": "^2.7.0",
         "@azure/ms-rest-nodeauth": "^3.1.1",
         "@azure/storage-blob": "12.18.0",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -35,7 +35,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4"
     },
     "dependencies": {

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -58,7 +58,7 @@
         "moment": "^2.30.1",
         "node-cache": "^5.1.2",
         "p-limit": "^3.1.0",
-        "pretty-format": "^30.2.0",
+        "pretty-format": "^30.4.1",
         "reflect-metadata": "^0.2.2",
         "storage-documents": "workspace:*"
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
         "webpack-node-externals": "^3.0.0"
     },
     "dependencies": {
-        "@apify/log": "2.5.38",
+        "@apify/log": "2.5.41",
         "@axe-core/puppeteer": "4.11.2",
         "@crawlee/browser-pool": "^3.16.0",
         "@crawlee/puppeteer": "^3.16.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,7 @@
         "mockdate": "^3.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
         "ts-jest": "^29.4.9",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-node-externals": "^3.0.0"
     },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -31,7 +31,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -37,7 +37,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "rollup": "^4.60.2",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -36,7 +36,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "rollup": "^4.60.2",
+        "rollup": "^4.61.0",
         "ts-jest": "^29.4.9",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -43,7 +43,7 @@
     },
     "standAlonePackage": "This is a stand-alone package. Do NOT add dependencies to any service packages.",
     "dependencies": {
-        "@apify/log": "2.5.38",
+        "@apify/log": "2.5.41",
         "@axe-core/puppeteer": "4.11.2",
         "@crawlee/browser-pool": "^3.16.0",
         "@crawlee/puppeteer": "^3.16.0",

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -35,7 +35,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -36,7 +36,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",
         "webpack-cli": "^5.1.4",

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -43,6 +43,6 @@
         "webpack-ignore-dynamic-require": "^1.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.12.0"
+        "@azure/functions": "^4.16.0"
     }
 }

--- a/packages/e2e-web-apis/package.json
+++ b/packages/e2e-web-apis/package.json
@@ -38,7 +38,7 @@
         "ts-jest": "^29.4.9",
         "ts-loader": "^9.5.7",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -30,7 +30,7 @@
         "mockdate": "^3.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -33,7 +33,7 @@
         "ts-jest": "^29.4.9",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/health-client/package.json
+++ b/packages/health-client/package.json
@@ -30,7 +30,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "shebang-loader": "^0.0.1",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -35,7 +35,7 @@
         "typescript": "^5.5.3"
     },
     "dependencies": {
-        "@apify/log": "2.5.38",
+        "@apify/log": "2.5.41",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-grpc": "^0.57.1",
         "@opentelemetry/instrumentation": "^0.214.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -30,7 +30,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/privacy-scan-core/package.json
+++ b/packages/privacy-scan-core/package.json
@@ -31,7 +31,7 @@
         "mockdate": "^3.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/privacy-scan-job-manager/package.json
+++ b/packages/privacy-scan-job-manager/package.json
@@ -37,7 +37,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/privacy-scan-job-manager/package.json
+++ b/packages/privacy-scan-job-manager/package.json
@@ -33,7 +33,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/privacy-scan-job-manager/package.json
+++ b/packages/privacy-scan-job-manager/package.json
@@ -34,7 +34,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/privacy-scan-runner/package.json
+++ b/packages/privacy-scan-runner/package.json
@@ -39,7 +39,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/privacy-scan-runner/package.json
+++ b/packages/privacy-scan-runner/package.json
@@ -38,7 +38,7 @@
         "npm-force-resolutions": "^0.0.10",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/privacy-scan-runner/package.json
+++ b/packages/privacy-scan-runner/package.json
@@ -42,7 +42,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/report-generator-job-manager/package.json
+++ b/packages/report-generator-job-manager/package.json
@@ -37,7 +37,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/report-generator-job-manager/package.json
+++ b/packages/report-generator-job-manager/package.json
@@ -33,7 +33,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/report-generator-job-manager/package.json
+++ b/packages/report-generator-job-manager/package.json
@@ -34,7 +34,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/report-generator-runner/package.json
+++ b/packages/report-generator-runner/package.json
@@ -39,7 +39,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/report-generator-runner/package.json
+++ b/packages/report-generator-runner/package.json
@@ -38,7 +38,7 @@
         "npm-force-resolutions": "^0.0.10",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/report-generator-runner/package.json
+++ b/packages/report-generator-runner/package.json
@@ -42,7 +42,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/scanner-global-library/package.json
+++ b/packages/scanner-global-library/package.json
@@ -32,7 +32,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -41,7 +41,7 @@
     },
     "dependencies": {
         "@azure/cosmos": "^4.0.0",
-        "@azure/functions": "^4.12.0",
+        "@azure/functions": "^4.16.0",
         "@azure/identity": "^4.13.0",
         "@azure/storage-blob": "12.18.0",
         "@crawlee/puppeteer": "^3.16.0",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -35,7 +35,7 @@
         "mockdate": "^3.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/storage-documents/package.json
+++ b/packages/storage-documents/package.json
@@ -28,7 +28,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/web-api-client/package.json
+++ b/packages/web-api-client/package.json
@@ -27,7 +27,7 @@
         "jest-junit": "^17.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3"
     },

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -37,7 +37,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -33,7 +33,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/web-api-scan-job-manager/package.json
+++ b/packages/web-api-scan-job-manager/package.json
@@ -34,7 +34,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -30,7 +30,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -34,7 +34,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/web-api-scan-request-sender/package.json
+++ b/packages/web-api-scan-request-sender/package.json
@@ -31,7 +31,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -40,7 +40,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -43,7 +43,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -39,7 +39,7 @@
         "npm-force-resolutions": "^0.0.10",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/web-api-scan-runner/package.json
+++ b/packages/web-api-scan-runner/package.json
@@ -50,7 +50,7 @@
     "dependencies": {
         "@axe-core/puppeteer": "4.11.2",
         "@azure/cosmos": "^4.0.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "accessibility-insights-report": "7.6.0",
         "applicationinsights": "^3.15.0",
         "axe-core": "4.11.3",

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -33,7 +33,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -36,7 +36,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/web-api-send-notification-job-manager/package.json
+++ b/packages/web-api-send-notification-job-manager/package.json
@@ -32,7 +32,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -41,7 +41,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -37,7 +37,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/web-api-send-notification-runner/package.json
+++ b/packages/web-api-send-notification-runner/package.json
@@ -38,7 +38,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -47,7 +47,7 @@
         "webpack-ignore-dynamic-require": "^1.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.12.0",
+        "@azure/functions": "^4.16.0",
         "applicationinsights": "^3.15.0",
         "azure-services": "workspace:*",
         "common": "workspace:*",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -38,7 +38,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -39,7 +39,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -42,7 +42,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -48,7 +48,7 @@
         "webpack-ignore-dynamic-require": "^1.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.12.0",
+        "@azure/functions": "^4.16.0",
         "applicationinsights": "^3.15.0",
         "azure-services": "workspace:*",
         "common": "workspace:*",

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -52,7 +52,7 @@
         "applicationinsights": "^3.15.0",
         "azure-services": "workspace:*",
         "common": "workspace:*",
-        "durable-functions": "^3.3.0",
+        "durable-functions": "^3.3.1",
         "functional-tests": "workspace:*",
         "inversify": "^6.0.1",
         "lodash": "^4.18.0",

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -40,7 +40,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "ts-loader": "^9.5.7",
+        "ts-loader": "^9.6.0",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
         "webpack": "^5.106.2",

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -43,7 +43,7 @@
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",
-        "webpack": "^5.106.2",
+        "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "webpack-ignore-dynamic-require": "^1.0.0"
     },

--- a/packages/web-workers/package.json
+++ b/packages/web-workers/package.json
@@ -39,7 +39,7 @@
         "node-loader": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-loader": "^9.5.7",
         "typemoq": "^2.1.0",
         "typescript": "^5.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9086,9 +9086,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"durable-functions@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "durable-functions@npm:3.3.0"
+"durable-functions@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "durable-functions@npm:3.3.1"
   dependencies:
     "@azure/functions": "npm:^4.0.0"
     "@opentelemetry/api": "npm:^1.9.0"
@@ -9098,7 +9098,7 @@ __metadata:
     moment: "npm:^2.29.2"
     uuid: "npm:^9.0.1"
     validator: "npm:~13.15.20"
-  checksum: 10/e2d4eb7560f0e8d15e5129415ed2825fde471d052d2559660316600010028945fb99037dfc9d333af5399737f814a02e75faa3ae415e6617863b53ed85c4e390
+  checksum: 10/9bcdfcf6a10d8822dd4d445d6b62d1cc1087756565bb1f129777adcb4d63309b431ef9c6186b2582bf498bbaa70714f0d507d2429a40db852543411123b18b31
   languageName: node
   linkType: hard
 
@@ -19689,7 +19689,7 @@ __metadata:
     azure-services: "workspace:*"
     common: "workspace:*"
     copy-webpack-plugin: "npm:^13.0.1"
-    durable-functions: "npm:^3.3.0"
+    durable-functions: "npm:^3.3.1"
     fork-ts-checker-webpack-plugin: "npm:^9.0.2"
     functional-tests: "workspace:*"
     inversify: "npm:^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5618,32 +5618,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/parser@npm:8.59.1"
+"@typescript-eslint/parser@npm:^8.60.1":
+  version: 8.60.1
+  resolution: "@typescript-eslint/parser@npm:8.60.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.59.1"
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/typescript-estree": "npm:8.59.1"
-    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    "@typescript-eslint/scope-manager": "npm:8.60.1"
+    "@typescript-eslint/types": "npm:8.60.1"
+    "@typescript-eslint/typescript-estree": "npm:8.60.1"
+    "@typescript-eslint/visitor-keys": "npm:8.60.1"
     debug: "npm:^4.4.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/b014b485e5ec9c7430a87117271836b86fd80083fe6b1d216167313518f26222f45c0ee3f4cbc0616dbd6335cbde50336d8953ca5ffefecc55b2d896ac7645f9
+  checksum: 10/f9c484c4a3897015328f328a1c6ee778d113dd134201f635c0421cb72efe6e63f3a68524aff0df6e19e76ff93daf5cabd946e67f12f10dddcf19bda534aa68dc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/project-service@npm:8.59.1"
+"@typescript-eslint/project-service@npm:8.60.1":
+  version: 8.60.1
+  resolution: "@typescript-eslint/project-service@npm:8.60.1"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.59.1"
-    "@typescript-eslint/types": "npm:^8.59.1"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.60.1"
+    "@typescript-eslint/types": "npm:^8.60.1"
     debug: "npm:^4.4.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/dd98f49a407cb21999d31ec527a0f8c2c34422dde9fdb21210d66c3cc3d498d9d3678d95c99d76450af68ce3392692902d9ba044718d6c99122655df7afdc0a7
+  checksum: 10/fec693dd79c3a1e6a24091127a37af4eb9d9cee8192cf2a434adae48543eadff834bc0623b5b563c8b592b250bc080570f9e7b42807252ea898442c525beeee9
   languageName: node
   linkType: hard
 
@@ -5667,22 +5667,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.59.1"
+"@typescript-eslint/scope-manager@npm:8.60.1":
+  version: 8.60.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.60.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/visitor-keys": "npm:8.59.1"
-  checksum: 10/50c941d1af470d3e67a9bd2247c541a676ae6bb2931440a44458682d61382ba1194ce29d0388dd1e538c5a35d7a542febd9519d8170abe758692d1b6cd196eab
+    "@typescript-eslint/types": "npm:8.60.1"
+    "@typescript-eslint/visitor-keys": "npm:8.60.1"
+  checksum: 10/7228c110410ff8cfc01e96d8f17c986f8b4dd447fe3a3291baaab8fe946026ccdf0291865f788f18cf538ab49bfc067fe797708b6b8590104a65f7e69f921cc5
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.59.1, @typescript-eslint/tsconfig-utils@npm:^8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.1"
+"@typescript-eslint/tsconfig-utils@npm:8.60.1, @typescript-eslint/tsconfig-utils@npm:^8.60.1":
+  version: 8.60.1
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.60.1"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/9e3351bb182bb02f6f140759472f08ce334c7c96f4ebfeec8e9e404fe60b8fe1865e1a6d1b50526f83f41e7224301485e46459df6c3675923f3b657177415cd7
+  checksum: 10/afc78b19b856a71dc4e493f931ae44e1a91dc6441a14cb92e4063db880892f3874768f9d347d4b2f45362f2090e4455407c70f42027d77ddc85d6cba95cdb76c
   languageName: node
   linkType: hard
 
@@ -5717,10 +5717,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.59.1, @typescript-eslint/types@npm:^8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/types@npm:8.59.1"
-  checksum: 10/4d324a01c2314d8e196b43b9dc5fe9a4d82c1b65f4915cd2f965879c5565d4453603b6f7b6bcdc436fb629135f07ad0f9d274e4697b02ce8bc1c0310916f7ace
+"@typescript-eslint/types@npm:8.60.1, @typescript-eslint/types@npm:^8.60.1":
+  version: 8.60.1
+  resolution: "@typescript-eslint/types@npm:8.60.1"
+  checksum: 10/c603417e621b5b1263c2f60fad9e202d560fd07fce7f40e9a356c0530e5eaf0ff1a9af865237bf93aa18a5a4e2f034ee0cce0fe6c070f08df33e35a099bdea47
   languageName: node
   linkType: hard
 
@@ -5762,14 +5762,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.59.1"
+"@typescript-eslint/typescript-estree@npm:8.60.1":
+  version: 8.60.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.60.1"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.59.1"
-    "@typescript-eslint/tsconfig-utils": "npm:8.59.1"
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    "@typescript-eslint/project-service": "npm:8.60.1"
+    "@typescript-eslint/tsconfig-utils": "npm:8.60.1"
+    "@typescript-eslint/types": "npm:8.60.1"
+    "@typescript-eslint/visitor-keys": "npm:8.60.1"
     debug: "npm:^4.4.3"
     minimatch: "npm:^10.2.2"
     semver: "npm:^7.7.3"
@@ -5777,7 +5777,7 @@ __metadata:
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/8ede99640ac8b08ac73905bbc66dd06b2c4dc211240a4a9cb532b0fcf5c36ec9e7639ed7e1c17f86a948499279ff93e9dbcdf9170661d9f8347fcb53e8266772
+  checksum: 10/9c3a56266aadf589bc6e770cd04cb3f55b1ee1507dcacda61866408c656ae4462aa7e11baf39eb939bc4d1e3b843cf58e60f3ebdeb3e75f042ff0f6fb39c311b
   languageName: node
   linkType: hard
 
@@ -5832,13 +5832,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.59.1"
+"@typescript-eslint/visitor-keys@npm:8.60.1":
+  version: 8.60.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.60.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.60.1"
     eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10/5343f3424cafdcaf2550fade29eca6b86ad3f6ac953aef6ba1dccd39789a1c38520634fbbc0814419d9227f508789053c1c9f59c2841d72e56431c3fdd93ac65
+  checksum: 10/6d120b4a790477ae0291e69f6457686c71b929cc40519148f6b6c7fbc09604b15821ae8cf1005aa23acec5105b4016db256a68d68f30eda8d6c24d4fdb0ede86
   languageName: node
   linkType: hard
 
@@ -6278,7 +6278,7 @@ __metadata:
     "@types/node": "npm:^20.14.9"
     "@typescript-eslint/eslint-plugin": "npm:^7.15.0"
     "@typescript-eslint/eslint-plugin-tslint": "npm:^7.0.2"
-    "@typescript-eslint/parser": "npm:^8.59.1"
+    "@typescript-eslint/parser": "npm:^8.60.1"
     accessibility-insights-report: "npm:7.6.0"
     combine-dependabot-prs: "npm:^1.0.5"
     commander: "npm:^14.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7013,7 +7013,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -9129,7 +9129,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     rimraf: "npm:^6.1.3"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
     webpack-cli: "npm:^5.1.4"
@@ -15811,7 +15811,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -15860,7 +15860,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -16572,7 +16572,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -16620,7 +16620,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -18696,9 +18696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-loader@npm:^9.5.7":
-  version: 9.5.7
-  resolution: "ts-loader@npm:9.5.7"
+"ts-loader@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "ts-loader@npm:9.6.0"
   dependencies:
     chalk: "npm:^4.1.0"
     enhanced-resolve: "npm:^5.0.0"
@@ -18706,9 +18706,13 @@ __metadata:
     semver: "npm:^7.3.4"
     source-map: "npm:^0.7.4"
   peerDependencies:
+    loader-utils: "*"
     typescript: "*"
-    webpack: ^5.0.0
-  checksum: 10/c70c53679a877f94ae75c03eb0c7690e5c00891af9d2eef9a95271e84ac1b7144e25451dc41385ac3eb05950465c5b231cc5ce2fbd1c711a68c4012323ab03b7
+    webpack: ^4.0.0 || ^5.0.0
+  peerDependenciesMeta:
+    loader-utils:
+      optional: true
+  checksum: 10/0f4b5fcafb419aee49b29a68fd05149d3dcdff17fcba7277b866125e3df6bd7ecfd8f7208dd755ace9b371bb3f4cefdc0d3de71da12a9342c3ebd2adb21ca5fc
   languageName: node
   linkType: hard
 
@@ -19449,7 +19453,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -19483,7 +19487,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -19542,7 +19546,7 @@ __metadata:
     sha.js: "npm:^2.4.12"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -19581,7 +19585,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -19625,7 +19629,7 @@ __metadata:
     sha.js: "npm:^2.4.12"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -19665,7 +19669,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -19707,7 +19711,7 @@ __metadata:
     service-library: "workspace:*"
     storage-documents: "workspace:*"
     ts-jest: "npm:^29.4.9"
-    ts-loader: "npm:^9.5.7"
+    ts-loader: "npm:^9.6.0"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     web-api-client: "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5089,26 +5089,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.7":
-  version: 3.7.7
-  resolution: "@types/eslint-scope@npm:3.7.7"
-  dependencies:
-    "@types/eslint": "npm:*"
-    "@types/estree": "npm:*"
-  checksum: 10/e2889a124aaab0b89af1bab5959847c5bec09809209255de0e63b9f54c629a94781daa04adb66bffcdd742f5e25a17614fb933965093c0eea64aacda4309380e
-  languageName: node
-  linkType: hard
-
-"@types/eslint@npm:*":
-  version: 7.2.6
-  resolution: "@types/eslint@npm:7.2.6"
-  dependencies:
-    "@types/estree": "npm:*"
-    "@types/json-schema": "npm:*"
-  checksum: 10/aeb587e8d88d3accb5155445b6f5e92403bdaa4be68eeafeff84925cedf13bf899071effeeeddc9acc5e7f891e40e90f02f9347193100f6df38ed5036992d715
-  languageName: node
-  linkType: hard
-
 "@types/eslint@npm:^8.56.5":
   version: 8.56.10
   resolution: "@types/eslint@npm:8.56.10"
@@ -6262,7 +6242,7 @@ __metadata:
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     uuid-with-v6: "npm:^2.0.0"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-node-externals: "npm:^3.0.0"
     yargs: "npm:^17.7.2"
@@ -7016,7 +6996,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
@@ -9131,7 +9111,7 @@ __metadata:
     ts-jest: "npm:^29.4.9"
     ts-loader: "npm:^9.5.7"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
   languageName: unknown
@@ -9280,13 +9260,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.20.0":
-  version: 5.20.1
-  resolution: "enhanced-resolve@npm:5.20.1"
+"enhanced-resolve@npm:^5.22.0":
+  version: 5.22.1
+  resolution: "enhanced-resolve@npm:5.22.1"
   dependencies:
     graceful-fs: "npm:^4.2.4"
-    tapable: "npm:^2.3.0"
-  checksum: 10/588afc56de97334e5742faebcf8177a504da08ea817d399f9901f35d8e9e5e6fa86b4c2ce95a99081f947764e09c9991cc0fc0ba5751bae455c329643a709187
+    tapable: "npm:^2.3.3"
+  checksum: 10/2124366118c1e93836b23b4aad933352ba8d404c2c50129388b5d83520bfea1021169e975967e048bfca3a82cbf07756ba76a26e1eab305ef06b2ab1a384e6c0
   languageName: node
   linkType: hard
 
@@ -9510,10 +9490,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "es-module-lexer@npm:2.0.0"
-  checksum: 10/b075855289b5f40ee496f3d7525c5c501d029c3da15c22298a0030d625bf36d1da0768b26278f7f4bada2a602459b505888e20b77c414fba5da5619b0e84dbd1
+"es-module-lexer@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-module-lexer@npm:2.1.0"
+  checksum: 10/554c4374e78a812a1fa3673871ce7d42236438c414ea80c2ec35521cd9bb26d1d9155287529057d07431fd91df50d6a26d9bee5afd755fb7f6f7c81905a03956
   languageName: node
   linkType: hard
 
@@ -11448,7 +11428,7 @@ __metadata:
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     web-api-client: "workspace:*"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -13769,10 +13749,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-runner@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "loader-runner@npm:4.3.1"
-  checksum: 10/d77127497c3f91fdba351e3e91156034e6e590e9f050b40df6c38ac16c54b5c903f7e2e141e09fefd046ee96b26fb50773c695ebc0aa205a4918683b124b04ba
+"loader-runner@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "loader-runner@npm:4.3.2"
+  checksum: 10/fc0cf0026cdea7182720f58e8ff07869334bf299bd451d6192a8c2c4119ad493f1e0f5df099d031e81361f96196150d21047bf415edef4dc1e0fa02fa65ecced
   languageName: node
   linkType: hard
 
@@ -15814,7 +15794,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -15863,7 +15843,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -16575,7 +16555,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -16623,7 +16603,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -18332,6 +18312,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tapable@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "tapable@npm:2.3.3"
+  checksum: 10/21fb64a7ae1a0e11d855a6c33a22ae5ecf7e2f23170c942da673b44bf4c3aae8aa52451ef2792d0ce36c7feca13dceafa4f135105d66fc06912632488c0913fd
+  languageName: node
+  linkType: hard
+
 "tar-fs@npm:2.1.1, tar-fs@npm:3.0.5, tar-fs@npm:^3.1.1":
   version: 3.1.1
   resolution: "tar-fs@npm:3.1.1"
@@ -18409,9 +18396,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.3.17":
-  version: 5.4.0
-  resolution: "terser-webpack-plugin@npm:5.4.0"
+"terser-webpack-plugin@npm:^5.5.0":
+  version: 5.6.1
+  resolution: "terser-webpack-plugin@npm:5.6.1"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jest-worker: "npm:^27.4.5"
@@ -18420,13 +18407,31 @@ __metadata:
   peerDependencies:
     webpack: ^5.1.0
   peerDependenciesMeta:
+    "@minify-html/node":
+      optional: true
     "@swc/core":
+      optional: true
+    "@swc/css":
+      optional: true
+    "@swc/html":
+      optional: true
+    clean-css:
+      optional: true
+    cssnano:
+      optional: true
+    csso:
       optional: true
     esbuild:
       optional: true
+    html-minifier-terser:
+      optional: true
+    lightningcss:
+      optional: true
+    postcss:
+      optional: true
     uglify-js:
       optional: true
-  checksum: 10/f4618b18cec5dd41fca4a53f621ea06df04ff7bb2b09d3766559284e171a91df2884083e5c143aaacee2000870b046eb7157e39d1d2d8024577395165a070094
+  checksum: 10/75e5ebb6759ccd85f34a5af04c2f1693f61d7691a4a1614f0892a1d2caf29c12395d1d04d4f4014d4c4a77b63f9f7f36ac9241fcbcc24085a7575d4a4310d70f
   languageName: node
   linkType: hard
 
@@ -19452,7 +19457,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -19486,7 +19491,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -19545,7 +19550,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -19584,7 +19589,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -19628,7 +19633,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
     yargs: "npm:^17.7.2"
@@ -19668,7 +19673,7 @@ __metadata:
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
   languageName: unknown
@@ -19711,7 +19716,7 @@ __metadata:
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     web-api-client: "workspace:*"
-    webpack: "npm:^5.106.2"
+    webpack: "npm:^5.107.2"
     webpack-cli: "npm:^5.1.4"
     webpack-ignore-dynamic-require: "npm:^1.0.0"
   languageName: unknown
@@ -19787,18 +19792,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.3.4":
-  version: 3.3.4
-  resolution: "webpack-sources@npm:3.3.4"
-  checksum: 10/714427b235b04c2d7cf229f204b9e65145ea3643da3c7b139ebfa8a51056238d1e3a2a47c3cc3fc8eab71ed4300f66405cdc7cff29cd2f7f6b71086252f81cf1
+"webpack-sources@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "webpack-sources@npm:3.5.0"
+  checksum: 10/e5af4245dbe52bb1520c7c373d73042fe091e273ff94269b877725a7873481e544ba4e71722df13e278f88069de900052764d98b99f9910be634826ec2f6e67d
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.106.2":
-  version: 5.106.2
-  resolution: "webpack@npm:5.106.2"
+"webpack@npm:^5.107.2":
+  version: 5.107.2
+  resolution: "webpack@npm:5.107.2"
   dependencies:
-    "@types/eslint-scope": "npm:^3.7.7"
     "@types/estree": "npm:^1.0.8"
     "@types/json-schema": "npm:^7.0.15"
     "@webassemblyjs/ast": "npm:^1.14.1"
@@ -19808,26 +19812,26 @@ __metadata:
     acorn-import-phases: "npm:^1.0.3"
     browserslist: "npm:^4.28.1"
     chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.20.0"
-    es-module-lexer: "npm:^2.0.0"
+    enhanced-resolve: "npm:^5.22.0"
+    es-module-lexer: "npm:^2.1.0"
     eslint-scope: "npm:5.1.1"
     events: "npm:^3.2.0"
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.2.11"
-    loader-runner: "npm:^4.3.1"
+    loader-runner: "npm:^4.3.2"
     mime-db: "npm:^1.54.0"
     neo-async: "npm:^2.6.2"
     schema-utils: "npm:^4.3.3"
     tapable: "npm:^2.3.0"
-    terser-webpack-plugin: "npm:^5.3.17"
+    terser-webpack-plugin: "npm:^5.5.0"
     watchpack: "npm:^2.5.1"
-    webpack-sources: "npm:^3.3.4"
+    webpack-sources: "npm:^3.5.0"
   peerDependenciesMeta:
     webpack-cli:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10/524dcd7f07dfa993ab46c5ae2e302aeaa98bed760e40644f61544c1db67e5cd7be24016c8ee245895eda024020cfa58a953f1771a21028ac5d040adc92240e0f
+  checksum: 10/c02488e699902ca308c735ccc6a22e276e54f4c13d46cb8558a35deda1a347d6c0b263a9b75797c6d84cedcd672213e8442a10afc71cb951b432284c2460e7bd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6395,6 +6395,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-base@npm:9.0.0":
+  version: 9.0.0
+  resolution: "agent-base@npm:9.0.0"
+  checksum: 10/3a61414cd10dbb17fa8dae35124ffaa55fbb00f495004b2e7a8f4eca3a2b6ed9879474d4e2ebc27ee2f4207265652341525b4154e85c4d479be4854acd786bfb
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:^6.0.2":
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
@@ -6960,19 +6967,19 @@ __metadata:
   linkType: hard
 
 "azure-functions-core-tools@npm:^4.x":
-  version: 4.10.0
-  resolution: "azure-functions-core-tools@npm:4.10.0"
+  version: 4.12.0
+  resolution: "azure-functions-core-tools@npm:4.12.0"
   dependencies:
-    chalk: "npm:3.0.0"
+    chalk: "npm:^4.1.2"
     extract-zip: "npm:^2.0.1"
-    https-proxy-agent: "npm:5.0.1"
+    https-proxy-agent: "npm:9.0.0"
     progress: "npm:2.0.3"
-    rimraf: "npm:4.4.1"
+    rimraf: "npm:^6.1.3"
   bin:
     azfun: lib/main.js
     azurefunctions: lib/main.js
     func: lib/main.js
-  checksum: 10/5e16565ade4f3b4635903bc3bc4df4f313f891550850a9c86cbf8d19293c73b0bb465699d57e2a4ab5a0168eb5fda8689275debdb8e69da3199076dd8b0c0705
+  checksum: 10/3ec753f0ad0626fe800bd5fd205c9d0a3d3de1f55af5672c4a439831c94202537b61c4f944b9e3c3db9c92251eca13db63558b5d1e342316534b8e77c0c21f9a
   conditions: (os=win32 | os=darwin | os=linux)
   languageName: node
   linkType: hard
@@ -7721,16 +7728,6 @@ __metadata:
     pathval: "npm:^1.1.1"
     type-detect: "npm:^4.0.5"
   checksum: 10/615eabfeb9032315fb2d287fb03c29b7996f943024c7d4482b1b5370b6c22807fd4da329244dc5ac0c8802408d741dfb9b86245ffeddc83ce18898dda8d7aed4
-  languageName: node
-  linkType: hard
-
-"chalk@npm:3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10/37f90b31fd655fb49c2bd8e2a68aebefddd64522655d001ef417e6f955def0ed9110a867ffc878a533f2dafea5f2032433a37c8a7614969baa7f8a1cd424ddfc
   languageName: node
   linkType: hard
 
@@ -11019,18 +11016,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^9.2.0":
-  version: 9.3.5
-  resolution: "glob@npm:9.3.5"
-  dependencies:
-    fs.realpath: "npm:^1.0.0"
-    minimatch: "npm:^8.0.2"
-    minipass: "npm:^4.2.4"
-    path-scurry: "npm:^1.6.1"
-  checksum: 10/e5fa8a58adf53525bca42d82a1fad9e6800032b7e4d372209b80cfdca524dd9a7dbe7d01a92d7ed20d89c572457f12c250092bc8817cb4f1c63efefdf9b658c0
-  languageName: node
-  linkType: hard
-
 "global-agent@npm:3.0.0":
   version: 3.0.0
   resolution: "global-agent@npm:3.0.0"
@@ -11579,6 +11564,16 @@ __metadata:
     agent-base: "npm:6"
     debug: "npm:4"
   checksum: 10/f0dce7bdcac5e8eaa0be3c7368bb8836ed010fb5b6349ffb412b172a203efe8f807d9a6681319105ea1b6901e1972c7b5ea899672a7b9aad58309f766dcbe0df
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:9.0.0":
+  version: 9.0.0
+  resolution: "https-proxy-agent@npm:9.0.0"
+  dependencies:
+    agent-base: "npm:9.0.0"
+    debug: "npm:^4.3.4"
+  checksum: 10/27457d671278c8c1074cc901fe305b70d1e340127433219124c4aefc44153a179a8921e4b16d67beb2868a3a39b6b7ec84d91d8f24f2ec1d39cf4ac385351a92
   languageName: node
   linkType: hard
 
@@ -14304,15 +14299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^8.0.2":
-  version: 8.0.4
-  resolution: "minimatch@npm:8.0.4"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/aef05598ee565e1013bc8a10f53410ac681561f901c1a084b8ecfd016c9ed919f58f4bbd5b63e05643189dfb26e8106a84f0e1ff12e4a263aa37e1cae7ce9828
-  languageName: node
-  linkType: hard
-
 "minimist-options@npm:4.1.0":
   version: 4.1.0
   resolution: "minimist-options@npm:4.1.0"
@@ -14397,13 +14383,6 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10/70a12e3d3e6b8bd1c25bce2604a754cb30cadca34b32ed3e9721e83ccb3854744d2cee674afdc96e8e0df90201aa56ab39dce319f2adf28159271d5587c10377
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^4.2.4":
-  version: 4.2.8
-  resolution: "minipass@npm:4.2.8"
-  checksum: 10/e148eb6dcb85c980234cad889139ef8ddf9d5bdac534f4f0268446c8792dd4c74f4502479be48de3c1cce2f6450f6da4d0d4a86405a8a12be04c1c36b339569a
   languageName: node
   linkType: hard
 
@@ -15359,7 +15338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.11.1, path-scurry@npm:^1.6.1":
+"path-scurry@npm:^1.11.1":
   version: 1.11.1
   resolution: "path-scurry@npm:1.11.1"
   dependencies:
@@ -16904,17 +16883,6 @@ __metadata:
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
   checksum: 10/14222c9e1d3f9ae01480c50d96057228a8524706db79cdeb5a2ce5bb7070dd9f409a6f84a02cbef8cdc80d39aef86f2dd03d155188a1300c599b05437dcd2ffb
-  languageName: node
-  linkType: hard
-
-"rimraf@npm:4.4.1":
-  version: 4.4.1
-  resolution: "rimraf@npm:4.4.1"
-  dependencies:
-    glob: "npm:^9.2.0"
-  bin:
-    rimraf: dist/cjs/src/bin.js
-  checksum: 10/218ef9122145ccce9d0a71124d36a3894537de46600b37fae7dba26ccff973251eaa98aa63c2c5855a05fa04bca7cbbd7a92d4b29f2875d2203e72530ecf6ede
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,9 +561,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/keyvault-secrets@npm:^4.11.1":
-  version: 4.11.1
-  resolution: "@azure/keyvault-secrets@npm:4.11.1"
+"@azure/keyvault-secrets@npm:^4.11.2":
+  version: 4.11.2
+  resolution: "@azure/keyvault-secrets@npm:4.11.2"
   dependencies:
     "@azure-rest/core-client": "npm:^2.3.3"
     "@azure/abort-controller": "npm:^2.1.2"
@@ -576,7 +576,7 @@ __metadata:
     "@azure/keyvault-common": "npm:^2.1.0"
     "@azure/logger": "npm:^1.1.4"
     tslib: "npm:^2.8.1"
-  checksum: 10/f9bc77fe2556e206abcb85309eb49da87f9e3e17639dffba50d1f6219863da1793fc9f8fab9c3ffea706e1d3b495783714e435cc5dd05c60191566c2ed1c0c43
+  checksum: 10/e38610e85e0d11a8b62ebb49b7a673df08773c5520211e89a8d09782ec0e31bb4466d425a56ca9c9e03d2d0f5243b352ecf5fccd7f6ec05716aefe51a9597c92
   languageName: node
   linkType: hard
 
@@ -6985,7 +6985,7 @@ __metadata:
     "@azure/core-auth": "npm:^1.10.1"
     "@azure/cosmos": "npm:^4.0.0"
     "@azure/identity": "npm:^4.13.0"
-    "@azure/keyvault-secrets": "npm:^4.11.1"
+    "@azure/keyvault-secrets": "npm:^4.11.2"
     "@azure/ms-rest-js": "npm:^2.7.0"
     "@azure/ms-rest-nodeauth": "npm:^3.1.1"
     "@azure/storage-blob": "npm:12.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,6 +462,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/functions-extensions-base@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@azure/functions-extensions-base@npm:0.3.0"
+  checksum: 10/be55be51fdeb08c5dae7ddde9974889cd4bf9ae9ba28deaf2e5ec34f551c9f4c8c19a2412312484fdee17f2b70f0795d943fe73391b313ef1a7e25709a14757d
+  languageName: node
+  linkType: hard
+
 "@azure/functions-old@npm:@azure/functions@3.5.1":
   version: 3.5.1
   resolution: "@azure/functions@npm:3.5.1"
@@ -494,13 +501,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/functions@npm:^4.12.0":
-  version: 4.12.0
-  resolution: "@azure/functions@npm:4.12.0"
+"@azure/functions@npm:^4.16.0":
+  version: 4.16.0
+  resolution: "@azure/functions@npm:4.16.0"
   dependencies:
-    "@azure/functions-extensions-base": "npm:0.2.0"
+    "@azure/functions-extensions-base": "npm:0.3.0"
     cookie: "npm:^0.7.0"
-  checksum: 10/80da22a3bb048bc90eafb40e65d4ad7a524549a4829f42ade41feb72851a20f702fa038f2d9e91e94388a27567d7b647fe33484a2a44e3bbebd27cb00fb39d1d
+  checksum: 10/37fcf9861a5432c5aa08a9925a6ec890cde0ffe01a81703e889116cdfa5de0ca890c4e01a21a57f6c6dba48bda56d34c1d98423d64343f155924a27c3849a371
   languageName: node
   linkType: hard
 
@@ -9116,7 +9123,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-web-apis@workspace:packages/e2e-web-apis"
   dependencies:
-    "@azure/functions": "npm:^4.12.0"
+    "@azure/functions": "npm:^4.16.0"
     "@types/dotenv": "npm:^8.2.3"
     "@types/jest": "npm:^29.5.12"
     "@types/lodash": "npm:^4.17.24"
@@ -17339,7 +17346,7 @@ __metadata:
   resolution: "service-library@workspace:packages/service-library"
   dependencies:
     "@azure/cosmos": "npm:^4.0.0"
-    "@azure/functions": "npm:^4.12.0"
+    "@azure/functions": "npm:^4.16.0"
     "@azure/identity": "npm:^4.13.0"
     "@azure/storage-blob": "npm:12.18.0"
     "@crawlee/puppeteer": "npm:^3.16.0"
@@ -19639,7 +19646,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web-api@workspace:packages/web-api"
   dependencies:
-    "@azure/functions": "npm:^4.12.0"
+    "@azure/functions": "npm:^4.16.0"
     "@types/dotenv": "npm:^8.2.3"
     "@types/jest": "npm:^29.5.12"
     "@types/lodash": "npm:^4.17.24"
@@ -19678,7 +19685,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web-workers@workspace:packages/web-workers"
   dependencies:
-    "@azure/functions": "npm:^4.12.0"
+    "@azure/functions": "npm:^4.16.0"
     "@types/dotenv": "npm:^8.2.3"
     "@types/jest": "npm:^29.5.12"
     "@types/lodash": "npm:^4.17.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,6 +2904,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/schemas@npm:30.4.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10/86e62c8fd8fc77535085f1ede3a416430a3740f78b8f88ec7d0ee4516b22daf3326ffc1ade9d5f7839bbde923aaf1b5ac430a42ed4bb1a38edc3de5005a58f51
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^29.4.3":
   version: 29.4.3
   resolution: "@jest/schemas@npm:29.4.3"
@@ -7028,7 +7037,7 @@ __metadata:
     node-cache: "npm:^5.1.2"
     npm-run-all: "npm:^4.1.5"
     p-limit: "npm:^3.1.0"
-    pretty-format: "npm:^30.2.0"
+    pretty-format: "npm:^30.4.1"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
     storage-documents: "workspace:*"
@@ -15724,7 +15733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:30.2.0, pretty-format@npm:^30.2.0":
+"pretty-format@npm:30.2.0":
   version: 30.2.0
   resolution: "pretty-format@npm:30.2.0"
   dependencies:
@@ -15754,6 +15763,18 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 10/dea96bc83c83cd91b2bfc55757b6b2747edcaac45b568e46de29deee80742f17bc76fe8898135a70d904f4928eafd8bb693cd1da4896e8bdd3c5e82cadf1d2bb
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^30.4.1":
+  version: 30.4.1
+  resolution: "pretty-format@npm:30.4.1"
+  dependencies:
+    "@jest/schemas": "npm:30.4.1"
+    ansi-styles: "npm:^5.2.0"
+    react-is-18: "npm:react-is@^18.3.1"
+    react-is-19: "npm:react-is@^19.2.5"
+  checksum: 10/60311ef47a646eeaec0432efe66290cb6f0d2eccb123a28ad4ab6d7e53087bc62db91cfd54c3cc00c89d6875aefb2bf6264381b6c9411ce6bff3d6aa8280abad
   languageName: node
   linkType: hard
 
@@ -16309,17 +16330,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is-18@npm:react-is@^18.3.1, react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+  languageName: node
+  linkType: hard
+
+"react-is-19@npm:react-is@^19.2.5":
+  version: 19.2.7
+  resolution: "react-is@npm:19.2.7"
+  checksum: 10/ae0d3ae7638aa2fa2a82a78a817daf2806e57fa0aef357d07e1e8d1e9a301902e5967168e9334b5816db0df8fa980a725cd57569ba5a9e6e76a71e117b18be04
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.1.0
   resolution: "react-is@npm:18.1.0"
   checksum: 10/fe09c86d5e12a8531bf3e748660f3dffbe900a6da0b488c7efaf0a866e16b74ecc1b0011b0960b13594f8719f39f87a987c0c85edff0b2d3e2f14b87e7230ad2
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18523,17 +18523,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.2.4
-  resolution: "tmp@npm:0.2.4"
-  checksum: 10/6fa6c4e6749824e51cb45f0b050090f0fec6b037cfd327d328ebaf3eae80b7e1a53c6651f9bc36f1fa80cf367ec9dc05067fc1a14034fcfbba96d3a2aaa5c732
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.4":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10/dd4b78b32385eab4899d3ae296007b34482b035b6d73e1201c4a9aede40860e90997a1452c65a2d21aee73d53e93cd167d741c3db4015d90e63b6d568a93d7ec
+"tmp@npm:^0.2.6":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,10 +70,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/consts@npm:^2.53.0":
-  version: 2.53.0
-  resolution: "@apify/consts@npm:2.53.0"
-  checksum: 10/2e43d8c216a83e6de008752f40ac00e9f50eefc7bae7d2ee2cd7c4439269a547271759ba116175463e51328b8f65778c9cea8cc34194061218230ec9ba3d8113
+"@apify/consts@npm:^2.53.3":
+  version: 2.53.3
+  resolution: "@apify/consts@npm:2.53.3"
+  checksum: 10/64888b0ba20c13a0c4b25a86aec820ad1210f1f53992b3387b15a164cc038cfcf1d09412ff1b4e14d5164afdf792e15cba6791d8f48a97301ea5257f9bf94eca
   languageName: node
   linkType: hard
 
@@ -84,13 +84,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/log@npm:2.5.38":
-  version: 2.5.38
-  resolution: "@apify/log@npm:2.5.38"
+"@apify/log@npm:2.5.41":
+  version: 2.5.41
+  resolution: "@apify/log@npm:2.5.41"
   dependencies:
-    "@apify/consts": "npm:^2.53.0"
+    "@apify/consts": "npm:^2.53.3"
     ansi-colors: "npm:^4.1.1"
-  checksum: 10/5fdd4c03ce14825424fa27a8571c63202af401d91393fddb563b1e3498766ac66f774c40bbeee9ed4861c2e73c4ea29a96c99f827b39b10e66105f4217c0aa17
+  checksum: 10/d4d34dbce4b4e768bfeeed6f0e06577904cfecc0270ade7aee69916f917f50a88816bda074ec60f09fd3a89d70277b67f9c727fd7c4808c1fa8a9081317204ea
   languageName: node
   linkType: hard
 
@@ -6142,7 +6142,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "accessibility-insights-crawler@workspace:packages/crawler"
   dependencies:
-    "@apify/log": "npm:2.5.38"
+    "@apify/log": "npm:2.5.41"
     "@axe-core/puppeteer": "npm:4.11.2"
     "@crawlee/browser-pool": "npm:^3.16.0"
     "@crawlee/puppeteer": "npm:^3.16.0"
@@ -6206,7 +6206,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "accessibility-insights-scan@workspace:packages/cli"
   dependencies:
-    "@apify/log": "npm:2.5.38"
+    "@apify/log": "npm:2.5.41"
     "@axe-core/puppeteer": "npm:4.11.2"
     "@crawlee/browser-pool": "npm:^3.16.0"
     "@crawlee/puppeteer": "npm:^3.16.0"
@@ -13892,7 +13892,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "logger@workspace:packages/logger"
   dependencies:
-    "@apify/log": "npm:2.5.38"
+    "@apify/log": "npm:2.5.41"
     "@opentelemetry/api": "npm:^1.9.1"
     "@opentelemetry/exporter-metrics-otlp-grpc": "npm:^0.57.1"
     "@opentelemetry/instrumentation": "npm:^0.214.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4587,177 +4587,177 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.2"
+"@rollup/rollup-android-arm-eabi@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.61.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-android-arm64@npm:4.60.2"
+"@rollup/rollup-android-arm64@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.61.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.2"
+"@rollup/rollup-darwin-arm64@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.61.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-darwin-x64@npm:4.60.2"
+"@rollup/rollup-darwin-x64@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.61.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.2"
+"@rollup/rollup-freebsd-arm64@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.61.0"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.2"
+"@rollup/rollup-freebsd-x64@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.61.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.61.0"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.2"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.61.0"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.2"
+"@rollup/rollup-linux-arm64-gnu@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.61.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.2"
+"@rollup/rollup-linux-arm64-musl@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.61.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loong64-gnu@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.2"
+"@rollup/rollup-linux-loong64-gnu@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.61.0"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loong64-musl@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.2"
+"@rollup/rollup-linux-loong64-musl@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.61.0"
   conditions: os=linux & cpu=loong64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-ppc64-gnu@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.2"
+"@rollup/rollup-linux-ppc64-gnu@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.61.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-ppc64-musl@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.2"
+"@rollup/rollup-linux-ppc64-musl@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.61.0"
   conditions: os=linux & cpu=ppc64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.2"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.61.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-musl@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.2"
+"@rollup/rollup-linux-riscv64-musl@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.61.0"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.2"
+"@rollup/rollup-linux-s390x-gnu@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.61.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.2"
+"@rollup/rollup-linux-x64-gnu@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.61.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.2"
+"@rollup/rollup-linux-x64-musl@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.61.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-openbsd-x64@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.2"
+"@rollup/rollup-openbsd-x64@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.61.0"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-openharmony-arm64@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.2"
+"@rollup/rollup-openharmony-arm64@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.61.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.2"
+"@rollup/rollup-win32-arm64-msvc@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.61.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.2"
+"@rollup/rollup-win32-ia32-msvc@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.61.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-gnu@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.2"
+"@rollup/rollup-win32-x64-gnu@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.61.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.60.2":
-  version: 4.60.2
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.2"
+"@rollup/rollup-win32-x64-msvc@npm:4.61.0":
+  version: 4.61.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.61.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5126,10 +5126,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "@types/estree@npm:1.0.8"
-  checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
+"@types/estree@npm:1.0.9":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10/16aabfa703b5bdac83f719b07ce92a11b2d3c9b8628eacc92889d8af46cab2d78fc45c7b5378de383d0500585cea5c2f79125eeddfe5fbc6bd6a27eb0c8ccee5
   languageName: node
   linkType: hard
 
@@ -5144,6 +5144,13 @@ __metadata:
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: 10/7de6d928dd4010b0e20c6919e1a6c27b61f8d4567befa89252055fad503d587ecb9a1e3eab1b1901f923964d7019796db810b7fd6430acb26c32866d126fd408
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
   languageName: node
   linkType: hard
 
@@ -6175,7 +6182,7 @@ __metadata:
     puppeteer: "npm:^24.40.0"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
-    rollup: "npm:^4.60.2"
+    rollup: "npm:^4.61.0"
     serialize-error: "npm:^8.1.0"
     sha.js: "npm:^2.4.12"
     ts-jest: "npm:^29.4.9"
@@ -16962,36 +16969,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.60.2":
-  version: 4.60.2
-  resolution: "rollup@npm:4.60.2"
+"rollup@npm:^4.61.0":
+  version: 4.61.0
+  resolution: "rollup@npm:4.61.0"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.60.2"
-    "@rollup/rollup-android-arm64": "npm:4.60.2"
-    "@rollup/rollup-darwin-arm64": "npm:4.60.2"
-    "@rollup/rollup-darwin-x64": "npm:4.60.2"
-    "@rollup/rollup-freebsd-arm64": "npm:4.60.2"
-    "@rollup/rollup-freebsd-x64": "npm:4.60.2"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.2"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.2"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.2"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.60.2"
-    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.2"
-    "@rollup/rollup-linux-loong64-musl": "npm:4.60.2"
-    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.2"
-    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.2"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.2"
-    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.2"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.2"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.60.2"
-    "@rollup/rollup-linux-x64-musl": "npm:4.60.2"
-    "@rollup/rollup-openbsd-x64": "npm:4.60.2"
-    "@rollup/rollup-openharmony-arm64": "npm:4.60.2"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.2"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.2"
-    "@rollup/rollup-win32-x64-gnu": "npm:4.60.2"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.60.2"
-    "@types/estree": "npm:1.0.8"
+    "@rollup/rollup-android-arm-eabi": "npm:4.61.0"
+    "@rollup/rollup-android-arm64": "npm:4.61.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.61.0"
+    "@rollup/rollup-darwin-x64": "npm:4.61.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.61.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.61.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.61.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.61.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.61.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.61.0"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.61.0"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.61.0"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.61.0"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.61.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.61.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.61.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.61.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.61.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.61.0"
+    "@rollup/rollup-openbsd-x64": "npm:4.61.0"
+    "@rollup/rollup-openharmony-arm64": "npm:4.61.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.61.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.61.0"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.61.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.61.0"
+    "@types/estree": "npm:1.0.9"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
     "@rollup/rollup-android-arm-eabi":
@@ -17048,7 +17055,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10/354041c7d7f745866cc001bb09d157ae8c0602e82311823e724aa85a45c16346a09bd6bced9f773b0a16aba66abaf45e2952ec643e694a4b30df6dc69daa47ce
+  checksum: 10/66809d13e2ee2108a33a86488a61ed3d8424ad94002d7c38ffbd078b58e3215b6469453760c56a8b550c592c3dd7235761a95866c31c166730530c368ff59340
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6178,7 +6178,7 @@ __metadata:
     rollup: "npm:^4.60.2"
     serialize-error: "npm:^8.1.0"
     sha.js: "npm:^2.4.12"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     yargs: "npm:^17.7.2"
@@ -6258,7 +6258,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     serialize-error: "npm:^8.1.0"
     sha.js: "npm:^2.4.12"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     uuid-with-v6: "npm:^2.0.0"
@@ -6303,7 +6303,7 @@ __metadata:
     shellcheck: "npm:^4.1.0"
     simple-git: "npm:^3.36.0"
     syncpack: "npm:^8.4.11"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     tslint: "npm:^6.1.3"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -6897,7 +6897,7 @@ __metadata:
     puppeteer: "npm:^24.40.0"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -6928,7 +6928,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -7012,7 +7012,7 @@ __metadata:
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -8194,7 +8194,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     serialize-error: "npm:^8.1.0"
     sha.js: "npm:^2.4.12"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     uuid-with-v6: "npm:^2.0.0"
@@ -9128,7 +9128,7 @@ __metadata:
     node-loader: "npm:^2.1.0"
     npm-run-all: "npm:^4.1.5"
     rimraf: "npm:^6.1.3"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typescript: "npm:^5.5.3"
     webpack: "npm:^5.106.2"
@@ -10721,7 +10721,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     web-api-client: "workspace:*"
@@ -11444,7 +11444,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     shebang-loader: "npm:^0.0.1"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     web-api-client: "workspace:*"
@@ -13914,7 +13914,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -15775,7 +15775,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     scanner-global-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -15810,7 +15810,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -15859,7 +15859,7 @@ __metadata:
     scanner-global-library: "workspace:*"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -16571,7 +16571,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -16619,7 +16619,7 @@ __metadata:
     scanner-global-library: "workspace:*"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -17220,7 +17220,7 @@ __metadata:
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -17375,7 +17375,7 @@ __metadata:
     scanner-global-library: "workspace:*"
     sha.js: "npm:^2.4.12"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
     yargs: "npm:^17.7.2"
@@ -17917,7 +17917,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -18656,9 +18656,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.4.9":
-  version: 29.4.9
-  resolution: "ts-jest@npm:29.4.9"
+"ts-jest@npm:^29.4.11":
+  version: 29.4.11
+  resolution: "ts-jest@npm:29.4.11"
   dependencies:
     bs-logger: "npm:^0.2.6"
     fast-json-stable-stringify: "npm:^2.1.0"
@@ -18666,7 +18666,7 @@ __metadata:
     json5: "npm:^2.2.3"
     lodash.memoize: "npm:^4.1.2"
     make-error: "npm:^1.3.6"
-    semver: "npm:^7.7.4"
+    semver: "npm:^7.8.0"
     type-fest: "npm:^4.41.0"
     yargs-parser: "npm:^21.1.1"
   peerDependencies:
@@ -18692,7 +18692,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: 10/f5e81b1e13fff08da5b92d5a72f984f3393f40df73a1ae54473a780436b95dddb1452c78256e6d70a701c09ea427449657a5fbb3d142dc7e7a82eb192e80c3db
+  checksum: 10/8a76800cac1c102c789429a82655adde1d540d7ff025fc888006f4f458afe07ca4d3f73622a10a604edea06aa12c298605cd1a208a6380c0e3d591a3daed8af6
   languageName: node
   linkType: hard
 
@@ -19413,7 +19413,7 @@ __metadata:
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
   languageName: unknown
@@ -19448,7 +19448,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -19482,7 +19482,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -19541,7 +19541,7 @@ __metadata:
     service-library: "workspace:*"
     sha.js: "npm:^2.4.12"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -19580,7 +19580,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -19624,7 +19624,7 @@ __metadata:
     service-library: "workspace:*"
     sha.js: "npm:^2.4.12"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -19664,7 +19664,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"
@@ -19706,7 +19706,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     service-library: "workspace:*"
     storage-documents: "workspace:*"
-    ts-jest: "npm:^29.4.9"
+    ts-jest: "npm:^29.4.11"
     ts-loader: "npm:^9.5.7"
     typemoq: "npm:^2.1.0"
     typescript: "npm:^5.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,14 +4368,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.59.1":
-  version: 1.59.1
-  resolution: "@playwright/test@npm:1.59.1"
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    playwright: "npm:1.59.1"
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10/27a894c4d4216b51cddc96e18fd0638a9e2e0a3f0b7ee32a56121fb61df395ec43529f5dcdca32578af8a34a04722ee3767f99f0ae4d39fa8edceda89a96014c
+  checksum: 10/a13d369014e1934b0aa484c5d59537f5249af0fe006ac4ecbcbe14c673221412706193ea2d9cf3b2c0cc69e3ddbb4daddb006f0bedfdeb05f687776ed8c35f5f
   languageName: node
   linkType: hard
 
@@ -15580,27 +15580,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright-core@npm:1.59.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10/d27857a6701587c2a9bfa26fed9a5d8c617a392299b99b187f2ddc198d012a1e296449806bc907220debea938152677e8b4d91d304ed00645f762f778de3abec
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright@npm:1.59.1"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.59.1"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/17b2df42effa362adc6aa3192b625bd80f26b91a0c253a2375ac89ace68407b746dd87b4081629c50c58c3cb031c5b837a32fef43a3c98c60ea504e0b001e5fa
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -19499,7 +19499,7 @@ __metadata:
   dependencies:
     "@axe-core/puppeteer": "npm:4.11.2"
     "@azure/cosmos": "npm:^4.0.0"
-    "@playwright/test": "npm:^1.59.1"
+    "@playwright/test": "npm:^1.60.0"
     "@types/dotenv": "npm:^8.2.3"
     "@types/jest": "npm:^29.5.12"
     "@types/lodash": "npm:^4.17.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17498,9 +17498,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.6.1":
-  version: 1.7.3
-  resolution: "shell-quote@npm:1.7.3"
-  checksum: 10/0ab00c37c84ea3ac13d5f0d45c6850701254fd1d6653d0604a48973ba3911ad0dd9f414672253a01f68fe48bb651a7138317ed4543b75ce4192c1d610e453d4c
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Details

This pull request combines several open Dependabot PRs along with a CG alert fix to keep the project up to date and clear an S360 `[SFI-ES5.2]` action item. The changes primarily involve bumping versions of build tooling, telemetry, and Azure SDK packages, along with one yarn resolution addressing a CG alert. No functional or logic changes are introduced; all updates are dependency-related.

Combined Dependabot PRs (closed by this PR):

* [#3100](https://github.com/microsoft/accessibility-insights-service/pull/3100) — chore(deps-dev): bump `ts-jest` from `29.4.9` to `29.4.11`
* [#3099](https://github.com/microsoft/accessibility-insights-service/pull/3099) — chore(deps-dev): bump `azure-functions-core-tools` from `4.10.0` to `4.12.0`
* [#3098](https://github.com/microsoft/accessibility-insights-service/pull/3098) — chore(deps-dev): bump `webpack` from `5.106.2` to `5.107.2`
* [#3097](https://github.com/microsoft/accessibility-insights-service/pull/3097) — chore(deps-dev): bump `ts-loader` from `9.5.7` to `9.6.0`
* [#3096](https://github.com/microsoft/accessibility-insights-service/pull/3096) — chore(deps): bump `@azure/keyvault-secrets` from `4.11.1` to `4.11.2`
* [#3095](https://github.com/microsoft/accessibility-insights-service/pull/3095) — chore(deps-dev): bump `@typescript-eslint/parser` from `8.59.1` to `8.60.1`
* [#3094](https://github.com/microsoft/accessibility-insights-service/pull/3094) — chore(deps): bump `pretty-format` from `30.2.0` to `30.4.1`
* [#3093](https://github.com/microsoft/accessibility-insights-service/pull/3093) — chore(deps): bump `@playwright/test` from `1.59.1` to `1.60.0`
* [#3091](https://github.com/microsoft/accessibility-insights-service/pull/3091) — chore(deps): bump `@apify/log` from `2.5.38` to `2.5.41`
* [#3089](https://github.com/microsoft/accessibility-insights-service/pull/3089) — chore(deps-dev): bump `rollup` from `4.60.2` to `4.61.0`
* [#3087](https://github.com/microsoft/accessibility-insights-service/pull/3087) — chore(deps): bump `durable-functions` from `3.3.0` to `3.3.1`
* [#3084](https://github.com/microsoft/accessibility-insights-service/pull/3084) — chore(deps): bump `@azure/functions` from `4.12.0` to `4.16.0`
* [#3103](https://github.com/microsoft/accessibility-insights-service/pull/3103) — chore(deps): bump `shell-quote` from `1.7.3` to `1.8.4`

Dependency updates (core and shared libraries):

* Updated `@azure/keyvault-secrets` to `4.11.2` in `packages/azure-services` for the latest Azure SDK patch.
* Updated `@azure/functions` to `4.16.0` in `packages/web-api`, `packages/web-workers`, `packages/service-library`, and `packages/e2e-web-apis` for the latest Azure Functions Node.js programming model.
* Updated `durable-functions` to `3.3.1` in `packages/web-workers` for compatibility with the latest Azure Functions runtime.
* Updated `@apify/log` to `2.5.41` in `packages/cli`, `packages/crawler`, and `packages/logger`.
* Updated `pretty-format` to `30.4.1` in `packages/azure-services`.
* Updated `shell-quote` to `1.8.4` (transitive dependency, resolved in `yarn.lock`) for the latest patch.

Development and build tool updates:

* Upgraded `webpack` to `5.107.2` across all relevant packages for improved tooling.
* Upgraded `ts-jest` to `29.4.11` across all test-enabled packages.
* Upgraded `ts-loader` to `9.6.0` across all webpack-enabled packages.
* Upgraded `rollup` to `4.61.0` in `packages/crawler` for improved build process.
* Upgraded `@typescript-eslint/parser` to `8.60.1` in the root for improved linting.
* Upgraded `azure-functions-core-tools` to `4.12.0` for local Azure Functions development and testing.
* Upgraded `@playwright/test` to `1.60.0` for end-to-end browser test tooling.

S360 CG alert resolution:

* Added a yarn resolution `"tmp": "^0.2.6"` to the root `package.json` to clear the S360 `[SFI-ES5.2]` 1ES Open Source Vulnerabilities (Operational) action item for **CVE-2026-44705** (path traversal in `tmp < 0.2.6`). The vulnerable `tmp@0.2.5` was a transitive of `patch-package@8.0.1` (declares `tmp: ^0.2.4`). After the resolution, both `tmp` parents (`external-editor` and `patch-package`) resolve to `tmp@0.2.7`. S360 links are intentionally omitted.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: S360 `[SFI-ES5.2]` CVE-2026-44705
- [ ] Added relevant unit test for your changes. (`yarn test`) - n/a (dependency-only)
- [ ] Verified code coverage for the changes made. - n/a (dependency-only)
- [x] Ran precheckin (`yarn precheckin`) - ran `yarn install`, `yarn build`, and `yarn test` locally; all passed
- [ ] Validated in an Azure resource group - n/a (dependency-only)