### PR TITLE
feat: add enableRoleAssignments flag to control role assignments in deployment scripts

### DIFF
--- a/packages/resource-deployment/scripts/create-function-apps.sh
+++ b/packages/resource-deployment/scripts/create-function-apps.sh
@@ -163,11 +163,15 @@ function enableCosmosAccess() {
     role="DocumentDB Account Contributor"
     . "${0%/*}/create-role-assignment.sh"
 
-    az cosmosdb sql role assignment create --account-name "${cosmosAccountName}" \
-        --resource-group "${resourceGroupName}" \
-        --scope "/" \
-        --principal-id "${principalId}" \
-        --role-definition-id "${RBACRoleId}" 1>/dev/null
+    if [[ "${enableRoleAssignments:-false}" == "true" ]]; then
+        az cosmosdb sql role assignment create --account-name "${cosmosAccountName}" \
+            --resource-group "${resourceGroupName}" \
+            --scope "/" \
+            --principal-id "${principalId}" \
+            --role-definition-id "${RBACRoleId}" 1>/dev/null
+    else
+        echo "Skipping Cosmos DB role assignment for principal ${principalId} because enableRoleAssignments flag is disabled."
+    fi
 }
 
 function enableApplicationInsightsWriteAccess() {

--- a/packages/resource-deployment/scripts/create-key-vault.sh
+++ b/packages/resource-deployment/scripts/create-key-vault.sh
@@ -108,6 +108,11 @@ fi
 createOrRecoverKeyvault
 setupKeyVaultResources
 setAccessPolicies
-. "${0%/*}/push-secrets-to-key-vault.sh"
+
+if [[ "${enableRoleAssignments:-false}" == "true" ]]; then
+    . "${0%/*}/push-secrets-to-key-vault.sh"
+else
+    echo "Skipping push-secrets-to-key-vault.sh because enableRoleAssignments flag is disabled."
+fi
 
 echo "The ${keyVault} Azure Key Vault successfully deployed."

--- a/packages/resource-deployment/scripts/create-role-assignment.sh
+++ b/packages/resource-deployment/scripts/create-role-assignment.sh
@@ -57,4 +57,8 @@ grantRoleToResource() {
     echo "Successfully granted ${role} role for service principal ${principalId} in ${scope}"
 }
 
-grantRoleToResource
+if [[ "${enableRoleAssignments:-false}" == "true" ]]; then
+    grantRoleToResource
+else
+    echo "Skipping ${role} role assignment for service principal ${principalId} in ${scope} because enableRoleAssignments flag is disabled."
+fi

--- a/packages/resource-deployment/scripts/enable-batch-node-identity.sh
+++ b/packages/resource-deployment/scripts/enable-batch-node-identity.sh
@@ -60,11 +60,15 @@ function enableCosmosRole() {
             --exists 1>/dev/null
     fi
 
-    az cosmosdb sql role assignment create --account-name "${cosmosAccountName}" \
-        --resource-group "${resourceGroupName}" \
-        --scope "/" \
-        --principal-id "${principalId}" \
-        --role-definition-id "${roleId}" 1>/dev/null
+    if [[ "${enableRoleAssignments:-false}" == "true" ]]; then
+        az cosmosdb sql role assignment create --account-name "${cosmosAccountName}" \
+            --resource-group "${resourceGroupName}" \
+            --scope "/" \
+            --principal-id "${principalId}" \
+            --role-definition-id "${roleId}" 1>/dev/null
+    else
+        echo "Skipping Cosmos DB role assignment for principal ${principalId} because enableRoleAssignments flag is disabled."
+    fi
 }
 
 function enableStorageAccess() {

--- a/packages/resource-deployment/scripts/enable-cosmos-auth.sh
+++ b/packages/resource-deployment/scripts/enable-cosmos-auth.sh
@@ -30,10 +30,14 @@ fi
 customRoleName="CosmosDocumentRW"
 RBACRoleId=$(az cosmosdb sql role definition list --account-name "${cosmosAccountName}" --resource-group "${resourceGroupName}" --query "[?roleName=='${customRoleName}'].id" -o tsv)
 
-az cosmosdb sql role assignment create --account-name "${cosmosAccountName}" \
-    --resource-group "${resourceGroupName}" \
-    --scope "/" \
-    --principal-id "${principalId}" \
-    --role-definition-id "${RBACRoleId}" 1>/dev/null
+if [[ "${enableRoleAssignments:-false}" == "true" ]]; then
+    az cosmosdb sql role assignment create --account-name "${cosmosAccountName}" \
+        --resource-group "${resourceGroupName}" \
+        --scope "/" \
+        --principal-id "${principalId}" \
+        --role-definition-id "${RBACRoleId}" 1>/dev/null
 
-echo "The custom role ${customRoleName} has been successfully assigned to the principal ${principalId}"
+    echo "The custom role ${customRoleName} has been successfully assigned to the principal ${principalId}"
+else
+    echo "Skipping the custom role ${customRoleName} assignment to the principal ${principalId} because enableRoleAssignments flag is disabled."
+fi

--- a/packages/resource-deployment/scripts/install-parallel.sh
+++ b/packages/resource-deployment/scripts/install-parallel.sh
@@ -6,7 +6,7 @@
 # shellcheck disable=SC1091
 set -eo pipefail
 
-# Еxport variables to all child processes
+# Export variables to all child processes
 export apiManagementName
 export batchAccountName
 export cosmosAccountName
@@ -24,6 +24,12 @@ export templatesFolder="${0%/*}/../templates/"
 export dropFolder="${0%/*}/../../../"
 export dropPools=false
 export keepImages=false
+
+# Global flag to gate all 'az role assignment' / 'az cosmosdb sql role assignment' calls.
+# Disabled by default because some environments enforce policies (e.g. pimOnlyModeForAzure)
+# that disallow role assignments created directly by a service principal.
+# Set to "true" to allow the deployment scripts to create/delete role assignments.
+export enableRoleAssignments=false
 
 exitWithUsageInfo() {
     echo "

--- a/packages/resource-deployment/scripts/key-vault-enable-msi.sh
+++ b/packages/resource-deployment/scripts/key-vault-enable-msi.sh
@@ -38,14 +38,18 @@ fi
 
 # Grant permissions to the managed identity
 echo "Granting $principalId service principal permissions to $keyVault key vault"
-az role assignment create \
-    --role "Key Vault Secrets User" \
-    --assignee "$principalId" \
-    --scope "/subscriptions/$subscription/resourcegroups/$resourceGroupName/providers/Microsoft.KeyVault/vaults/$keyVault" 1>/dev/null
+if [[ "${enableRoleAssignments:-false}" == "true" ]]; then
+    az role assignment create \
+        --role "Key Vault Secrets User" \
+        --assignee "$principalId" \
+        --scope "/subscriptions/$subscription/resourcegroups/$resourceGroupName/providers/Microsoft.KeyVault/vaults/$keyVault" 1>/dev/null
 
-az role assignment create \
-    --role "Key Vault Certificates Officer" \
-    --assignee "$principalId" \
-    --scope "/subscriptions/$subscription/resourcegroups/$resourceGroupName/providers/Microsoft.KeyVault/vaults/$keyVault" 1>/dev/null
+    az role assignment create \
+        --role "Key Vault Certificates Officer" \
+        --assignee "$principalId" \
+        --scope "/subscriptions/$subscription/resourcegroups/$resourceGroupName/providers/Microsoft.KeyVault/vaults/$keyVault" 1>/dev/null
 
-echo "  Permission successfully granted."
+    echo "  Permission successfully granted."
+else
+    echo "  Skipping key vault role assignments because enableRoleAssignments flag is disabled."
+fi


### PR DESCRIPTION
This pull request introduces a global flag, `enableRoleAssignments`, to control whether Azure role assignments are created by the deployment scripts. This flag is disabled by default to accommodate environments where direct role assignments are restricted. All relevant scripts now check this flag before attempting to create role assignments, and provide clear messages when role assignments are skipped.

**Role assignment gating:**

* Added the `enableRoleAssignments` environment variable to `install-parallel.sh`, defaulting to `false`, with documentation explaining its purpose and usage.
* Updated all scripts that create Azure role assignments (such as for Cosmos DB, Key Vault, and custom roles) to check the `enableRoleAssignments` flag before executing assignment commands. If the flag is not enabled, the scripts skip the assignment and output a message explaining why. [[1]](diffhunk://#diff-96c4d4d6ecff18fec3122325d44c0a9c9b16085d1283fbc22b60d88888d88818R166-R174) [[2]](diffhunk://#diff-c0bcdb814c2175005e0504b38f5924a542e57cda53a693f67c31054ff38e4f33R63-R71) [[3]](diffhunk://#diff-d78435488075c78cd4ac1122f610facde92cdaf4e6ad59b9ecec685dafd5c1dbR60-R64) [[4]](diffhunk://#diff-db81be5cd873c9914336204bb9ebc2b6ad6128943772c613232edc9c33dd61acR33-R43) [[5]](diffhunk://#diff-c1160b13b70e1b7ded85c704bd613dce9cf51cb03d630621123a34642b2bbcf6R41) [[6]](diffhunk://#diff-c1160b13b70e1b7ded85c704bd613dce9cf51cb03d630621123a34642b2bbcf6R53-R55) [[7]](diffhunk://#diff-dc314fe718869101dcfbb6b3cf183cfdb963c08f756d17eed8640d5301a08d53R111-R116)

**Documentation and clarity improvements:**

* Fixed a comment typo in `install-parallel.sh` (“Еxport” → “Export”).
* Added explanatory comments to clarify the rationale for the new flag and its default setting.