### PR TITLE
Bump scan package to version 3.4.0 for release

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-scan",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
     "scripts": {
         "build": "webpack --config ./webpack.config.js \"$@\"",


### PR DESCRIPTION
#### Details

This pull request updates the version of the `accessibility-insights-scan` CLI package from 3.3.0 to 3.4.0. No other changes are included

##### Motivation

This is for releasing new version (3.4.0) of accessibility-insights-scan package.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Addresses an existing issue: To release new version of package with fixes from previous commits
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
