### PR TITLE
Enable cross-tenant authentication

### DIFF
--- a/packages/resource-deployment/scripts/create-function-apps.sh
+++ b/packages/resource-deployment/scripts/create-function-apps.sh
@@ -66,6 +66,26 @@ getAllowedApplications() {
     fi
 }
 
+getAllowedAudiences() {
+    audienceFilePath="${0%/*}/../templates/web-api-aad-audience.txt"
+
+    if [[ -f ${audienceFilePath} ]]; then
+        echo "Using Azure Functions allowed audiences configuration ${audienceFilePath}"
+        allowedAudiences=$(<"${audienceFilePath}")
+    else
+        echo "Azure Functions allowed audiences configuration file not found. Expected configuration file ${audienceFilePath}"
+    fi
+
+    # The webApiIdentityClientId is the application (client) id of the user assigned managed identity (${webApiManagedIdentityName})
+    # used by the service. It is not part of the web-api-aad-audience.txt file and must be added implicitly so it remains a
+    # valid token audience for existing same-tenant clients.
+    if [[ -z ${allowedAudiences} ]]; then
+        allowedAudiences="${webApiIdentityClientId}"
+    else
+        allowedAudiences="${allowedAudiences},${webApiIdentityClientId}"
+    fi
+}
+
 copyConfigFileToScriptFolder() {
     local packageName=$1
 
@@ -247,7 +267,7 @@ function enableManagedIdentity() {
 function deployWebApiFunction() {
     # Upload the deployment package BEFORE deploying the ARM template
     publishFunctionAppScripts "web-api" "${webApiFuncAppName}"
-    deployFunctionAppTemplate "web-api-allyfuncapp" "${webApiFuncTemplateFilePath}" "${webApiFuncAppName}" "clientId=${webApiIdentityClientId} releaseVersion=${releaseVersion} allowedApplications=${allowedApplications}"
+    deployFunctionAppTemplate "web-api-allyfuncapp" "${webApiFuncTemplateFilePath}" "${webApiFuncAppName}" "clientId=${webApiIdentityClientId} releaseVersion=${releaseVersion} allowedApplications=${allowedApplications} allowedAudiences=${allowedAudiences}"
     assignUserIdentity "${webApiFuncAppName}"
     az functionapp restart --resource-group "${resourceGroupName}" --name "${webApiFuncAppName}"
 }
@@ -311,5 +331,6 @@ webApiIdentityPrincipalId=$(az identity show --name "${webApiManagedIdentityName
 userIdentityId=$(az identity show --name "${webApiManagedIdentityName}" --resource-group "${resourceGroupName}" --query "id" -o tsv)
 
 getAllowedApplications
+getAllowedAudiences
 createCosmosRBACRole
 setupAzureFunctions

--- a/packages/resource-deployment/scripts/create-function-apps.sh
+++ b/packages/resource-deployment/scripts/create-function-apps.sh
@@ -67,7 +67,13 @@ getAllowedApplications() {
 }
 
 getAllowedAudiences() {
-    audienceFilePath="${0%/*}/../templates/web-api-aad-audience.txt"
+    if [[ ${environment} == prod* ]]; then
+        audienceFilePath="${0%/*}/../templates/web-api-aad-audience-prod.txt"
+    elif [[ ${environment} == ppe* ]]; then
+        audienceFilePath="${0%/*}/../templates/web-api-aad-audience-ppe.txt"
+    else
+        audienceFilePath="${0%/*}/../templates/web-api-aad-audience-${environment}.txt"
+    fi
 
     if [[ -f ${audienceFilePath} ]]; then
         echo "Using Azure Functions allowed audiences configuration ${audienceFilePath}"
@@ -77,7 +83,7 @@ getAllowedAudiences() {
     fi
 
     # The webApiIdentityClientId is the application (client) id of the user assigned managed identity (${webApiManagedIdentityName})
-    # used by the service. It is not part of the web-api-aad-audience.txt file and must be added implicitly so it remains a
+    # used by the service. It is not part of the web-api-aad-audience-*.txt file and must be added implicitly so it remains a
     # valid token audience for existing same-tenant clients.
     if [[ -z ${allowedAudiences} ]]; then
         allowedAudiences="${webApiIdentityClientId}"

--- a/packages/resource-deployment/templates/function-web-api-app-template.json
+++ b/packages/resource-deployment/templates/function-web-api-app-template.json
@@ -50,6 +50,13 @@
                 "description": "An allowlist of string application client IDs representing the client resource that is calling into the app."
             }
         },
+        "allowedAudiences": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "An allowlist of token audiences (application client IDs) accepted by the app. Enables cross-tenant callers that request a token for the consented multi-tenant application."
+            }
+        },
         "keyVaultName": {
             "type": "string",
             "defaultValue": "[concat('allyvault', toLower(uniqueString(resourceGroup().id)))]",
@@ -173,13 +180,14 @@
                             "azureActiveDirectory": {
                                 "enabled": true,
                                 "registration": {
-                                    "openIdIssuer": "[concat('https://sts.windows.net/', subscription().tenantId, '/v2.0')]",
+                                    "openIdIssuer": "https://login.microsoftonline.com/common/v2.0",
                                     "clientId": "[parameters('clientId')]"
                                 },
                                 "login": {
                                     "disableWWWAuthenticate": true
                                 },
                                 "validation": {
+                                    "allowedAudiences": "[array(split(parameters('allowedAudiences'), ','))]",
                                     "defaultAuthorizationPolicy": {
                                         "allowedApplications": "[array(split(parameters('allowedApplications'), ','))]"
                                     }


### PR DESCRIPTION
This pull request enhances the Azure Functions deployment process by introducing support for specifying allowed token audiences for the web API Function App. This enables cross-tenant authentication scenarios by allowing the app to accept tokens for multiple audiences. The main changes are grouped into script updates and ARM template modifications.

**Script updates:**

* Added a new `getAllowedAudiences()` function to `create-function-apps.sh` that determines the list of allowed token audiences based on the deployment environment and ensures the managed identity client ID is always included.
* Updated the deployment call in `deployWebApiFunction()` to pass the new `allowedAudiences` parameter to the ARM template.
* Ensured `getAllowedAudiences` is called during the deployment process.

**ARM template modifications:**

* Added a new `allowedAudiences` parameter to `function-web-api-app-template.json` to accept a comma-separated list of allowed token audiences.
* Updated the AAD authentication configuration to use the `allowedAudiences` parameter for token validation, and changed the `openIdIssuer` to use the common endpoint to support multi-tenant scenarios.